### PR TITLE
Run unit and integration tests on each PR to main via Github Actions + enable linting and CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ dev, master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ dev ]
+    branches: [ main ]
   schedule:
     - cron: '40 8 * * 5'
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,68 @@
+name: Integration tests
+
+on:
+  pull_request:
+    branches:
+      - main
+env:
+  PORT: 3100
+  EMAIL_API_KEY: 'SOME-LONG-SECRET-KEY'
+  APP_SECRET: 'SOME-LONG-SECRET-KEY'
+  CLOUDINARY_SECRET: CLOUDINARY_SECRET
+  CLOUDINARY_KEY: CLOUDINARY_KEY
+  PARTNERS_PORTAL_URL: http://127.0.0.1:3001
+  DATABASE_URL: postgres://bloom-dev:bloom@127.0.0.1:5432/bloom
+  TEST_DATABASE_URL: postgres://bloom-dev:bloom@127.0.0.1:5432/bloom_test
+
+jobs:
+  integration-tests:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: bloom-dev
+          POSTGRES_USER: bloom-dev
+          POSTGRES_PASSWORD: bloom
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Check postgres
+        run: pg_isready -h 127.0.0.1 -p ${{ job.services.postgres.ports[5432] }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: yarn in root dir
+        run: yarn
+
+      - name: yarn in backend/core dir
+        working-directory: ./backend/core
+        run: yarn
+
+      - name: Check postgres
+        run: pg_isready -h 127.0.0.1 -p 5432
+
+      - name: Not sure why but there is a dependency on this database existing
+        run: psql -c 'CREATE DATABASE bloom_test;'
+        env:
+          PGHOST: 127.0.0.1
+          PGPASSWORD: bloom
+          PGUSER: bloom-dev
+
+      - name: yarn e2e tests backend
+        working-directory: ./backend/core
+        run: yarn test:e2e:local
+        env:
+          PGHOST: 127.0.0.1
+          PGPASSWORD: bloom
+          PGUSER: bloom-dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,10 @@ name: Lint
 
 on:
   # Trigger the workflow on pull request,
-  # but only for the dev branch
+  # but only for the main branch
   pull_request:
     branches:
-      - dev
+      - main
 
 jobs:
   run-linters:
@@ -19,14 +19,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       # ESLint and Prettier must be in `package.json`
       - name: Install Node.js dependencies
         run: yarn install
 
       - name: Run linters
-        uses: wearerequired/lint-action@v1
-        with:
-          prettier: true
-          auto_fix: true
+        run: yarn lint

--- a/.github/workflows/unit_tests_backend_core.yml
+++ b/.github/workflows/unit_tests_backend_core.yml
@@ -1,0 +1,44 @@
+name: Unit tests for backend/core
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests-for-backend-core:
+    name: Run unit tests for backend/core
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: yarn in root dir
+        run: yarn
+
+      # Rerun yarn in each app.
+      # It may seem unnecessary but there are some complex yarn package 
+      # versioning dependencies here, so best to run to be safe.
+      # See https://github.com/bloom-housing/bloom/issues/3217#issuecomment-1430301029 
+      # for more context.
+      - name: yarn in sites/public dir
+        working-directory: ./sites/public
+        run: yarn
+
+      - name: yarn in backend/core dir
+        working-directory: ./backend/core
+        run: yarn
+
+      - name: yarn in sites/partners dir
+        working-directory: ./sites/partners
+        run: yarn
+
+      # Tests
+      - name: yarn unit test backend/core
+        run: yarn test:backend:core

--- a/.github/workflows/unit_tests_shared_helpers.yml
+++ b/.github/workflows/unit_tests_shared_helpers.yml
@@ -1,0 +1,44 @@
+name: Unit tests for shared/helpers
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests-for-shared-helpers:
+    name: Run unit tests for shared/helpers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: yarn in root dir
+        run: yarn
+
+      # Rerun yarn in each app.
+      # It may seem unnecessary but there are some complex yarn package 
+      # versioning dependencies here, so best to run to be safe.
+      # See https://github.com/bloom-housing/bloom/issues/3217#issuecomment-1430301029 
+      # for more context.
+      - name: yarn in sites/public dir
+        working-directory: ./sites/public
+        run: yarn
+
+      - name: yarn in backend/core dir
+        working-directory: ./backend/core
+        run: yarn
+
+      - name: yarn in sites/partners dir
+        working-directory: ./sites/partners
+        run: yarn
+
+      # Tests
+      - name: yarn unit test shared/helpers
+        run: yarn test:shared:helpers

--- a/.github/workflows/unit_tests_sites_partners.yml
+++ b/.github/workflows/unit_tests_sites_partners.yml
@@ -1,0 +1,44 @@
+name: Unit tests for sites/partners
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests-for-sites-partners:
+    name: Run unit tests for sites/partners
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: yarn in root dir
+        run: yarn
+
+      # Rerun yarn in each app.
+      # It may seem unnecessary but there are some complex yarn package 
+      # versioning dependencies here, so best to run to be safe.
+      # See https://github.com/bloom-housing/bloom/issues/3217#issuecomment-1430301029 
+      # for more context.
+      - name: yarn in sites/public dir
+        working-directory: ./sites/public
+        run: yarn
+
+      - name: yarn in backend/core dir
+        working-directory: ./backend/core
+        run: yarn
+
+      - name: yarn in sites/partners dir
+        working-directory: ./sites/partners
+        run: yarn
+
+      # Tests
+      - name: yarn unit test sites/partners
+        run: yarn test:app:partners:unit

--- a/.github/workflows/unit_tests_sites_public.yml
+++ b/.github/workflows/unit_tests_sites_public.yml
@@ -1,0 +1,44 @@
+name: Unit tests for sites/public
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests-for-sites-public:
+    name: Run unit tests for sites/public
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: yarn in root dir
+        run: yarn
+
+      # Rerun yarn in each app.
+      # It may seem unnecessary but there are some complex yarn package 
+      # versioning dependencies here, so best to run to be safe.
+      # See https://github.com/bloom-housing/bloom/issues/3217#issuecomment-1430301029 
+      # for more context.
+      - name: yarn in sites/public dir
+        working-directory: ./sites/public
+        run: yarn
+
+      - name: yarn in backend/core dir
+        working-directory: ./backend/core
+        run: yarn
+
+      - name: yarn in sites/public dir
+        working-directory: ./sites/public
+        run: yarn
+
+      # Tests
+      - name: yarn unit test sites/public
+        run: yarn test:app:public:unit


### PR DESCRIPTION
See title.

I tested this by iterating on my personal fork. See https://github.com/lisunshiny/bloom/pull/1 for an example of this working.

I also disabled the version-packages GitHub action since it was just failing every time and I'm not sure that we need it, so the hope is that the green check mark and red x are descriptive once this is merged.

It is not super DRY, but given that this is a patch while we prop up a Docker-based CI/CD system, I'm not super worried about it.