### PR TITLE
feat: style mobile listing cards

### DIFF
--- a/doorway-ui-components/src/blocks/ImageCard.scss
+++ b/doorway-ui-components/src/blocks/ImageCard.scss
@@ -4,7 +4,7 @@
 .image-card {
   /* Component Variables */
   --default-background-color: var(--bloom-color-gray-500);
-  --border-radius: 6px;
+  --border-radius: var(--bloom-rounded-md);
   --image-height: auto;
   --tags-justify-mobile: center;
   --tags-justify-desktop: flex-start;

--- a/doorway-ui-components/src/blocks/ImageCard.scss
+++ b/doorway-ui-components/src/blocks/ImageCard.scss
@@ -4,7 +4,7 @@
 .image-card {
   /* Component Variables */
   --default-background-color: var(--bloom-color-gray-500);
-  --border-radius: 0px;
+  --border-radius: 6px;
   --image-height: auto;
   --tags-justify-mobile: center;
   --tags-justify-desktop: flex-start;

--- a/doorway-ui-components/src/global/text.scss
+++ b/doorway-ui-components/src/global/text.scss
@@ -116,14 +116,14 @@ h1.title {
 }
 :root {
   --text-large-primary-font-weight: 500;
-  --text-large-primary-font-size: var(--bloom-font-size-2xl);
+  --text-large-primary-font-size: var(--bloom-font-size-xl);
 }
 
 .text__large-primary {
   font-family: var(--text-large-primary-font-family, var(--bloom-font-alt-sans));
   font-weight: var(--text-large-primary-font-weight, 600);
   color: var(--text-large-primary--color, var(--bloom-color-primary-dark));
-  font-size: var(--text-large-primary-font-size, var(--bloom-font-size-2xl));
+  font-size: var(--text-large-primary-font-size, var(--bloom-font-size-xl));
   margin-block: var(--text-large-primary-margin-block, 0 var(--bloom-s1));
   line-height: var(--text-large-primary-line-height, var(--bloom-line-height-tight));
 }

--- a/doorway-ui-components/src/global/text.scss
+++ b/doorway-ui-components/src/global/text.scss
@@ -124,7 +124,7 @@ h1.title {
   font-weight: var(--text-large-primary-font-weight, 600);
   color: var(--text-large-primary--color, var(--bloom-color-primary-dark));
   font-size: var(--text-large-primary-font-size, var(--bloom-font-size-2xl));
-  margin-block: var(--text-large-primary-margin-block, 0 var(--bloom-s3));
+  margin-block: var(--text-large-primary-margin-block, 0 var(--bloom-s1));
   line-height: var(--text-large-primary-line-height, var(--bloom-line-height-tight));
 }
 
@@ -149,7 +149,6 @@ h1.title {
   font-weight: var(--text-small-normal-font-weight, 400);
   color: var(--text-small-normal-color, var(--bloom-text-color));
   font-size: var(--text-small-normal-font-size, var(--bloom-font-size-xs));
-  margin-block: var(--text-small-normal-margin-block, 0 var(--bloom-s3));
 }
 
 .text__light-weighted {

--- a/doorway-ui-components/src/page_components/listing/DoorwayListingTable.scss
+++ b/doorway-ui-components/src/page_components/listing/DoorwayListingTable.scss
@@ -1,9 +1,9 @@
 .doorway-listing_table {
-  margin-top: var(--bloom-s5);
+  margin-top: var(--bloom-s2);
 
   .doorway-listing_table-row {
     display: flex;
-  
+
     .table-content-0 {
       @apply uppercase;
       flex: 1;

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -15,7 +15,7 @@
   max-width: var(--max-width);
   margin: var(--margin);
   position: relative;
-  border-bottom: 1px solid var(--bloom-color-gray-450);
+  border-bottom: var(--bloom-border-1) solid var(--bloom-color-gray-450);
   padding-bottom: var(--inter-row-gap);
 
   @media (min-width: $screen-xl) {

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -55,16 +55,12 @@
     flex-basis: 50%;
   }
 
-  .listings-row_headers, .listings-row_preheader {
+  .listings-row_headers,
+  .listings-row_preheader {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    text-align: center;
-
-    @media (min-width: $screen-md) {
-      align-items: flex-start;
-      text-align: left;
-    }
+    align-items: flex-start;
+    text-align: left;
 
     .listings-row_tags {
       order: var(--tags-flex-order);

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -160,9 +160,17 @@
 
 .card-subheader {
   font-family: var(--bloom-font-alt-sans);
-  color: var(--bloom-color-black);
-  font-size: var(--bloom-font-size-base);
+  color: var(--bloom-color-gray-800);
+  font-size: var(--bloom-font-size-sm);
   margin-bottom: var(--bloom-s2);
+  line-height: var(--bloom-line-height-normal);
+}
+
+.card-preheader {
+  font-family: var(--bloom-font-alt-sans);
+  color: var(--bloom-color-gray-700);
+  font-size: var(--bloom-font-size-sm);
+  line-height: var(--bloom-line-height-normal);
 }
 
 .listing-card__tag-icon {

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -1,6 +1,6 @@
 .listings-row {
   --tags-flex-order: 0;
-  --inter-row-gap: var(--bloom-s5);
+  --inter-row-gap: var(--bloom-s6);
   --max-width: var(--bloom-width-3xl);
   --max-width-large-screen: var(--bloom-width-5xl);
   --cell-padding: var(--bloom-s3);
@@ -14,12 +14,20 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   max-width: var(--max-width);
-  margin: var(--margin);
+  margin-bottom: var(--margin);
+  margin-left: var(--margin);
+  margin-right: var(--margin);
+  margin-top: 0;
   position: relative;
   border-bottom: 1px solid var(--bloom-color-gray-450);
+  padding-bottom: var(--bloom-s6);
 
   @media (min-width: $screen-xl) {
     --max-width: var(--max-width-large-screen);
+  }
+
+  @media (max-width: $screen-md) {
+    padding-bottom: 0;
   }
 
   &:first-of-type {
@@ -33,7 +41,7 @@
 
 .listings-row_figure {
   display: flex;
-  padding: var(--cell-padding);
+  padding: 0;
   flex: 1;
 
   @media (max-width: $screen-md) {
@@ -52,16 +60,20 @@
 }
 
 .listings-row_content {
-  flex-basis: 50%;
+  flex: 1;
   min-width: 200px;
-  padding: var(--cell-padding);
+  //padding: var(--cell-padding);
+  padding-right: 0;
+  padding-left: var(--cell-padding);
+  padding-top: 0;
+  padding-bottom: 0;
 
   @media (max-width: $screen-md) {
     padding-right: 0;
     padding-left: var(--cell-padding);
     padding-top: 0;
     padding-bottom: 0;
-    flex-basis: 70%;
+    flex: 2;
   }
 
   .listings-row_headers,
@@ -119,11 +131,11 @@
 .listings-row_footer_container {
   display: flex;
   flex-direction: column;
-  margin-top: var(--bloom-s4);
-  margin-bottom: var(--bloom-s5);
 
   @media (max-width: $screen-md) {
     flex-basis: 100%;
+    margin-top: var(--bloom-s4);
+    margin-bottom: var(--bloom-s5);
   }
 }
 

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -18,10 +18,6 @@
   position: relative;
   border-bottom: 1px solid var(--bloom-color-gray-450);
 
-  @media (max-width: $screen-md) {
-    flex-direction: row;
-  }
-
   @media (min-width: $screen-xl) {
     --max-width: var(--max-width-large-screen);
   }
@@ -38,10 +34,7 @@
 .listings-row_figure {
   display: flex;
   padding: var(--cell-padding);
-  //order: 1;
-  //flex: 1 100%;
-  //flex: 1;
-  //height: 400px;
+  flex: 1;
 
   @media (max-width: $screen-md) {
     padding: 0;
@@ -59,10 +52,9 @@
 }
 
 .listings-row_content {
-  //flex: 1 auto;
-  //min-width: 200px;
+  flex-basis: 50%;
+  min-width: 200px;
   padding: var(--cell-padding);
-  //order: 2;
 
   @media (max-width: $screen-md) {
     padding-right: 0;
@@ -126,15 +118,12 @@
 
 .listings-row_footer_container {
   display: flex;
-  //flex: 1 auto;
-  //order: 2;
-  //min-width: 200px;
-  flex-basis: 50%;
+  flex-direction: column;
   margin-top: var(--bloom-s4);
   margin-bottom: var(--bloom-s5);
 
   @media (max-width: $screen-md) {
-    flex: 1;
+    flex-basis: 100%;
   }
 }
 

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -14,13 +14,10 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   max-width: var(--max-width);
-  margin-bottom: var(--margin);
-  margin-left: var(--margin);
-  margin-right: var(--margin);
-  margin-top: 0;
+  margin: var(--margin);
   position: relative;
   border-bottom: 1px solid var(--bloom-color-gray-450);
-  padding-bottom: var(--bloom-s6);
+  padding-bottom: var(--inter-row-gap);
 
   @media (min-width: $screen-xl) {
     --max-width: var(--max-width-large-screen);
@@ -44,11 +41,6 @@
   padding: 0;
   flex: 1;
 
-  @media (max-width: $screen-md) {
-    padding: 0;
-    flex: 1;
-  }
-
   .image_card {
     flex: 1;
   }
@@ -62,17 +54,9 @@
 .listings-row_content {
   flex: 1;
   min-width: 200px;
-  //padding: var(--cell-padding);
-  padding-right: 0;
-  padding-left: var(--cell-padding);
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: 0 0 0 var(--cell-padding);
 
   @media (max-width: $screen-md) {
-    padding-right: 0;
-    padding-left: var(--cell-padding);
-    padding-top: 0;
-    padding-bottom: 0;
     flex: 2;
   }
 

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -12,7 +12,6 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: flex-end;
   max-width: var(--max-width);
   margin: var(--margin);
   position: relative;

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -12,10 +12,15 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  justify-content: flex-end;
   max-width: var(--max-width);
   margin: var(--margin);
   position: relative;
   border-bottom: 1px solid var(--bloom-color-gray-450);
+
+  @media (max-width: $screen-md) {
+    flex-direction: row;
+  }
 
   @media (min-width: $screen-xl) {
     --max-width: var(--max-width-large-screen);
@@ -33,12 +38,14 @@
 .listings-row_figure {
   display: flex;
   padding: var(--cell-padding);
+  //order: 1;
+  //flex: 1 100%;
+  //flex: 1;
+  //height: 400px;
 
   @media (max-width: $screen-md) {
-    padding-left: 0;
-    padding-right: 0;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0;
+    flex: 1;
   }
 
   .image_card {
@@ -49,23 +56,20 @@
   img {
     height: 100%;
   }
-  flex: 1;
 }
 
 .listings-row_content {
-  flex-basis: 70%;
+  //flex: 1 auto;
   //min-width: 200px;
   padding: var(--cell-padding);
+  //order: 2;
 
   @media (max-width: $screen-md) {
     padding-right: 0;
     padding-left: var(--cell-padding);
     padding-top: 0;
     padding-bottom: 0;
-  }
-
-  @media (min-width: $screen-sm) {
-    flex-basis: 50%;
+    flex-basis: 70%;
   }
 
   .listings-row_headers,
@@ -122,12 +126,15 @@
 
 .listings-row_footer_container {
   display: flex;
-  flex-direction: column;
+  //flex: 1 auto;
+  //order: 2;
+  //min-width: 200px;
+  flex-basis: 50%;
+  margin-top: var(--bloom-s4);
+  margin-bottom: var(--bloom-s5);
 
   @media (max-width: $screen-md) {
     flex: 1;
-    margin-top: var(--bloom-s4);
-    margin-bottom: var(--bloom-s5);
   }
 }
 

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -4,7 +4,8 @@
   --max-width: var(--bloom-width-3xl);
   --max-width-large-screen: var(--bloom-width-5xl);
   --cell-padding: var(--bloom-s3);
-  --margin: var(--inter-row-gap) auto;
+  --wider-cell-padding: var(--bloom-s5);
+  --margin: var(--inter-row-gap);
   --card-tag-padding: var(--bloom-s3) var(--bloom-s5);
   --card-tag-font-weight: inherit;
 
@@ -14,6 +15,7 @@
   max-width: var(--max-width);
   margin: var(--margin);
   position: relative;
+  border-bottom: 1px solid var(--bloom-color-gray-450);
 
   @media (min-width: $screen-xl) {
     --max-width: var(--max-width-large-screen);
@@ -30,6 +32,14 @@
 
 .listings-row_figure {
   display: flex;
+  padding: var(--cell-padding);
+
+  @media (max-width: $screen-md) {
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 
   .image_card {
     flex: 1;
@@ -42,14 +52,17 @@
   flex: 1;
 }
 
-.listings-row_figure,
-.listings-row_content {
-  padding: var(--cell-padding);
-}
-
 .listings-row_content {
   flex-basis: 70%;
-  min-width: 200px;
+  //min-width: 200px;
+  padding: var(--cell-padding);
+
+  @media (max-width: $screen-md) {
+    padding-right: 0;
+    padding-left: var(--cell-padding);
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 
   @media (min-width: $screen-sm) {
     flex-basis: 50%;
@@ -101,11 +114,21 @@
 
 .listings-row_table {
   margin-block-end: var(--bloom-s4);
+
+  @media (max-width: $screen-md) {
+    margin-block-end: 0;
+  }
 }
 
 .listings-row_footer_container {
   display: flex;
   flex-direction: column;
+
+  @media (max-width: $screen-md) {
+    flex: 1;
+    margin-top: var(--bloom-s4);
+    margin-bottom: var(--bloom-s5);
+  }
 }
 
 .listings-row_footer {
@@ -131,7 +154,7 @@
   font-family: var(--bloom-font-alt-sans);
   color: var(--bloom-color-black);
   font-size: var(--bloom-font-size-base);
-  margin-bottom: var(--bloom-s3);
+  margin-bottom: var(--bloom-s2);
 }
 
 .listing-card__tag-icon {

--- a/doorway-ui-components/src/page_components/listing/ListingCard.tsx
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.tsx
@@ -189,25 +189,30 @@ const ListingCard = (props: ListingCardProps) => {
             <DoorwayListingTable data={tableProps?.data} headers={tableProps?.headers} />
           )}
         </div>
-        <div className={"listings-row_footer_container"}>
-          {footerContent && footerContent}
-          {footerButtons && footerButtons?.length > 0 && (
-            <div className={footerContainerClass ?? "listings-row_footer"}>
-              {footerButtons?.map((footerButton, index) => {
-                return (
-                  <LinkButton
-                    href={footerButton.href}
-                    ariaHidden={footerButton.ariaHidden}
-                    key={index}
-                    className={"is-secondary"}
-                  >
-                    {footerButton.text}
-                  </LinkButton>
-                )
-              })}
-            </div>
-          )}
-        </div>
+      </>
+    )
+  }
+
+  const getContentFooter = () => {
+    return (
+      <>
+        {footerContent && footerContent}
+        {footerButtons && footerButtons?.length > 0 && (
+          <div className={footerContainerClass ?? "listings-row_footer"}>
+            {footerButtons?.map((footerButton, index) => {
+              return (
+                <LinkButton
+                  href={footerButton.href}
+                  ariaHidden={footerButton.ariaHidden}
+                  key={index}
+                  className={"is-secondary"}
+                >
+                  {footerButton.text}
+                </LinkButton>
+              )
+            })}
+          </div>
+        )}
       </>
     )
   }
@@ -232,6 +237,7 @@ const ListingCard = (props: ListingCardProps) => {
         {getContentHeader()}
         {getContent()}
       </div>
+      <div className={"listings-row_footer_container"}>{getContentFooter()}</div>
     </article>
   )
 }

--- a/doorway-ui-components/src/page_components/listing/ListingCard.tsx
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.tsx
@@ -255,7 +255,7 @@ const ListingCard = (props: ListingCardProps) => {
       <div className="listings-row_content">
         {props.preheader && (
           <div className="listings-row_preheader">
-            <span>{props.preheader}</span>
+            <span className="card-preheader">{props.preheader}</span>
           </div>
         )}
         {getContentHeader()}

--- a/doorway-ui-components/src/page_components/listing/ListingCard.tsx
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import { ImageCard, ImageCardProps, ImageTag } from "../../blocks/ImageCard"
 import { LinkButton } from "../../actions/LinkButton"
 import { StackedTableProps } from "../../tables/StackedTable"
@@ -61,6 +61,8 @@ export interface ListingCardProps {
   stackedTable?: boolean
   /** Prop interface for the StandardTable and StackedTable components */
   tableProps?: ListingCardTableProps
+  /** Override for the minimum width for the desktop layout */
+  desktopMinWidth?: number
 }
 
 /**
@@ -88,6 +90,27 @@ const ListingCard = (props: ListingCardProps) => {
       linkRef.current.click()
     }
   }
+
+  const [isDesktop, setIsDesktop] = useState(true)
+
+  const DESKTOP_MIN_WIDTH = props.desktopMinWidth || 767 // @screen md
+  useEffect(() => {
+    if (window.innerWidth > DESKTOP_MIN_WIDTH) {
+      setIsDesktop(true)
+    } else {
+      setIsDesktop(false)
+    }
+
+    const updateMedia = () => {
+      if (window.innerWidth > DESKTOP_MIN_WIDTH) {
+        setIsDesktop(true)
+      } else {
+        setIsDesktop(false)
+      }
+    }
+    window.addEventListener("resize", updateMedia)
+    return () => window.removeEventListener("resize", updateMedia)
+  }, [DESKTOP_MIN_WIDTH])
 
   const getHeader = (
     header: ListingCardHeader | undefined,
@@ -189,6 +212,7 @@ const ListingCard = (props: ListingCardProps) => {
             <DoorwayListingTable data={tableProps?.data} headers={tableProps?.headers} />
           )}
         </div>
+        {isDesktop && getContentFooter()}
       </>
     )
   }
@@ -237,7 +261,7 @@ const ListingCard = (props: ListingCardProps) => {
         {getContentHeader()}
         {getContent()}
       </div>
-      <div className={"listings-row_footer_container"}>{getContentFooter()}</div>
+      {!isDesktop && <div className={"listings-row_footer_container"}>{getContentFooter()}</div>}
     </article>
   )
 }


### PR DESCRIPTION
# Pull Request Template

## Description

- Change location of "See details" button for desktop vs mobile
- Update margins and padding for mobile listing card as well as desktop where needed
- Round the corners of the image card
- Update font sizes and colors according to Figma specs
- Add border to the bottom of each listing card
- Center listing card content to the left for mobile

Mobile before:
![image](https://github.com/metrotranscom/doorway/assets/67125998/13b243d9-2e18-4a06-88b3-cabec072724c)

Mobile after:
![image](https://github.com/metrotranscom/doorway/assets/67125998/dbb36fc3-bf33-4bb6-8538-388f5958f5bb)

Desktop before:
![image](https://github.com/metrotranscom/doorway/assets/67125998/db935cc0-ff26-4922-86eb-bc397efaff97)

Desktop after:
![image](https://github.com/metrotranscom/doorway/assets/67125998/6d917086-8f11-42d3-934c-fcb8e79900d0)

iPad before:
![image](https://github.com/metrotranscom/doorway/assets/67125998/44547313-1dc1-4c97-90d3-ddee1fd5dca6)

iPad after:
![image](https://github.com/metrotranscom/doorway/assets/67125998/4792f62f-4860-4277-8211-23031bd07f55)

## How Can This Be Tested/Reviewed?

Go to the listings page and try using different devices with the chrome developer tools device emulator
