### PR TITLE
Update .env.template file with new defaults + Doorway signifier

### DIFF
--- a/backend/core/.env.template
+++ b/backend/core/.env.template
@@ -1,7 +1,8 @@
 PORT=3100
 NODE_ENV=development
-DATABASE_URL=postgres://localhost/bloom
-TEST_DATABASE_URL=postgres://localhost/bloom_test
+DATABASE_URL=postgres://bloom-dev:bloom@localhost:5432/bloom
+TEST_DATABASE_URL=postgres://bloom-dev:bloom@localhost:5432/bloom_test
+REDIS_URL="<no_longer_used>"
 THROTTLE_TTL=60
 THROTTLE_LIMIT=2
 EMAIL_API_KEY='SOME-LONG-SECRET-KEY'

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -611,7 +611,7 @@
   "nav.properties": "Propiedades",
   "nav.signIn": "Iniciar sesión",
   "nav.signOut": "Cerrar sesión",
-  "nav.siteTitle": "Portal de viviendas",
+  "nav.siteTitle": "🚪 Portal de viviendas",
   "pageDescription.additionalResources": "Le recomendamos que busque más viviendas económicas.",
   "pageDescription.listing": "Haga su solicitud de vivienda de precio accesible en %{listingName} en %{regionName}, construida en sociedad con Exygy.",
   "pageDescription.welcome": "Busque y haga su solicitud de vivienda de precio accesible en el Portal de vivienda de %{regionName}",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -789,7 +789,7 @@
   "nav.signInMFA.verifyByPhone": "verify with phone number",
   "nav.signInMFA.verifyTitle": "Verify that it's you",
   "nav.signOut": "Sign Out",
-  "nav.siteTitle": "Housing Portal",
+  "nav.siteTitle": "🚪 Housing Portal",
   "pageDescription.additionalResources": "We encourage you to browse other affordable housing resources.",
   "pageDescription.listing": "Apply for affordable housing at %{listingName} in %{regionName}, built in partnership with Exygy.",
   "pageDescription.welcome": "Search and apply for affordable housing on %{regionName}'s Housing Portal",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -532,7 +532,7 @@
   "nav.properties": "Mga Property",
   "nav.signIn": "Mag-sign In",
   "nav.signOut": "Mag-sign Out",
-  "nav.siteTitle": "Portal ng Pabahay",
+  "nav.siteTitle": "🚪 Portal ng Pabahay",
   "pageDescription.additionalResources": "Hinihikayat ka naming mag-browse ng iba pang mapagkukunan ng abot-kayang pabahay.",
   "pageDescription.listing": "Mag-apply para sa abot-kayang pabahay sa %{listingName} sa %{regionName}_ na binuo sa pakikipagtulungan ng Exygy.",
   "pageDescription.welcome": "Maghanap at mag-apply para sa abot-kayang pabahay sa Housing Portal ng %{regionName}.",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -588,7 +588,7 @@
   "nav.properties": "Các bất động sản",
   "nav.signIn": "Đăng nhập",
   "nav.signOut": "Đăng Xuất",
-  "nav.siteTitle": "Cổng thông tin về Gia cư",
+  "nav.siteTitle": "🚪 Cổng thông tin về Gia cư",
   "pageDescription.additionalResources": "Chúng tôi khuyến khích quý vị tìm các nguồn hỗ trợ nhà ở giá cả phải chăng khác.",
   "pageDescription.listing": "Ghi danh nhà ở giá phải chăng tại %{listingNam} ở %{regionName}, được xây dựng với sự hợp tác của Exygy.",
   "pageDescription.welcome": "Tìm kiếm và ghi danh nhà ở giá cả phải chăng trên Cổng thông tin về Gia cư tại %{regionName}",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -593,7 +593,7 @@
   "nav.properties": "物業",
   "nav.signIn": "登入",
   "nav.signOut": "登出",
-  "nav.siteTitle": "房屋入口網站",
+  "nav.siteTitle": "🚪 房屋入口網站",
   "pageDescription.additionalResources": "我們鼓勵您瀏覽其他可負擔的住房資源。",
   "pageDescription.listing": "申請在 %{regionName} 的 %{listingName}（與 Exygy 合作興建）可負擔房屋。",
   "pageDescription.welcome": "在 %{regionName} 的房屋網站搜尋並申請可負擔房屋",

--- a/sites/public/src/pages/index.tsx
+++ b/sites/public/src/pages/index.tsx
@@ -33,7 +33,7 @@ export default function Home(props: IndexProps) {
   useEffect(() => {
     pushGtmEvent<PageView>({
       event: "pageView",
-      pageTitle: "Housing Portal",
+      pageTitle: "🚪 Housing Portal",
       status: profile ? UserStatus.LoggedIn : UserStatus.NotLoggedIn,
     })
   }, [profile])


### PR DESCRIPTION
2 changes in this PR, both meant to facilitate development

1) We already have our internal set of .env file changes, making those changes to the template to codify informal knowledge

2) Adding a door emoji to the title and header of the page. This change is meant to be temporary until the Doorway UI is finalized and becomes distinct from Bloom. Why do this? there are so many different versions of Bloom/etc that it may be useful to be able to visually identify whether or not the demo is a Bloom demo or a Doorway demo.

![image](https://user-images.githubusercontent.com/10789523/216705990-98b3eccb-5eea-4b3e-b699-44526cf87d66.png)

