### PR TITLE
feat: make listing card clickable without breaking hover states

### DIFF
--- a/doorway-ui-components/src/config/NavigationContext.tsx
+++ b/doorway-ui-components/src/config/NavigationContext.tsx
@@ -38,8 +38,9 @@ export interface NavigationContextProps {
 
 export const NavigationContext = createContext<NavigationContextProps>({
   LinkComponent: (props) => {
+    const { className, linkRef, ...defaultProps } = props
     return (
-      <a className={props.className} ref={props.linkRef} {...props}>
+      <a className={className} ref={linkRef} {...defaultProps}>
         {props.children}
       </a>
     )

--- a/doorway-ui-components/src/config/NavigationContext.tsx
+++ b/doorway-ui-components/src/config/NavigationContext.tsx
@@ -3,6 +3,7 @@ import React, {
   FunctionComponent,
   AnchorHTMLAttributes,
   DetailedHTMLProps,
+  RefObject,
 } from "react"
 import { UrlObject } from "url"
 
@@ -15,6 +16,7 @@ type DefaultLinkProps = DetailedHTMLProps<
 
 export interface LinkProps extends DefaultLinkProps {
   className?: string
+  linkRef?: React.RefObject<HTMLAnchorElement>
 }
 
 export interface GenericRouterOptions {
@@ -35,11 +37,13 @@ export interface NavigationContextProps {
 }
 
 export const NavigationContext = createContext<NavigationContextProps>({
-  LinkComponent: (props) => (
-    <a className={props.className} {...props}>
-      {props.children}
-    </a>
-  ),
+  LinkComponent: (props) => {
+    return (
+      <a className={props.className} ref={props.linkRef} {...props}>
+        {props.children}
+      </a>
+    )
+  },
   router: {
     push: () => {
       // no-op

--- a/doorway-ui-components/src/global/text.scss
+++ b/doorway-ui-components/src/global/text.scss
@@ -47,7 +47,7 @@ a {
   @apply text-primary;
 
   &:hover {
-    @apply text-primary;
+    @apply text-primary-darker;
   }
 
   &:focus {

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -1,6 +1,6 @@
 .listings-row {
   --tags-flex-order: 0;
-  --inter-row-gap: var(--bloom-s12);
+  --inter-row-gap: var(--bloom-s5);
   --max-width: var(--bloom-width-3xl);
   --max-width-large-screen: var(--bloom-width-5xl);
   --cell-padding: var(--bloom-s3);
@@ -22,7 +22,12 @@
   &:first-of-type {
     margin-top: 0;
   }
+
+  &:hover {
+    background-color: var(--bloom-color-gray-300);
+  }
 }
+
 .listings-row_figure {
   display: flex;
 
@@ -40,7 +45,6 @@
 .listings-row_figure,
 .listings-row_content {
   padding: var(--cell-padding);
-  padding-bottom: 0px;
 }
 
 .listings-row_content {
@@ -94,6 +98,8 @@
     top: 0;
     right: 0;
     bottom: 0;
+    width: 0;
+    height: 0;
   }
 }
 

--- a/doorway-ui-components/src/page_components/listing/ListingCard.tsx
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.tsx
@@ -20,6 +20,7 @@ export interface ListingCardHeader {
   styleType?: AppearanceStyleType
   isPillType?: boolean
   priority?: number
+  makeCardClickable?: boolean
 }
 
 export interface ListingFooterButton {
@@ -81,6 +82,12 @@ const ListingCard = (props: ListingCardProps) => {
     tableProps,
   } = props
   const { LinkComponent } = useContext(NavigationContext)
+  const linkRef = React.useRef<HTMLAnchorElement>(null)
+  const simulateLinkClick = () => {
+    if (linkRef.current) {
+      linkRef.current.click()
+    }
+  }
 
   const getHeader = (
     header: ListingCardHeader | undefined,
@@ -105,7 +112,7 @@ const ListingCard = (props: ListingCardProps) => {
       return (
         <Heading priority={priority} styleType={styleType} className={customClass}>
           {header.href ? (
-            <LinkComponent className="is-card-link" href={header.href}>
+            <LinkComponent className="is-card-link" href={header.href} linkRef={linkRef}>
               {header.content}
             </LinkComponent>
           ) : (
@@ -205,8 +212,14 @@ const ListingCard = (props: ListingCardProps) => {
     )
   }
 
+  const componentIsClickable =
+    contentProps?.contentHeader?.makeCardClickable && contentProps?.contentHeader?.href
   return (
-    <article className="listings-row" data-testid={"listing-card-component"}>
+    <article
+      className={`listings-row ${componentIsClickable ? "cursor-pointer" : ""}`}
+      data-testid={"listing-card-component"}
+      onClick={componentIsClickable ? simulateLinkClick : undefined}
+    >
       <div className="listings-row_figure">
         <ImageCard {...imageCardProps} />
       </div>

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -182,6 +182,7 @@ export const getListingCard = (listing: Listing, index: number) => {
         contentHeader: {
           content: displayIndex + ". " + listing.name,
           href: uri,
+          makeCardClickable: true,
         },
         contentSubheader: { content: getListingCardSubtitle(listing.buildingAddress) },
       }}


### PR DESCRIPTION
This is one of many ways to fix the issue where hover states are not working on the ListingCard component.

The bug here was that the way that the entire card was made clickable was via an `a:after` element with a very high z index covering the whole card. This element even went over the header submenu (which is why the header submenu was messed up in #124).

We still want the card to be clickable (and using the anchor tag instead of js click handlers is I assume an accessibility thing) so I added a synthetic click event when someone clicks on the component itself onto the anchor tag. This shouldn't break screen readers etc. since the anchor tag is still there.

(note that the absolute most semantically correct way to do this is probably to just make the `<section>` tag an `<a> `tag, but then I would have to go and refactor the <a> tag located inside of the component and it would have ballooned in scope a lot (https://stackoverflow.com/questions/18666915/why-are-nested-anchor-tags-illegal). But I think this way is better than the old state imo)


https://github.com/metrotranscom/doorway/assets/10789523/db49897d-ed39-4081-858a-5c65f40e1c35


https://github.com/metrotranscom/doorway/assets/10789523/d879d21c-d18c-46bd-a0d1-17c120b2b94d

