### PR TITLE
fix: map display on desktop

### DIFF
--- a/sites/public/src/components/listings/ListingsCombined.module.scss
+++ b/sites/public/src/components/listings/ListingsCombined.module.scss
@@ -20,6 +20,7 @@
   .listings-map {
     flex: 1;
     position: relative;
+    display: flex;
     @media (max-width: $screen-md) {
       position: absolute;
       z-index: 0;


### PR DESCRIPTION
# Pull Request Template

## Description

- Fixes a bug which causes the listings map to not show on desktop. I must have introduced this bug when rebasing with main in https://github.com/metrotranscom/doorway/pull/143.

## How Can This Be Tested/Reviewed?

- Go to the listings site on desktop and make sure you can see the listings map.
