### PR TITLE
feat: restyle language bar to doorway version

### DIFF
--- a/doorway-ui-components/src/global/text.scss
+++ b/doorway-ui-components/src/global/text.scss
@@ -146,7 +146,7 @@ h1.title {
 
 .text__small-normal {
   font-family: var(--text-small-normal-font-family, var(--bloom-font-alt-sans));
-  font-weight: var(--text-small-normal-font-weight, normal);
+  font-weight: var(--text-small-normal-font-weight, 400);
   color: var(--text-small-normal-color, var(--bloom-text-color));
   font-size: var(--text-small-normal-font-size, var(--bloom-font-size-xs));
   margin-block: var(--text-small-normal-margin-block, 0 var(--bloom-s3));

--- a/doorway-ui-components/src/global/tokens/borders.scss
+++ b/doorway-ui-components/src/global/tokens/borders.scss
@@ -14,4 +14,6 @@
   --bloom-border-8: 8px;
 
   --bloom-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+
+  --doorway-standard-border: var(--bloom-border-1) solid var(--bloom-color-gray-450);
 }

--- a/doorway-ui-components/src/navigation/LanguageNav.scss
+++ b/doorway-ui-components/src/navigation/LanguageNav.scss
@@ -16,10 +16,7 @@
   padding: var(--bloom-s2) 0;
 
   @media (max-width: $screen-md) {
-    // padding: 0 var(--bloom-s3);
-    // padding: var(--inner-desktop-padding);
     justify-content: center;
-
   }
 }
 
@@ -44,12 +41,11 @@
   margin: 0 var(--bloom-s1_5);
 
   &:hover {
-    background-color: var(--doorway-color-cyan-300)
-
+    background-color: var(--doorway-color-cyan-300);
   }
 
   &.is-active {
     color: var(--bloom-text-color);
-    background-color: var(--doorway-color-cyan-300)
+    background-color: var(--doorway-color-cyan-300);
   }
 }

--- a/doorway-ui-components/src/navigation/LanguageNav.scss
+++ b/doorway-ui-components/src/navigation/LanguageNav.scss
@@ -3,7 +3,7 @@
   --inner-width: inherit;
   --inner-desktop-padding: inherit;
   --inner-mobile-padding: inherit;
-  background-color: var(--bloom-color-gray-800);
+  background-color: var(--bloom-color-gray-200);
 }
 
 .language-bar__inner {
@@ -13,30 +13,43 @@
   justify-content: flex-end;
   margin: auto;
   padding: var(--inner-mobile-padding);
+  padding: var(--bloom-s2) 0;
 
-  @media (min-width: $screen-md) {
-    padding: 0 var(--bloom-s3);
-    padding: var(--inner-desktop-padding);
+  @media (max-width: $screen-md) {
+    // padding: 0 var(--bloom-s3);
+    // padding: var(--inner-desktop-padding);
+    justify-content: center;
+
   }
 }
 
 .language-nav__list {
   display: flex;
+  @media (max-width: $screen-md) {
+    justify-content: center;
+  }
+  li:not(:last-child) {
+    border-right: var(--doorway-standard-border);
+  }
 }
 
 .language-nav__list-button {
-  padding: var(--bloom-s2) var(--bloom-s3);
-  color: var(--bloom-color-gray-500);
-  font-weight: 600;
+  padding: var(--bloom-s1) var(--bloom-s3);
+  color: var(--bloom-text-color);
+  border-radius: var(--bloom-rounded-full);
+  font-weight: 500;
+  font-size: var(--bloom-font-size-xs);
   cursor: pointer;
   background-color: transparent;
+  margin: 0 var(--bloom-s1_5);
 
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px #fff, 0 0 3px 4px var(--bloom-color-accent-cool);
+  &:hover {
+    background-color: var(--doorway-color-cyan-300)
+
   }
 
   &.is-active {
-    color: var(--bloom-color-white);
+    color: var(--bloom-text-color);
+    background-color: var(--doorway-color-cyan-300)
   }
 }

--- a/doorway-ui-components/src/navigation/LanguageNav.tsx
+++ b/doorway-ui-components/src/navigation/LanguageNav.tsx
@@ -23,10 +23,12 @@ const LanguageNav = ({ ariaLabel, languages }: LanguageNavProps) => {
                 <button
                   onClick={() => {
                     item.onClick()
-                  } }
-                  className={item.active
-                    ? "language-nav__list-button is-active"
-                    : "language-nav__list-button"}
+                  }}
+                  className={
+                    item.active
+                      ? "language-nav__list-button is-active"
+                      : "language-nav__list-button"
+                  }
                   type="button"
                 >
                   {item.label}


### PR DESCRIPTION
See our Figma file for mocks.

Before:
<img width="1169" alt="Screenshot 2023-05-11 at 2 15 42 PM" src="https://github.com/metrotranscom/doorway/assets/10789523/5cd2e943-9bf3-4c9d-8fff-9fd61ba40189">

After:

https://github.com/metrotranscom/doorway/assets/10789523/60686268-ccfc-48da-bcf7-519757e62874


