### PR TITLE
feat: add a provider for FileService which also creates a FileConfig object

### DIFF
--- a/shared-helpers/__tests__/pdfs.test.ts
+++ b/shared-helpers/__tests__/pdfs.test.ts
@@ -13,8 +13,8 @@ describe("pdfs helpers", () => {
   })
 
   it("should format cloudinary url", () => {
-    expect(cloudinaryPdfFromId("1234", "exygy")).toBe(
-      `https://res.cloudinary.com/exygy/image/upload/1234.pdf`
+    expect(cloudinaryPdfFromId("1234", "test")).toBe(
+      `https://res.cloudinary.com/test/image/upload/1234.pdf`
     )
   })
 

--- a/shared-helpers/__tests__/pdfs.test.ts
+++ b/shared-helpers/__tests__/pdfs.test.ts
@@ -13,7 +13,7 @@ describe("pdfs helpers", () => {
   })
 
   it("should format cloudinary url", () => {
-    expect(cloudinaryPdfFromId("1234")).toBe(
+    expect(cloudinaryPdfFromId("1234", "exygy")).toBe(
       `https://res.cloudinary.com/exygy/image/upload/1234.pdf`
     )
   })

--- a/shared-helpers/__tests__/pdfs.test.ts
+++ b/shared-helpers/__tests__/pdfs.test.ts
@@ -6,7 +6,7 @@ afterEach(cleanup)
 
 describe("pdfs helpers", () => {
   const OLD_ENV = process.env
-  process.env.CLOUDINARY_CLOUD_NAME = "exygy"
+  process.env.cloudinaryCloudName = "exygy"
 
   afterAll(() => {
     process.env = OLD_ENV

--- a/shared-helpers/__tests__/photos.test.ts
+++ b/shared-helpers/__tests__/photos.test.ts
@@ -13,8 +13,8 @@ describe("photos helper", () => {
   })
 
   it("should return correct cloudinary url", () => {
-    expect(cloudinaryUrlFromId("1234", "exygy")).toBe(
-      `https://res.cloudinary.com/exygy/image/upload/w_400,c_limit,q_65/1234.jpg`
+    expect(cloudinaryUrlFromId("1234", "test")).toBe(
+      `https://res.cloudinary.com/test/image/upload/w_400,c_limit,q_65/1234.jpg`
     )
   })
 

--- a/shared-helpers/__tests__/photos.test.ts
+++ b/shared-helpers/__tests__/photos.test.ts
@@ -6,7 +6,7 @@ afterEach(cleanup)
 
 describe("photos helper", () => {
   const OLD_ENV = process.env
-  process.env.CLOUDINARY_CLOUD_NAME = "exygy"
+  process.env.cloudinaryCloudName = "exygy"
 
   afterAll(() => {
     process.env = OLD_ENV

--- a/shared-helpers/__tests__/photos.test.ts
+++ b/shared-helpers/__tests__/photos.test.ts
@@ -6,26 +6,19 @@ afterEach(cleanup)
 
 describe("photos helper", () => {
   const OLD_ENV = process.env
-
-  beforeEach(() => {
-    jest.resetModules()
-    process.env = { ...OLD_ENV }
-  })
+  process.env.CLOUDINARY_CLOUD_NAME = "exygy"
 
   afterAll(() => {
     process.env = OLD_ENV
   })
 
   it("should return correct cloudinary url", () => {
-    process.env.CLOUDINARY_CLOUD_NAME = "exygy"
-    expect(cloudinaryUrlFromId("1234")).toBe(
+    expect(cloudinaryUrlFromId("1234", "exygy")).toBe(
       `https://res.cloudinary.com/exygy/image/upload/w_400,c_limit,q_65/1234.jpg`
     )
   })
 
   it("should return correct cloudinary url from a listing with new image field", () => {
-    process.env.CLOUDINARY_CLOUD_NAME = "exygy"
-
     const testListing = {
       images: [
         {
@@ -44,8 +37,6 @@ describe("photos helper", () => {
   })
 
   it("should return correct id when falling back to old field", () => {
-    process.env.CLOUDINARY_CLOUD_NAME = "exygy"
-
     const testListing = {
       assets: [
         {

--- a/shared-helpers/src/utilities/pdfs.ts
+++ b/shared-helpers/src/utilities/pdfs.ts
@@ -1,5 +1,5 @@
 import { ListingEvent, ListingEventType } from "@bloom-housing/backend-core/types"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 export const cloudinaryPdfFromId = (publicId: string) => {
   const cloudName = process.env.cloudinaryCloudName || process.env.CLOUDINARY_CLOUD_NAME
@@ -11,7 +11,7 @@ export const pdfUrlFromListingEvents = (
   listingEventType: ListingEventType
 ) => {
   const event = events.find((event) => event?.type === listingEventType)
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
   if (event) {
     return event.file?.label == "cloudinaryPDF"
       ? cloudinaryFileService.getDownloadUrlForPdf(event.file.fileId)

--- a/shared-helpers/src/utilities/pdfs.ts
+++ b/shared-helpers/src/utilities/pdfs.ts
@@ -1,8 +1,7 @@
 import { ListingEvent, ListingEventType } from "@bloom-housing/backend-core/types"
 import { FileServiceProvider } from "@bloom-housing/shared-services"
 
-export const cloudinaryPdfFromId = (publicId: string) => {
-  const cloudName = process.env.cloudinaryCloudName || process.env.CLOUDINARY_CLOUD_NAME
+export const cloudinaryPdfFromId = (publicId: string, cloudName: string) => {
   return `https://res.cloudinary.com/${cloudName}/image/upload/${publicId}.pdf`
 }
 

--- a/shared-helpers/src/utilities/pdfs.ts
+++ b/shared-helpers/src/utilities/pdfs.ts
@@ -1,5 +1,5 @@
 import { ListingEvent, ListingEventType } from "@bloom-housing/backend-core/types"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceInterface, FileServiceProvider } from "@bloom-housing/shared-services"
 
 export const cloudinaryPdfFromId = (publicId: string, cloudName: string) => {
   return `https://res.cloudinary.com/${cloudName}/image/upload/${publicId}.pdf`
@@ -10,10 +10,10 @@ export const pdfUrlFromListingEvents = (
   listingEventType: ListingEventType
 ) => {
   const event = events.find((event) => event?.type === listingEventType)
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
   if (event) {
     return event.file?.label == "cloudinaryPDF"
-      ? cloudinaryFileService.getDownloadUrlForPdf(event.file.fileId)
+      ? fileService.getDownloadUrlForPdf(event.file.fileId)
       : event.url ?? null
   }
   return null

--- a/shared-helpers/src/utilities/photos.ts
+++ b/shared-helpers/src/utilities/photos.ts
@@ -1,8 +1,7 @@
 import { Asset, Listing } from "@bloom-housing/backend-core/types"
 import { FileServiceProvider } from "@bloom-housing/shared-services"
 
-export const cloudinaryUrlFromId = (publicId: string, size = 400) => {
-  const cloudName = process.env.cloudinaryCloudName || process.env.CLOUDINARY_CLOUD_NAME
+export const cloudinaryUrlFromId = (publicId: string, cloudName: string, size = 400) => {
   return `https://res.cloudinary.com/${cloudName}/image/upload/w_${size},c_limit,q_65/${publicId}.jpg`
 }
 

--- a/shared-helpers/src/utilities/photos.ts
+++ b/shared-helpers/src/utilities/photos.ts
@@ -1,5 +1,5 @@
 import { Asset, Listing } from "@bloom-housing/backend-core/types"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 export const cloudinaryUrlFromId = (publicId: string, size = 400) => {
   const cloudName = process.env.cloudinaryCloudName || process.env.CLOUDINARY_CLOUD_NAME
@@ -11,7 +11,7 @@ export const imageUrlFromListing = (listing: Listing, size = 400) => {
   const imageAssets =
     listing?.images?.length && listing.images[0].image ? [listing.images[0].image] : listing?.assets
 
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
 
   // Fallback to `assets`
   const cloudinaryBuilding = imageAssets?.find(

--- a/shared-helpers/src/utilities/photos.ts
+++ b/shared-helpers/src/utilities/photos.ts
@@ -1,5 +1,5 @@
 import { Asset, Listing } from "@bloom-housing/backend-core/types"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceInterface, FileServiceProvider } from "@bloom-housing/shared-services"
 
 export const cloudinaryUrlFromId = (publicId: string, cloudName: string, size = 400) => {
   return `https://res.cloudinary.com/${cloudName}/image/upload/w_${size},c_limit,q_65/${publicId}.jpg`
@@ -10,14 +10,13 @@ export const imageUrlFromListing = (listing: Listing, size = 400) => {
   const imageAssets =
     listing?.images?.length && listing.images[0].image ? [listing.images[0].image] : listing?.assets
 
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
 
   // Fallback to `assets`
   const cloudinaryBuilding = imageAssets?.find(
     (asset: Asset) => asset.label == "cloudinaryBuilding"
   )?.fileId
-  if (cloudinaryBuilding)
-    return cloudinaryFileService.getDownloadUrlForPhoto(cloudinaryBuilding, size)
+  if (cloudinaryBuilding) return fileService.getDownloadUrlForPhoto(cloudinaryBuilding, size)
 
   return imageAssets?.find((asset: Asset) => asset.label == "building")?.fileId
 }

--- a/shared-services/index.ts
+++ b/shared-services/index.ts
@@ -1,1 +1,2 @@
 export * from "./src/files/file-service.provider"
+export * from "./src/files/file-service.interface"

--- a/shared-services/index.ts
+++ b/shared-services/index.ts
@@ -1,2 +1,1 @@
-export * from "./src/files/cloudinary-file.service"
-export * from "./src/files/cloudinary-file-uploader"
+export * from "./src/files/file-service.provider"

--- a/shared-services/src/files/cloudinary-file-uploader.ts
+++ b/shared-services/src/files/cloudinary-file-uploader.ts
@@ -10,10 +10,10 @@ export class CloudinaryFileUploader {
    */
   public async uploadCloudinaryFile(
     file: File,
-    setProgressValue: (value: number) => void
+    setProgressValue: (value: number) => void,
+    cloudName: string,
+    uploadPreset: string
   ): Promise<string> {
-    const cloudName = process.env.cloudinaryCloudName || ""
-    const uploadPreset = process.env.cloudinarySignedPreset || ""
     setProgressValue(1)
     const timestamp = Math.round(new Date().getTime() / 1000)
     const tag = "browser_upload"

--- a/shared-services/src/files/cloudinary-file.service.spec.ts
+++ b/shared-services/src/files/cloudinary-file.service.spec.ts
@@ -1,12 +1,15 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
 import { CloudinaryFileService } from "./cloudinary-file.service"
+import { FileServiceProvider } from "./file-service.provider"
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
 // see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
 declare const expect: jest.Expect
 
+process.env.CLOUDINARY_CLOUD_NAME = "exygy"
+let serviceProvider: FileServiceProvider
 let service: CloudinaryFileService
 const cloudinaryFileUploaderMock = {
   uploadCloudinaryFile: () => {
@@ -20,14 +23,15 @@ describe("CloudinaryFileService", () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        CloudinaryFileService,
+        FileServiceProvider,
         {
           provide: CloudinaryFileUploader,
           useValue: cloudinaryFileUploaderMock,
         },
       ],
     }).compile()
-    service = await module.resolve(CloudinaryFileService)
+    serviceProvider = await module.resolve(FileServiceProvider)
+    service = serviceProvider.getService()
   })
 
   it("should be defined", () => {
@@ -35,21 +39,18 @@ describe("CloudinaryFileService", () => {
   })
 
   it("should return download url for photo", () => {
-    process.env.CLOUDINARY_CLOUD_NAME = "exygy"
     const url = service.getDownloadUrlForPhoto("12345")
     const expectedUrl = "https://res.cloudinary.com/exygy/image/upload/w_400,c_limit,q_65/12345.jpg"
     expect(url).toEqual(expectedUrl)
   })
 
   it("should return download url for photo with size", () => {
-    process.env.CLOUDINARY_CLOUD_NAME = "exygy"
     const url = service.getDownloadUrlForPhoto("12345", 600)
     const expectedUrl = "https://res.cloudinary.com/exygy/image/upload/w_600,c_limit,q_65/12345.jpg"
     expect(url).toEqual(expectedUrl)
   })
 
   it("should return download url for pdf", () => {
-    process.env.CLOUDINARY_CLOUD_NAME = "exygy"
     const url = service.getDownloadUrlForPdf("12345")
     const expectedUrl = "https://res.cloudinary.com/exygy/image/upload/12345.pdf"
     expect(url).toEqual(expectedUrl)

--- a/shared-services/src/files/cloudinary-file.service.spec.ts
+++ b/shared-services/src/files/cloudinary-file.service.spec.ts
@@ -2,14 +2,13 @@ import { Test, TestingModule } from "@nestjs/testing"
 import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
 import { CloudinaryFileService } from "./cloudinary-file.service"
 import { FileServiceProvider } from "./file-service.provider"
+import { CloudinaryConfig } from "./file-config"
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
 // see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
 declare const expect: jest.Expect
 
-process.env.CLOUDINARY_CLOUD_NAME = "exygy"
-let serviceProvider: FileServiceProvider
 let service: CloudinaryFileService
 const cloudinaryFileUploaderMock = {
   uploadCloudinaryFile: () => {
@@ -18,20 +17,27 @@ const cloudinaryFileUploaderMock = {
     })
   },
 }
+const cloudinaryConfig: CloudinaryConfig = {
+  cloudinaryCloudName: "exygy",
+}
 
 describe("CloudinaryFileService", () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        FileServiceProvider,
+        CloudinaryFileService,
         {
           provide: CloudinaryFileUploader,
           useValue: cloudinaryFileUploaderMock,
         },
+        FileServiceProvider,
+        {
+          provide: CloudinaryConfig,
+          useValue: cloudinaryConfig,
+        },
       ],
     }).compile()
-    serviceProvider = await module.resolve(FileServiceProvider)
-    service = serviceProvider.getService()
+    service = await module.resolve(CloudinaryFileService)
   })
 
   it("should be defined", () => {

--- a/shared-services/src/files/cloudinary-file.service.spec.ts
+++ b/shared-services/src/files/cloudinary-file.service.spec.ts
@@ -19,6 +19,7 @@ const cloudinaryFileUploaderMock = {
 }
 const cloudinaryConfig: CloudinaryConfig = {
   cloudinaryCloudName: "exygy",
+  cloudinaryUploadPreset: "test",
 }
 
 describe("CloudinaryFileService", () => {

--- a/shared-services/src/files/cloudinary-file.service.ts
+++ b/shared-services/src/files/cloudinary-file.service.ts
@@ -2,10 +2,14 @@ import { Injectable } from "@nestjs/common"
 import { cloudinaryPdfFromId, cloudinaryUrlFromId } from "@bloom-housing/shared-helpers"
 import { FileServiceInterface } from "./file-service.interface"
 import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
+import type { CloudinaryConfig } from "./file-service.provider"
 
 @Injectable()
 export class CloudinaryFileService implements FileServiceInterface {
-  constructor(private readonly cloudinaryFileUploader: CloudinaryFileUploader) {}
+  constructor(
+    readonly cloudinaryFileUploader: CloudinaryFileUploader,
+    readonly cloudinaryConfig: CloudinaryConfig
+  ) {}
 
   async putFile(
     key: string,

--- a/shared-services/src/files/cloudinary-file.service.ts
+++ b/shared-services/src/files/cloudinary-file.service.ts
@@ -2,13 +2,13 @@ import { Injectable } from "@nestjs/common"
 import { cloudinaryPdfFromId, cloudinaryUrlFromId } from "@bloom-housing/shared-helpers"
 import { FileServiceInterface } from "./file-service.interface"
 import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
-import type { CloudinaryConfig } from "./file-service.provider"
+import { CloudinaryConfig } from "./file-config"
 
 @Injectable()
 export class CloudinaryFileService implements FileServiceInterface {
   constructor(
-    readonly cloudinaryFileUploader: CloudinaryFileUploader,
-    readonly cloudinaryConfig: CloudinaryConfig
+    private readonly cloudinaryFileUploader: CloudinaryFileUploader,
+    private readonly cloudinaryConfig: CloudinaryConfig
   ) {}
 
   async putFile(
@@ -20,7 +20,7 @@ export class CloudinaryFileService implements FileServiceInterface {
     return id
   }
   getDownloadUrlForPhoto(id: string, size = 400): string {
-    return cloudinaryUrlFromId(id, size)
+    return cloudinaryUrlFromId(id, this.cloudinaryConfig.cloudinaryCloudName, size)
   }
   getDownloadUrlForPdf(id: string): string {
     return cloudinaryPdfFromId(id)

--- a/shared-services/src/files/cloudinary-file.service.ts
+++ b/shared-services/src/files/cloudinary-file.service.ts
@@ -16,13 +16,18 @@ export class CloudinaryFileService implements FileServiceInterface {
     file: File,
     setProgressValue: (value: number) => void
   ): Promise<string> {
-    const id = await this.cloudinaryFileUploader.uploadCloudinaryFile(file, setProgressValue)
+    const id = await this.cloudinaryFileUploader.uploadCloudinaryFile(
+      file,
+      setProgressValue,
+      this.cloudinaryConfig.cloudinaryCloudName,
+      this.cloudinaryConfig.cloudinaryUploadPreset
+    )
     return id
   }
   getDownloadUrlForPhoto(id: string, size = 400): string {
     return cloudinaryUrlFromId(id, this.cloudinaryConfig.cloudinaryCloudName, size)
   }
   getDownloadUrlForPdf(id: string): string {
-    return cloudinaryPdfFromId(id)
+    return cloudinaryPdfFromId(id, this.cloudinaryConfig.cloudinaryCloudName)
   }
 }

--- a/shared-services/src/files/file-config.ts
+++ b/shared-services/src/files/file-config.ts
@@ -1,0 +1,12 @@
+export enum FileServiceTypeEnum {
+  cloudinary = "cloudinary",
+}
+
+export class CloudinaryConfig {
+  cloudinaryCloudName: string
+}
+
+export class FileConfig {
+  fileServiceType: FileServiceTypeEnum
+  cloudinaryConfig: CloudinaryConfig
+}

--- a/shared-services/src/files/file-config.ts
+++ b/shared-services/src/files/file-config.ts
@@ -4,6 +4,7 @@ export enum FileServiceTypeEnum {
 
 export class CloudinaryConfig {
   cloudinaryCloudName: string
+  cloudinaryUploadPreset: string
 }
 
 export class FileConfig {

--- a/shared-services/src/files/file-service-provider.spec.ts
+++ b/shared-services/src/files/file-service-provider.spec.ts
@@ -7,8 +7,8 @@ import { FileServiceProvider } from "./file-service.provider"
 // see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
 declare const expect: jest.Expect
 
-process.env.CLOUDINARY_CLOUD_NAME = "exygy"
-process.env.CLOUDINARY_UPLOAD_PRESET = "test"
+process.env.cloudinaryCloudName = "exygy"
+process.env.cloudinaryUploadPreset = "test"
 let provider: FileServiceProvider
 
 describe("FileServiceProvider", () => {

--- a/shared-services/src/files/file-service-provider.spec.ts
+++ b/shared-services/src/files/file-service-provider.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from "@nestjs/testing"
+import { CloudinaryFileService } from "./cloudinary-file.service"
+import { FileServiceProvider } from "./file-service.provider"
+
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
+process.env.CLOUDINARY_CLOUD_NAME = "exygy"
+let provider: FileServiceProvider
+
+describe("FileServiceProvider", () => {
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FileServiceProvider],
+    }).compile()
+    provider = await module.resolve(FileServiceProvider)
+  })
+
+  it("should be defined", () => {
+    expect(provider).toBeDefined()
+  })
+
+  it("should return Cloudinary file service", () => {
+    const service = provider.getService()
+    expect(service).toBeDefined()
+    expect(service).toBeInstanceOf(CloudinaryFileService)
+  })
+})

--- a/shared-services/src/files/file-service-provider.spec.ts
+++ b/shared-services/src/files/file-service-provider.spec.ts
@@ -8,6 +8,7 @@ import { FileServiceProvider } from "./file-service.provider"
 declare const expect: jest.Expect
 
 process.env.CLOUDINARY_CLOUD_NAME = "exygy"
+process.env.CLOUDINARY_UPLOAD_PRESET = "test"
 let provider: FileServiceProvider
 
 describe("FileServiceProvider", () => {

--- a/shared-services/src/files/file-service.interface.ts
+++ b/shared-services/src/files/file-service.interface.ts
@@ -1,11 +1,11 @@
-import { SetStateAction } from "react"
+import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
+import { CloudinaryConfig } from "./file-service.provider"
 
 export interface FileServiceInterface {
-  putFile(
-    key: string,
-    file: File,
-    setProgressValue: (value: SetStateAction<number>) => void
-  ): Promise<string>
-  getDownloadUrlForPhoto(id: string): string
+  cloudinaryFileUploader: CloudinaryFileUploader
+  cloudinaryConfig: CloudinaryConfig
+
+  putFile(key: string, file: File, setProgressValue: (value: number) => void): Promise<string>
+  getDownloadUrlForPhoto(id: string, size?: number): string
   getDownloadUrlForPdf(id: string): string
 }

--- a/shared-services/src/files/file-service.interface.ts
+++ b/shared-services/src/files/file-service.interface.ts
@@ -1,11 +1,5 @@
-import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
-import { CloudinaryConfig } from "./file-service.provider"
-
 export interface FileServiceInterface {
-  cloudinaryFileUploader: CloudinaryFileUploader
-  cloudinaryConfig: CloudinaryConfig
-
   putFile(key: string, file: File, setProgressValue: (value: number) => void): Promise<string>
-  getDownloadUrlForPhoto(id: string, size?: number): string
+  getDownloadUrlForPhoto(id: string): string
   getDownloadUrlForPdf(id: string): string
 }

--- a/shared-services/src/files/file-service.interface.ts
+++ b/shared-services/src/files/file-service.interface.ts
@@ -1,5 +1,5 @@
 export interface FileServiceInterface {
   putFile(key: string, file: File, setProgressValue: (value: number) => void): Promise<string>
-  getDownloadUrlForPhoto(id: string): string
+  getDownloadUrlForPhoto(id: string, size?: number): string
   getDownloadUrlForPdf(id: string): string
 }

--- a/shared-services/src/files/file-service.provider.ts
+++ b/shared-services/src/files/file-service.provider.ts
@@ -1,19 +1,7 @@
 import { CloudinaryFileService } from "./cloudinary-file.service"
 import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
 import { FileServiceInterface } from "./file-service.interface"
-
-export enum FileServiceTypeEnum {
-  cloudinary = "cloudinary",
-}
-
-export interface CloudinaryConfig {
-  cloudinaryCloudName: string
-}
-
-interface FileConfig {
-  fileServiceType: FileServiceTypeEnum
-  cloudinaryConfig: CloudinaryConfig
-}
+import { FileConfig, FileServiceTypeEnum } from "./file-config"
 
 export class FileServiceProvider {
   service: FileServiceInterface
@@ -36,6 +24,9 @@ export class FileServiceProvider {
           new CloudinaryFileUploader(),
           fileConfig.cloudinaryConfig
         )
+        break
+      default:
+        throw new Error("Unknown file service type")
     }
   }
 

--- a/shared-services/src/files/file-service.provider.ts
+++ b/shared-services/src/files/file-service.provider.ts
@@ -1,0 +1,48 @@
+import { CloudinaryFileService } from "./cloudinary-file.service"
+import { CloudinaryFileUploader } from "./cloudinary-file-uploader"
+import { FileServiceInterface } from "./file-service.interface"
+
+export enum FileServiceTypeEnum {
+  cloudinary = "cloudinary",
+}
+
+export interface CloudinaryConfig {
+  cloudinaryCloudName: string
+}
+
+interface FileConfig {
+  fileServiceType: FileServiceTypeEnum
+  cloudinaryConfig: CloudinaryConfig
+}
+
+export class FileServiceProvider {
+  service: FileServiceInterface
+
+  private configure(): FileConfig {
+    const fileConfig: FileConfig = {
+      fileServiceType: FileServiceTypeEnum.cloudinary,
+      cloudinaryConfig: {
+        cloudinaryCloudName: process.env.CLOUDINARY_CLOUD_NAME || "",
+      },
+    }
+    return fileConfig
+  }
+
+  private create(): void {
+    const fileConfig = this.configure()
+    switch (fileConfig.fileServiceType) {
+      case FileServiceTypeEnum.cloudinary:
+        this.service = new CloudinaryFileService(
+          new CloudinaryFileUploader(),
+          fileConfig.cloudinaryConfig
+        )
+    }
+  }
+
+  public getService(): FileServiceInterface {
+    if (this.service === undefined) {
+      this.create()
+    }
+    return this.service
+  }
+}

--- a/shared-services/src/files/file-service.provider.ts
+++ b/shared-services/src/files/file-service.provider.ts
@@ -10,7 +10,8 @@ export class FileServiceProvider {
     const fileConfig: FileConfig = {
       fileServiceType: FileServiceTypeEnum.cloudinary,
       cloudinaryConfig: {
-        cloudinaryCloudName: process.env.CLOUDINARY_CLOUD_NAME || "",
+        cloudinaryCloudName: process.env.cloudinaryCloudName || "",
+        cloudinaryUploadPreset: process.env.cloudinarySignedPreset || "",
       },
     }
     return fileConfig

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailAdditionalEligibility.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailAdditionalEligibility.tsx
@@ -9,11 +9,11 @@ import {
 } from "@bloom-housing/ui-components"
 import { ListingContext } from "../../ListingContext"
 import { getDetailFieldString } from "./helpers"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceInterface, FileServiceProvider } from "@bloom-housing/shared-services"
 
 const DetailAdditionalEligibility = () => {
   const listing = useContext(ListingContext)
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
 
   return (
     <GridSection
@@ -65,7 +65,7 @@ const DetailAdditionalEligibility = () => {
                         <TableThumbnail>
                           <img
                             alt="PDF preview"
-                            src={cloudinaryFileService.getDownloadUrlForPhoto(
+                            src={fileService.getDownloadUrlForPhoto(
                               listing.buildingSelectionCriteriaFile.fileId
                             )}
                           />

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailAdditionalEligibility.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailAdditionalEligibility.tsx
@@ -9,11 +9,11 @@ import {
 } from "@bloom-housing/ui-components"
 import { ListingContext } from "../../ListingContext"
 import { getDetailFieldString } from "./helpers"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 const DetailAdditionalEligibility = () => {
   const listing = useContext(ListingContext)
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
 
   return (
     <GridSection

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailListingPhoto.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailListingPhoto.tsx
@@ -7,7 +7,7 @@ import {
   TableThumbnail,
 } from "@bloom-housing/ui-components"
 import { ListingContext } from "../../ListingContext"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 const DetailListingPhoto = () => {
   const listing = useContext(ListingContext)
@@ -21,7 +21,7 @@ const DetailListingPhoto = () => {
     listingFormPhoto = { ordinal: 0, image: { fileId: asset.fileId, label: asset.label } }
   }
 
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
   const urlTest = new RegExp(/https?:\/\//)
   const listingPhotoUrl = listingFormPhoto?.image
     ? urlTest.test(listingFormPhoto.image.fileId)

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailListingPhoto.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailListingPhoto.tsx
@@ -7,7 +7,7 @@ import {
   TableThumbnail,
 } from "@bloom-housing/ui-components"
 import { ListingContext } from "../../ListingContext"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceInterface, FileServiceProvider } from "@bloom-housing/shared-services"
 
 const DetailListingPhoto = () => {
   const listing = useContext(ListingContext)
@@ -21,12 +21,12 @@ const DetailListingPhoto = () => {
     listingFormPhoto = { ordinal: 0, image: { fileId: asset.fileId, label: asset.label } }
   }
 
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
   const urlTest = new RegExp(/https?:\/\//)
   const listingPhotoUrl = listingFormPhoto?.image
     ? urlTest.test(listingFormPhoto.image.fileId)
       ? listingFormPhoto.image.fileId
-      : cloudinaryFileService.getDownloadUrlForPhoto(listingFormPhoto.image.fileId)
+      : fileService.getDownloadUrlForPhoto(listingFormPhoto.image.fileId)
     : null
 
   const photoTableHeaders = {

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
@@ -25,7 +25,7 @@ import {
   Language,
 } from "@bloom-housing/backend-core/types"
 import { FormListing } from "../../../../lib/listings/formTypes"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceInterface, FileServiceProvider } from "@bloom-housing/shared-services"
 
 interface Methods {
   digital: ApplicationMethodCreate
@@ -104,18 +104,14 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
     Pass the file for the dropzone callback along to the uploader
   */
   const pdfUploader = async (file: File) => {
-    const cloudinaryFileService = new FileServiceProvider().getService()
+    const fileService: FileServiceInterface = new FileServiceProvider().getService()
     const setProgressValueCallback = (value: number) => {
       setProgressValue(value)
     }
-    const generatedId = await cloudinaryFileService.putFile(
-      selectedLanguage,
-      file,
-      setProgressValueCallback
-    )
+    const generatedId = await fileService.putFile(selectedLanguage, file, setProgressValueCallback)
     setCloudinaryData({
       id: generatedId,
-      url: cloudinaryFileService.getDownloadUrlForPdf(generatedId),
+      url: fileService.getDownloadUrlForPdf(generatedId),
     })
   }
 

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
@@ -25,7 +25,7 @@ import {
   Language,
 } from "@bloom-housing/backend-core/types"
 import { FormListing } from "../../../../lib/listings/formTypes"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 interface Methods {
   digital: ApplicationMethodCreate
@@ -104,7 +104,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
     Pass the file for the dropzone callback along to the uploader
   */
   const pdfUploader = async (file: File) => {
-    const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+    const cloudinaryFileService = new FileServiceProvider().getService()
     const setProgressValueCallback = (value: number) => {
       setProgressValue(value)
     }

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -15,7 +15,7 @@ import {
   StandardTableData,
   AppearanceSizeType,
 } from "@bloom-housing/ui-components"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 const LotteryResults = () => {
   const formMethods = useFormContext()
@@ -36,7 +36,7 @@ const LotteryResults = () => {
     id: "",
     url: "",
   })
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
   const resetDrawerState = () => {
     setProgressValue(0)
     setCloudinaryData({

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -15,7 +15,7 @@ import {
   StandardTableData,
   AppearanceSizeType,
 } from "@bloom-housing/ui-components"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceProvider, FileServiceInterface } from "@bloom-housing/shared-services"
 
 const LotteryResults = () => {
   const formMethods = useFormContext()
@@ -36,7 +36,7 @@ const LotteryResults = () => {
     id: "",
     url: "",
   })
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
   const resetDrawerState = () => {
     setProgressValue(0)
     setCloudinaryData({
@@ -110,7 +110,7 @@ const LotteryResults = () => {
   */
   const criteriaTableRows: StandardTableData = []
   if (listingCriteriaFile?.fileId && listingCriteriaFile.fileId != "") {
-    const listingPhotoUrl = cloudinaryFileService.getDownloadUrlForPhoto(listingCriteriaFile.fileId)
+    const listingPhotoUrl = fileService.getDownloadUrlForPhoto(listingCriteriaFile.fileId)
 
     criteriaTableRows.push({
       preview: {
@@ -192,14 +192,10 @@ const LotteryResults = () => {
     const setProgressValueCallback = (value: number) => {
       setProgressValue(value)
     }
-    const generatedId = await cloudinaryFileService.putFile(
-      "cloudinaryPDF",
-      file,
-      setProgressValueCallback
-    )
+    const generatedId = await fileService.putFile("cloudinaryPDF", file, setProgressValueCallback)
     setCloudinaryData({
       id: generatedId,
-      url: cloudinaryFileService.getDownloadUrlForPhoto(generatedId),
+      url: fileService.getDownloadUrlForPhoto(generatedId),
     })
   }
 

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhoto.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhoto.tsx
@@ -14,7 +14,7 @@ import {
   AppearanceSizeType,
 } from "@bloom-housing/ui-components"
 import { fieldHasError } from "../../../../lib/helpers"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceProvider, FileServiceInterface } from "@bloom-housing/shared-services"
 
 /**
  *
@@ -36,7 +36,7 @@ const ListingPhoto = () => {
     id: "",
     url: "",
   })
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
   const resetDrawerState = () => {
     setProgressValue(0)
     setCloudinaryData({
@@ -104,7 +104,7 @@ const ListingPhoto = () => {
   if (listingFormPhoto?.image?.fileId && listingFormPhoto.image.fileId != "") {
     const listingPhotoUrl = listingFormPhoto.image.fileId.match(/https?:\/\//)
       ? listingFormPhoto.image.fileId
-      : cloudinaryFileService.getDownloadUrlForPhoto(listingFormPhoto.image.fileId)
+      : fileService.getDownloadUrlForPhoto(listingFormPhoto.image.fileId)
 
     listingPhotoTableRows.push({
       preview: {
@@ -152,14 +152,14 @@ const ListingPhoto = () => {
     const setProgressValueCallback = (value: number) => {
       setProgressValue(value)
     }
-    const generatedId = await cloudinaryFileService.putFile(
+    const generatedId = await fileService.putFile(
       "cloudinaryBuilding",
       file,
       setProgressValueCallback
     )
     setCloudinaryData({
       id: generatedId,
-      url: cloudinaryFileService.getDownloadUrlForPhoto(generatedId),
+      url: fileService.getDownloadUrlForPhoto(generatedId),
     })
   }
 

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhoto.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhoto.tsx
@@ -14,7 +14,7 @@ import {
   AppearanceSizeType,
 } from "@bloom-housing/ui-components"
 import { fieldHasError } from "../../../../lib/helpers"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 /**
  *
@@ -36,7 +36,7 @@ const ListingPhoto = () => {
     id: "",
     url: "",
   })
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
   const resetDrawerState = () => {
     setProgressValue(0)
     setCloudinaryData({

--- a/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
@@ -16,7 +16,7 @@ import {
   ListingEventCreate,
   ListingEventType,
 } from "@bloom-housing/backend-core/types"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 interface LotteryResultsProps {
   submitCallback: (data: { events: ListingEvent[] }) => void
@@ -36,7 +36,7 @@ const LotteryResults = (props: LotteryResultsProps) => {
     id: "",
     url: "",
   })
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
 
   const listingEvents = watch("events")
   const uploadedPDF = listingEvents.find(

--- a/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
@@ -16,7 +16,7 @@ import {
   ListingEventCreate,
   ListingEventType,
 } from "@bloom-housing/backend-core/types"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceProvider, FileServiceInterface } from "@bloom-housing/shared-services"
 
 interface LotteryResultsProps {
   submitCallback: (data: { events: ListingEvent[] }) => void
@@ -36,7 +36,7 @@ const LotteryResults = (props: LotteryResultsProps) => {
     id: "",
     url: "",
   })
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
 
   const listingEvents = watch("events")
   const uploadedPDF = listingEvents.find(
@@ -46,7 +46,7 @@ const LotteryResults = (props: LotteryResultsProps) => {
   useEffect(() => {
     if (uploadedPDF) {
       setCloudinaryData({
-        url: cloudinaryFileService.getDownloadUrlForPhoto(uploadedPDF.file?.fileId),
+        url: fileService.getDownloadUrlForPhoto(uploadedPDF.file?.fileId),
         id: uploadedPDF.id,
       })
       // Don't allow a new one to be uploaded if one already exists so setting progress to 100%
@@ -136,14 +136,10 @@ const LotteryResults = (props: LotteryResultsProps) => {
     const setProgressValueCallback = (value: number) => {
       setProgressValue(value)
     }
-    const generatedId = await cloudinaryFileService.putFile(
-      "cloudinaryPDF",
-      file,
-      setProgressValueCallback
-    )
+    const generatedId = await fileService.putFile("cloudinaryPDF", file, setProgressValueCallback)
     setCloudinaryData({
       id: generatedId,
-      url: cloudinaryFileService.getDownloadUrlForPhoto(generatedId),
+      url: fileService.getDownloadUrlForPhoto(generatedId),
     })
   }
 

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -58,7 +58,7 @@ import { getGenericAddress, openInFuture } from "../../lib/helpers"
 import { GetApplication } from "./GetApplication"
 import { DownloadLotteryResults } from "./DownloadLotteryResults"
 import { SubmitApplication } from "./SubmitApplication"
-import { FileServiceProvider } from "@bloom-housing/shared-services"
+import { FileServiceProvider, FileServiceInterface } from "@bloom-housing/shared-services"
 
 interface ListingProps {
   listing: Listing
@@ -73,7 +73,7 @@ export const ListingView = (props: ListingProps) => {
     content: appStatusContent,
     subContent: appStatusSubContent,
   } = useGetApplicationStatusProps(listing)
-  const cloudinaryFileService = new FileServiceProvider().getService()
+  const fileService: FileServiceInterface = new FileServiceProvider().getService()
 
   const appOpenInFuture = openInFuture(listing)
   const hasNonReferralMethods = listing?.applicationMethods
@@ -150,9 +150,7 @@ export const ListingView = (props: ListingProps) => {
     buildingSelectionCriteria = (
       <p>
         <a
-          href={cloudinaryFileService.getDownloadUrlForPdf(
-            listing.buildingSelectionCriteriaFile.fileId
-          )}
+          href={fileService.getDownloadUrlForPdf(listing.buildingSelectionCriteriaFile.fileId)}
           className={"text-blue-700"}
         >
           {t("listings.moreBuildingSelectionCriteria")}
@@ -327,7 +325,7 @@ export const ListingView = (props: ListingProps) => {
           return {
             fileURL: paperApp?.file?.fileId.includes("https")
               ? paperApp?.file?.fileId
-              : cloudinaryFileService.getDownloadUrlForPdf(paperApp?.file?.fileId || ""),
+              : fileService.getDownloadUrlForPdf(paperApp?.file?.fileId || ""),
             languageString: t(`languages.${paperApp.language}`),
           }
         }) ?? null

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -58,7 +58,7 @@ import { getGenericAddress, openInFuture } from "../../lib/helpers"
 import { GetApplication } from "./GetApplication"
 import { DownloadLotteryResults } from "./DownloadLotteryResults"
 import { SubmitApplication } from "./SubmitApplication"
-import { CloudinaryFileService, CloudinaryFileUploader } from "@bloom-housing/shared-services"
+import { FileServiceProvider } from "@bloom-housing/shared-services"
 
 interface ListingProps {
   listing: Listing
@@ -73,7 +73,7 @@ export const ListingView = (props: ListingProps) => {
     content: appStatusContent,
     subContent: appStatusSubContent,
   } = useGetApplicationStatusProps(listing)
-  const cloudinaryFileService = new CloudinaryFileService(new CloudinaryFileUploader())
+  const cloudinaryFileService = new FileServiceProvider().getService()
 
   const appOpenInFuture = openInFuture(listing)
   const hasNonReferralMethods = listing?.applicationMethods


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #20 

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Create a FileServiceProvider which instantiates FileService. The provider reads environment variables to create a config object determining which implementation of the file service to use, and any necessary keys/variables. Currently the only available implementation is Cloudinary which is why it is hardcoded, in the future AWS S3 will be implemented as a separate option and which service to use will be configurable.

## How Can This Be Tested/Reviewed?

Added unit tests for the new class and updated existing unit tests where needed.
Also verify that the public and partners sites can both be loaded, and tested adding a new listing photo in the partners site, which calls both putFile() and getDownloadUrlForPhoto().

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
