### PR TITLE
feat: change behavior for marker click on mobile

### DIFF
--- a/sites/public/src/components/listings/ListingsMap.tsx
+++ b/sites/public/src/components/listings/ListingsMap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { GoogleMap, InfoWindow, Marker, useJsApiLoader } from "@react-google-maps/api"
 import { getListingUrl, getListingCard } from "../../lib/helpers"
 import { Listing } from "@bloom-housing/backend-core"
@@ -8,6 +8,7 @@ import { MapControl } from "../shared/MapControl"
 type ListingsMapProps = {
   listings?: Listing[]
   googleMapsApiKey: string
+  desktopMinWidth?: number
 }
 
 const containerStyle: React.CSSProperties = {
@@ -29,6 +30,27 @@ const ListingsMap = (props: ListingsMapProps) => {
 
   const [openInfoWindow, setOpenInfoWindow] = useState(false)
   const [infoWindowIndex, setInfoWindowIndex] = useState(null)
+
+  const [isDesktop, setIsDesktop] = useState(true)
+
+  const DESKTOP_MIN_WIDTH = props.desktopMinWidth || 767 // @screen md
+  useEffect(() => {
+    if (window.innerWidth > DESKTOP_MIN_WIDTH) {
+      setIsDesktop(true)
+    } else {
+      setIsDesktop(false)
+    }
+
+    const updateMedia = () => {
+      if (window.innerWidth > DESKTOP_MIN_WIDTH) {
+        setIsDesktop(true)
+      } else {
+        setIsDesktop(false)
+      }
+    }
+    window.addEventListener("resize", updateMedia)
+    return () => window.removeEventListener("resize", updateMedia)
+  }, [DESKTOP_MIN_WIDTH])
 
   const markers = []
   let index = 0
@@ -70,8 +92,13 @@ const ListingsMap = (props: ListingsMapProps) => {
               fontSize: "var(--bloom-font-size-2xs)",
             }}
             onClick={() => {
-              setOpenInfoWindow(true)
-              setInfoWindowIndex(marker.key)
+              if (isDesktop) {
+                setOpenInfoWindow(true)
+                setInfoWindowIndex(marker.key)
+              } else {
+                const element = document.getElementsByClassName("listings-row")[marker.key - 1]
+                element.scrollIntoView()
+              }
             }}
             key={marker.key.toString()}
             icon={{


### PR DESCRIPTION
# Pull Request Template

## Description

- On mobile, scroll down to the correct listing on the listings list when a map pin is clicked. For example if pin "12" is clicked, the listings list will now show listing 12.
- On desktop, keep the existing behavior where a listing card pops up in a window when the marker is clicked.

This fixes the issue where the info window looks bad on mobile since the picture is too narrow, plus the screen is too crowded with both the pop up window and the hybrid listings list.

## How Can This Be Tested/Reviewed?

- Bring up the public site and go to the listings page.
- On desktop, click on a map pin and verify that an info window pops up with the corresponding listing.
- Close the info window.
- Switch to mobile by using the Chrome Device Emulator.
- Refresh the page for a better experience since this will recenter the map.
- Click on a map pin - pay attention to the number. This should not open an info window and instead should show the corresponding listing in the listings list.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
