### PR TITLE
feat: add info window with the listing card that opens on click on map markers

### DIFF
--- a/sites/public/src/components/listings/ListingsMap.tsx
+++ b/sites/public/src/components/listings/ListingsMap.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
-import { GoogleMap, Marker, useJsApiLoader } from "@react-google-maps/api"
-import { getListingUrl } from "../../lib/helpers"
+import React, { useState } from "react"
+import { GoogleMap, InfoWindow, Marker, useJsApiLoader } from "@react-google-maps/api"
+import { getListingUrl, getListingCard } from "../../lib/helpers"
 import { Listing } from "@bloom-housing/backend-core"
 
 type ListingsMapProps = {
@@ -30,10 +30,18 @@ const ListingsMap = (props: ListingsMapProps) => {
     const lat = listing.buildingAddress.latitude
     const lng = listing.buildingAddress.longitude
     const uri = getListingUrl(listing)
-    const label = (++index).toString()
+    const key = ++index
 
-    markers.push({ lat, lng, uri, label })
+    // Create an info window that is associated to each marker and that contains the listing card
+    // for that listing.
+    const infoWindow = (
+      <InfoWindow position={{ lat: lat, lng: lng }}>{getListingCard(listing, key - 1)}</InfoWindow>
+    )
+    markers.push({ lat, lng, uri, key, infoWindow })
   })
