### PR TITLE
Forward container Postgres to a different port than local Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,12 +75,12 @@ services:
       - ./backend/core/.env
     # Override database connections to point to the container instead of localhost.
     environment:
-      POSTGRES_USER: "postgres"
+      POSTGRES_USER: "bloom-dev"
       DATABASE_URL: "postgres://postgres:5432/bloom"
       REDIS_TLS_URL: "redis://redis:6379/0"
       REDIS_URL: "redis://redis:6379/0"
-      PGUSER: "postgres"
-      PGPASSWORD: "postgres"
+      PGUSER: "bloom-dev"
+      PGPASSWORD: "bloom"
       PGDATABASE: "bloom"
     depends_on:
       - redis
@@ -96,12 +96,12 @@ services:
     container_name: postgres
     image: postgres:13
     environment:
-      POSTGRES_USER: "postgres"
-      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_USER: "bloom-dev"
+      POSTGRES_PASSWORD: "bloom"
       POSTGRES_DB: "bloom"
       PG_DATA: /var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5433:5432"
     networks:
       - backend
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       POSTGRES_PASSWORD: "bloom"
       POSTGRES_DB: "bloom"
       PG_DATA: /var/lib/postgresql/data
+    # Forward to 5433 in order to avoid collisions with any local Postgres instances on 5432
     ports:
       - "5433:5432"
     networks:


### PR DESCRIPTION
@chriscasto and @ifranch found that there is a collision between local postgres and the containerized postgres's port. This avoids that collision by forwarding to a different local port, as well as updating the pguser to be consistent with our implementation

I tested this change by `docker-compose up`ing WITH a local postgres running, and not running into the port error.