### PR TITLE
fix: add urlSlug back to local listings

### DIFF
--- a/backend/core/src/listings/listings.controller.ts
+++ b/backend/core/src/listings/listings.controller.ts
@@ -15,7 +15,7 @@ import {
   Headers,
   ParseUUIDPipe,
 } from "@nestjs/common"
-import { ListingsService, ListingIncludeExternalResponse } from "./listings.service"
+import { ListingsService } from "./listings.service"
 import { ApiBearerAuth, ApiExtraModels, ApiOperation, ApiTags } from "@nestjs/swagger"
 import { ListingDto } from "./dto/listing.dto"
 import { ResourceType } from "../auth/decorators/resource-type.decorator"
@@ -66,12 +66,14 @@ export class ListingsController {
   })
   @UseInterceptors(ClassSerializerInterceptor)
   @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
-  public async getAllWithExternal(
-    @Query() queryParams: DoorwayListingsExternalQueryParams
-  ): Promise<ListingIncludeExternalResponse> {
+  public async getAllWithExternal(@Query() queryParams: DoorwayListingsExternalQueryParams) {
     const jurisdictions: string[] = queryParams.bloomJurisdiction
     mapTo(ListingsQueryParams, queryParams, { excludeExtraneousValues: true })
-    return await this.listingsService.listIncludeExternal(jurisdictions, queryParams)
+    const response = await this.listingsService.listIncludeExternal(jurisdictions, queryParams)
+    return {
+      ...response,
+      local: mapTo(PaginatedListingDto, response.local),
+    }
   }
 
   @Post()


### PR DESCRIPTION
`mapTo(PaginatedListingDto` is done on the /listings endpoint and does a lot to consolidate the Listing object and adds the urlSlug, so we need to add that back in here.

I didn't add a test since I think this code is getting deprecated soon and this is a hotfix to get it working again
before -- the URL is `listing/[id]/undefined`
after it is `listing/[id]/[urlSlug]`

![image](https://user-images.githubusercontent.com/10789523/232885016-7fa66970-49c1-4a25-8bca-ea755fa9e74b.png)
