### PR TITLE
[easy] chore: update seed script with Doorway namespace

### DIFF
--- a/backend/core/src/seeder/seed.ts
+++ b/backend/core/src/seeder/seed.ts
@@ -199,7 +199,7 @@ const seedListings = async (
     listing.applicationMethods = [applicationMethods]
     // Namespace all Doorway seeded listings to better understand what is
     // local vs. not
-    listing.name = "[🚪] " + listing.name
+    listing.name = "[doorway] " + listing.name
     await listingRepository.save(listing)
 
     seeds.push(listing)

--- a/backend/core/src/seeder/seed.ts
+++ b/backend/core/src/seeder/seed.ts
@@ -197,6 +197,9 @@ const seedListings = async (
       listing,
     })
     listing.applicationMethods = [applicationMethods]
+    // Namespace all Doorway seeded listings to better understand what is
+    // local vs. not
+    listing.name = "[🚪] " + listing.name
     await listingRepository.save(listing)
 
     seeds.push(listing)

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -280,12 +280,12 @@ describe("Listings", () => {
     const listings = res.body.items
 
     // The Coliseum seed has the soonest applicationDueDate (1 day in the future)
-    expect(listings[0].name).toBe("Test: Coliseum")
+    expect(listings[0].name).toContain("Test: Coliseum")
 
     // Triton and "Default, No Preferences" share the next-soonest applicationDueDate
     const secondListing = listings[1]
     const thirdListing = listings[2]
-    expect(thirdListing.name).toBe("Test: Default, No Preferences")
+    expect(thirdListing.name).toContain("Test: Default, No Preferences")
 
     const secondListingAppDueDate = new Date(secondListing.applicationDueDate)
     const thirdListingAppDueDate = new Date(thirdListing.applicationDueDate)

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -280,12 +280,12 @@ describe("Listings", () => {
     const listings = res.body.items
 
     // The Coliseum seed has the soonest applicationDueDate (1 day in the future)
-    expect(listings[0].name).toContain("Test: Coliseum")
+    expect(listings[0].name).toBe("[doorway] Test: Coliseum")
 
     // Triton and "Default, No Preferences" share the next-soonest applicationDueDate
     const secondListing = listings[1]
     const thirdListing = listings[2]
-    expect(thirdListing.name).toContain("Test: Default, No Preferences")
+    expect(thirdListing.name).toBe("[doorway] Test: Default, No Preferences")
 
     const secondListingAppDueDate = new Date(secondListing.applicationDueDate)
     const thirdListingAppDueDate = new Date(thirdListing.applicationDueDate)


### PR DESCRIPTION
Helps with testing #11 

Update the seed script to show that the listings are from the Doorway script so that its easier to tell at a glance what is local vs not.

## To test
* Reseed
* Verify that all listings have the Doorway namespace
![image](https://user-images.githubusercontent.com/10789523/229584537-ce9f0b6c-c386-452c-8d06-4cc6ff0741ad.png)
