### PR TITLE
fix: replace backendApiBase env vars

### DIFF
--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -14,25 +14,6 @@ import { imageUrlFromListing, getSummariesTable } from "@bloom-housing/shared-he
 
 export const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 
-// Next.js bakes env vars at build time
-// Thie lets us resolve values at runtime instead
-export const getListingServiceUrl = () => {
-  let backendApiBase: string
-
-  if (process.env.BACKEND_PROXY_BASE) {
-    // try proxy base first
-    backendApiBase = process.env.BACKEND_PROXY_BASE
-  } else if (process.env.BACKEND_API_BASE) {
-    // then backend api base
-    backendApiBase = process.env.BACKEND_API_BASE
-  } else {
-    // fall back on next config value if absolutely necessary
-    backendApiBase = process.env.backendApiBase
-  }
-
-  return backendApiBase + process.env.LISTINGS_QUERY
-}
-
 export const getGenericAddress = (bloomAddress: Address) => {
   return bloomAddress
     ? {

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -139,15 +139,15 @@ export async function fetchClosedListings() {
 
 let jurisdiction: Jurisdiction | null = null
 
-export async function fetchJurisdictionByName() {
+export async function fetchJurisdictionByName(backendApiBase: string, jurisdictionName: string) {
   try {
     if (jurisdiction) {
       return jurisdiction
     }
 
-    const jurisdictionName = process.env.jurisdictionName
+    //const jurisdictionName = process.env.jurisdictionName
     const jurisdictionRes = await axios.get(
-      `${process.env.backendApiBase}/jurisdictions/byName/${jurisdictionName}`
+      `${backendApiBase}/jurisdictions/byName/${jurisdictionName}`
     )
     jurisdiction = jurisdictionRes?.data
   } catch (error) {

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -145,7 +145,6 @@ export async function fetchJurisdictionByName(backendApiBase: string, jurisdicti
       return jurisdiction
     }
 
-    //const jurisdictionName = process.env.jurisdictionName
     const jurisdictionRes = await axios.get(
       `${backendApiBase}/jurisdictions/byName/${jurisdictionName}`
     )

--- a/sites/public/src/lib/runtime-config.ts
+++ b/sites/public/src/lib/runtime-config.ts
@@ -56,4 +56,8 @@ export const runtimeConfig = {
   getListingServiceUrl() {
     return `${this.getBackendApiBase()}${this.env.LISTINGS_QUERY}`
   },
+
+  getJurisdictionName() {
+    return this.env.JURISDICTION_NAME
+  },
 }

--- a/sites/public/src/pages/index.tsx
+++ b/sites/public/src/pages/index.tsx
@@ -16,6 +16,7 @@ import Layout from "../layouts/application"
 import { ConfirmationModal } from "../components/account/ConfirmationModal"
 import { MetaTags } from "../components/shared/MetaTags"
 import { fetchJurisdictionByName } from "../lib/hooks"
+import { runtimeConfig } from "../lib/runtime-config"
 
 interface IndexProps {
   jurisdiction: Jurisdiction
@@ -113,8 +114,11 @@ export default function Home(props: IndexProps) {
   )
 }
 
-export async function getStaticProps() {
-  const jurisdiction = await fetchJurisdictionByName()
+export async function getServerSideProps() {
+  const jurisdiction = await fetchJurisdictionByName(
+    runtimeConfig.getBackendApiBase(),
+    runtimeConfig.getJurisdictionName()
+  )
 
   return {
     props: { jurisdiction },

--- a/sites/public/src/pages/listing/[id].tsx
+++ b/sites/public/src/pages/listing/[id].tsx
@@ -1,5 +1,6 @@
 import Head from "next/head"
 import axios from "axios"
+import { runtimeConfig } from "../../lib/runtime-config"
 
 export default function ListingRedirect(props: Record<string, string>) {
   return (
@@ -12,8 +13,10 @@ export default function ListingRedirect(props: Record<string, string>) {
 export async function getServerSideProps(context: { params: Record<string, string> }) {
   let response
 
+  const listingServiceUrl = runtimeConfig.getListingServiceUrl()
+
   try {
-    response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`)
+    response = await axios.get(`${listingServiceUrl}/${context.params.id}`)
   } catch (e) {
     return { notFound: true }
   }

--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -128,8 +128,10 @@ export async function getServerSideProps(context: {
 }) {
   let response
 
+  const listingServiceUrl = runtimeConfig.getListingServiceUrl()
+
   try {
-    response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`, {
+    response = await axios.get(`${listingServiceUrl}/${context.params.id}`, {
       headers: { language: context.locale },
     })
   } catch (e) {

--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -8,7 +8,6 @@ import { imageUrlFromListing } from "@bloom-housing/shared-helpers"
 import Layout from "../../../layouts/application"
 import { ListingView } from "../../../components/listing/ListingView"
 import { MetaTags } from "../../../components/shared/MetaTags"
-import { fetchJurisdictionByName } from "../../../lib/hooks"
 import { runtimeConfig } from "../../../lib/runtime-config"
 
 interface ListingProps {
@@ -55,18 +54,20 @@ export default function ListingPage(props: ListingProps) {
 export async function getServerSideProps(context: { params: Record<string, string> }) {
   let response
 
+  const listingServiceUrl = runtimeConfig.getListingServiceUrl()
+
   try {
-    response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`)
+    response = await axios.get(`${listingServiceUrl}/${context.params.id}`)
   } catch (e) {
     return { notFound: true }
   }
 
-  const jurisdiction = fetchJurisdictionByName()
-
   return {
     props: {
       listing: response.data,
-      jurisdiction: await jurisdiction,
+      // There's nothing missing from the listing jurisdiction that
+      // justifies another call to the jurisdiction endpoint
+      jurisdiction: response.data.jurisdiction,
       googleMapsApiKey: runtimeConfig.getGoogleMapsApiKey(),
     },
   }

--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -66,7 +66,7 @@ export async function getServerSideProps(context: { params: Record<string, strin
     props: {
       listing: response.data,
       // There's nothing missing from the listing jurisdiction that
-      // justifies another call to the jurisdiction endpoint
+      // requires another call to the jurisdiction endpoint
       jurisdiction: response.data.jurisdiction,
       googleMapsApiKey: runtimeConfig.getGoogleMapsApiKey(),
     },

--- a/sites/public/src/pages/search-demo.tsx
+++ b/sites/public/src/pages/search-demo.tsx
@@ -4,7 +4,6 @@ import { MetaTags } from "../components/shared/MetaTags"
 import { t } from "@bloom-housing/doorway-ui-components"
 import { FormOption } from "../components/listings/search/ListingsSearchModal"
 import { ListingsSearchCombined } from "../components/listings/search/ListingsSearchCombined"
-import { getListingServiceUrl } from "../lib/helpers"
 import { runtimeConfig } from "../lib/runtime-config"
 import LayoutWithoutFooter from "../layouts/LayoutWithoutFooter"
 
@@ -148,7 +147,7 @@ export default function SearchTest(props: SearchTestProps) {
 export function getServerSideProps() {
   return {
     props: {
-      listingsEndpoint: getListingServiceUrl(),
+      listingsEndpoint: runtimeConfig.getListingServiceUrl(),
       googleMapsApiKey: runtimeConfig.getGoogleMapsApiKey(),
       // show Bloom counties by default
       initialSearch: "counties:Alameda,San Mateo,Santa Clara",


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

- [ ] This change addresses the issue in full
- [X] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Next.js ignores runtime env vars, replacing them with values present during build.  This causes a host of issues, in particular one where the listings detail page does not load correctly because it doesn't know where the backend is.  Since that information is determined during infra deployment and can only be known definitively at run time, the application needs to be updated to use values present at run time rather than build time.  This is already done in some places, but this PR implements it elsewhere to ensure the correct value is used by all pages.

## How Can This Be Tested/Reviewed?

Navigate to the public site directory.

Change your `.env` file so that `BACKEND_API_BASE` is an invalid value like `http://nowhere:3100`.  Run `yarn build`.

If you try to run the public site now, several pages will be broken.  Change it back to `http://localhost:3100` and run `yarn start` without building again.

Navigate to the landing page (`http://localhost:3000`) and verify that it works.

Navigate to the listings page and find the listing named "[doorway] Test: Default, Reserved" (should be in the first few results.  Click on it and verify that the page loads the listing info correctly.

Copy the listing id from the URL, open up a new tab, and go to `http://localhost:3000/preview/listings/<listing_id>` and verify that the page loads the listing info correctly.

Go back to the listing detail page, click on "Apply Online", and verify that the page loads the listing info correctly.

You can also run unit tests with `yarn test:unit`

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [X] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