+
+  const [openInfoWindow, setOpenInfoWindow] = useState(false)
+  const [infoWindowIndex, setInfoWindowIndex] = useState(null)
 
   return isLoaded ? (
     <GoogleMap mapContainerStyle={containerStyle} center={center} zoom={9}>
@@ -41,19 +49,25 @@ const ListingsMap = (props: ListingsMapProps) => {
         <Marker
           position={{ lat: marker.lat, lng: marker.lng }}
           label={{
-            text: marker.label,
+            text: marker.key.toString(),
             color: "var(--bloom-color-white)",
             fontFamily: "var(--bloom-font-sans)",
             fontWeight: "700",
             fontSize: "var(--bloom-font-size-2xs)",
           }}
-          onClick={() => (window.location.href = marker.uri)}
-          key={marker.label}
+          onClick={() => {
+            setOpenInfoWindow(true)
+            setInfoWindowIndex(marker.key)
+          }}
+          key={marker.key.toString()}
           icon={{
             url: "/images/map-pin.svg",
             labelOrigin: new google.maps.Point(14, 15),
           }}
-        />
+        >
+          {/* Only display the info window when the corresponding marker has been clicked. */}
+          {openInfoWindow && infoWindowIndex === marker.key && marker.infoWindow}
+        </Marker>
       ))}
     </GoogleMap>
   ) : (

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -65,12 +65,12 @@ export const openInFuture = (listing: Listing) => {
   return listing.applicationOpenDate && nowTime < dayjs(listing.applicationOpenDate)
 }
 
-export const getListingCardSubtitle = (address: Address) => {
+const getListingCardSubtitle = (address: Address) => {
   const { street, city, state, zipCode } = address || {}
   return address ? `${street}, ${city} ${state}, ${zipCode}` : null
 }
 
-export const getListingTableData = (
+const getListingTableData = (
   unitsSummarized: UnitsSummarized,
   listingReviewOrder: ListingReviewOrder
 ) => {
@@ -133,7 +133,7 @@ export const getListingApplicationStatus = (listing: Listing): StatusBarType => 
   }
 }
 
-export const generateTableSubHeader = (listing) => {
+const generateTableSubHeader = (listing) => {
   if (listing.reviewOrderType !== ListingReviewOrder.waitlist) {
     return {
       content: t("listings.availableUnits"),

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -65,12 +65,12 @@ export const openInFuture = (listing: Listing) => {
   return listing.applicationOpenDate && nowTime < dayjs(listing.applicationOpenDate)
 }
 
-const getListingCardSubtitle = (address: Address) => {
+export const getListingCardSubtitle = (address: Address) => {
   const { street, city, state, zipCode } = address || {}
   return address ? `${street}, ${city} ${state}, ${zipCode}` : null
 }
 
-const getListingTableData = (
+export const getListingTableData = (
   unitsSummarized: UnitsSummarized,
   listingReviewOrder: ListingReviewOrder
 ) => {
@@ -133,73 +133,77 @@ export const getListingApplicationStatus = (listing: Listing): StatusBarType => 
   }
 }
 
-export const getListings = (listings: Listing[]) => {
-  const unitSummariesHeaders = {
-    unitType: "t.unitType",
-    minimumIncome: "t.minimumIncome",
-    rent: "t.rent",
-  }
-
-  const generateTableSubHeader = (listing) => {
-    if (listing.reviewOrderType !== ListingReviewOrder.waitlist) {
-      return {
-        content: t("listings.availableUnits"),
-        styleType: AppearanceStyleType.success,
-        isPillType: true,
-      }
-    } else if (listing.reviewOrderType === ListingReviewOrder.waitlist) {
-      return {
-        content: t("listings.waitlist.open"),
-        styleType: AppearanceStyleType.primary,
-        isPillType: true,
-      }
+export const generateTableSubHeader = (listing) => {
+  if (listing.reviewOrderType !== ListingReviewOrder.waitlist) {
+    return {
+      content: t("listings.availableUnits"),
+      styleType: AppearanceStyleType.success,
+      isPillType: true,
     }
-    return null
+  } else if (listing.reviewOrderType === ListingReviewOrder.waitlist) {
+    return {
+      content: t("listings.waitlist.open"),
+      styleType: AppearanceStyleType.primary,
+      isPillType: true,
+    }
   }
+  return null
+}
 
+const unitSummariesHeaders = {
+  unitType: "t.unitType",
+  minimumIncome: "t.minimumIncome",
+  rent: "t.rent",
+}
+
+export const getListings = (listings: Listing[]) => {
   return listings.map((listing: Listing, index: number) => {
-    const uri = getListingUrl(listing)
-    const displayIndex: string = (index + 1).toString()
-    return (
-      <ListingCard
-        key={index}
-        imageCardProps={{
-          imageUrl:
-            imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize || "1302")) || "",
-          tags: listing.reservedCommunityType
-            ? [
-                {
-                  text: t(`listings.reservedCommunityTypes.${listing.reservedCommunityType.name}`),
-                },
-              ]
-            : undefined,
-          statuses: [getListingApplicationStatus(listing)],
-          description: listing.name,
-        }}
-        tableProps={{
-          headers: unitSummariesHeaders,
-          data: getListingTableData(listing.unitsSummarized, listing.reviewOrderType),
-          responsiveCollapse: true,
-          cellClassName: "px-5 py-3",
-        }}
-        footerButtons={[
-          {
-            text: t("t.seeDetails"),
-            href: uri,
-            ariaHidden: true,
-          },
-        ]}
-        contentProps={{
-          contentHeader: {
-            content: displayIndex + ". " + listing.name,
-            href: uri,
-          },
-          contentSubheader: { content: getListingCardSubtitle(listing.buildingAddress) },
-          tableHeader: generateTableSubHeader(listing),
-        }}
-      />
-    )
+    return getListingCard(listing, index)
   })
+}
+
+export const getListingCard = (listing: Listing, index: number) => {
+  const uri = getListingUrl(listing)
+  const displayIndex: string = (index + 1).toString()
+  return (
+    <ListingCard
+      key={index}
+      imageCardProps={{
+        imageUrl:
+          imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize || "1302")) || "",
+        tags: listing.reservedCommunityType
+          ? [
+              {
+                text: t(`listings.reservedCommunityTypes.${listing.reservedCommunityType.name}`),
+              },
+            ]
+          : undefined,
+        statuses: [getListingApplicationStatus(listing)],
+        description: listing.name,
+      }}
+      tableProps={{
+        headers: unitSummariesHeaders,
+        data: getListingTableData(listing.unitsSummarized, listing.reviewOrderType),
+        responsiveCollapse: true,
+        cellClassName: "px-5 py-3",
+      }}
+      footerButtons={[
+        {
+          text: t("t.seeDetails"),
+          href: uri,
+          ariaHidden: true,
+        },
+      ]}
+      contentProps={{
+        contentHeader: {
+          content: displayIndex + ". " + listing.name,
+          href: uri,
+        },
+        contentSubheader: { content: getListingCardSubtitle(listing.buildingAddress) },
+        tableHeader: generateTableSubHeader(listing),
+      }}
+    />
+  )
 }
 
 export const untranslateMultiselectQuestion = (


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #107 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

- When a pin on the map is clicked, open an info window that shows the listing card for that specific listing. This uses the existing ListingCard component.
- Refactor the existing code to create the listing card so there is a shared method to get just one listing card that can then be called by the map.

## How Can This Be Tested/Reviewed?
Screenshot of the listings page below. See how the listing card in the info window is the same as the existing card on the right side column and how the indices match.
![image](https://github.com/metrotranscom/doorway/assets/67125998/9c2d2a03-32ae-4379-b9df-e11775eccec1)

To test this feature, bring up the public site and go to the listings page. You will need to have a Google Maps API key specified in the environment variables for the public site. Click on any listing pin to open the info window, and then click on the x in the top right corner of the window to close it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
