### PR TITLE
fix: update state to not show info window on close click

### DIFF
--- a/sites/public/src/components/listings/ListingsMap.tsx
+++ b/sites/public/src/components/listings/ListingsMap.tsx
@@ -27,6 +27,9 @@ const ListingsMap = (props: ListingsMapProps) => {
     googleMapsApiKey: props.googleMapsApiKey,
   })
 
+  const [openInfoWindow, setOpenInfoWindow] = useState(false)
+  const [infoWindowIndex, setInfoWindowIndex] = useState(null)
+
   const markers = []
   let index = 0
   props.listings.forEach((listing: Listing) => {
@@ -38,13 +41,13 @@ const ListingsMap = (props: ListingsMapProps) => {
     // Create an info window that is associated to each marker and that contains the listing card
     // for that listing.
     const infoWindow = (
-      <InfoWindow position={{ lat: lat, lng: lng }}>{getListingCard(listing, key - 1)}</InfoWindow>
+      <InfoWindow position={{ lat: lat, lng: lng }} onCloseClick={() => setOpenInfoWindow(false)}>
+        {getListingCard(listing, key - 1)}
+      </InfoWindow>
     )
     markers.push({ lat, lng, uri, key, infoWindow })
   })
 
-  const [openInfoWindow, setOpenInfoWindow] = useState(false)
-  const [infoWindowIndex, setInfoWindowIndex] = useState(null)
   const mapRef = React.useRef(null)
   return isLoaded ? (
     <div className={styles["listings-map"]}>


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes a bug where clicking the same marker on the listings map twice doesn't open the info window the second time. The issue was that openInfoWindow is still true so clicking on the marker doesn't change its state. Now, closing the info window resets the state to false.

## How Can This Be Tested/Reviewed?

- Go to the listings page on the public site.
- Click on a marker, this should open a pop up info window.
- Close the info window.
- Click on the same marker again, this should open the same info window.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
