### PR TITLE
feat: show listing on listings list when a map pin is clicked on mobile

### DIFF
--- a/sites/public/src/components/listings/ListingsCombined.module.scss
+++ b/sites/public/src/components/listings/ListingsCombined.module.scss
@@ -1,7 +1,8 @@
 .listings-combined {
-  // This is a not-ideal way to do "fill window minus header" however I can't find another way to do this.
-  // TODO: update header to a not-magic number
-  --listings-component-height: calc(100vh - 138px);
+  // This is a not-ideal way to do "fill window minus header and filter modal" however
+  // I can't find another way to do this.
+  // TODO: update header + filter modal to a not-magic number
+  --listings-component-height: calc(100vh - 183px);
   --listings-component-half-height: calc(var(--listings-component-height) / 2);
   --swipe-area-height: var(--bloom-s14);
   --listings-list-width: 600px;

--- a/sites/public/src/components/listings/ListingsCombined.tsx
+++ b/sites/public/src/components/listings/ListingsCombined.tsx
@@ -57,7 +57,7 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
           <ListingsMap
             listings={props.listings}
             googleMapsApiKey={props.googleMapsApiKey}
-            openMarkerOnClick={false}
+            isMapExpanded={false}
           />
         </div>
         <div className={styles["swipe-area"]} {...swipeHandler}>
@@ -82,7 +82,8 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
           <ListingsMap
             listings={props.listings}
             googleMapsApiKey={props.googleMapsApiKey}
-            openMarkerOnClick={true}
+            isMapExpanded={true}
+            setShowListingsList={setShowListingsList}
           />
         </div>
         <div className={styles["swipe-area-bottom"]} {...swipeHandler}>
@@ -99,7 +100,7 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
           <ListingsMap
             listings={props.listings}
             googleMapsApiKey={props.googleMapsApiKey}
-            openMarkerOnClick={false}
+            isMapExpanded={false}
           />
         </div>
         <div className={styles["listings-outer-container"]}>

--- a/sites/public/src/components/listings/ListingsCombined.tsx
+++ b/sites/public/src/components/listings/ListingsCombined.tsx
@@ -54,7 +54,11 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
     return (
       <div className={styles["listings-combined"]}>
         <div className={styles["listings-map"]}>
-          <ListingsMap listings={props.listings} googleMapsApiKey={props.googleMapsApiKey} />
+          <ListingsMap
+            listings={props.listings}
+            googleMapsApiKey={props.googleMapsApiKey}
+            openMarkerOnClick={false}
+          />
         </div>
         <div className={styles["swipe-area"]} {...swipeHandler}>
           <div className={styles["swipe-area-line"]}></div>
@@ -75,7 +79,11 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
     return (
       <div className={styles["listings-combined"]}>
         <div className={styles["listings-map-expanded"]}>
-          <ListingsMap listings={props.listings} googleMapsApiKey={props.googleMapsApiKey} />
+          <ListingsMap
+            listings={props.listings}
+            googleMapsApiKey={props.googleMapsApiKey}
+            openMarkerOnClick={true}
+          />
         </div>
         <div className={styles["swipe-area-bottom"]} {...swipeHandler}>
           <div className={styles["swipe-area-line"]}></div>
@@ -88,7 +96,11 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
     return (
       <div className={styles["listings-combined"]}>
         <div className={styles["listings-map"]}>
-          <ListingsMap listings={props.listings} googleMapsApiKey={props.googleMapsApiKey} />
+          <ListingsMap
+            listings={props.listings}
+            googleMapsApiKey={props.googleMapsApiKey}
+            openMarkerOnClick={false}
+          />
         </div>
         <div className={styles["listings-outer-container"]}>
           <div className={styles["swipe-area"]} {...swipeHandler}>

--- a/sites/public/src/components/listings/ListingsMap.tsx
+++ b/sites/public/src/components/listings/ListingsMap.tsx
@@ -9,7 +9,8 @@ type ListingsMapProps = {
   listings?: Listing[]
   googleMapsApiKey: string
   desktopMinWidth?: number
-  openMarkerOnClick: boolean
+  isMapExpanded: boolean
+  setShowListingsList?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const containerStyle: React.CSSProperties = {
@@ -93,12 +94,22 @@ const ListingsMap = (props: ListingsMapProps) => {
               fontSize: "var(--bloom-font-size-2xs)",
             }}
             onClick={() => {
-              if (isDesktop || props.openMarkerOnClick) {
+              if (isDesktop) {
                 setOpenInfoWindow(true)
                 setInfoWindowIndex(marker.key)
               } else {
-                const element = document.getElementsByClassName("listings-row")[marker.key - 1]
-                element.scrollIntoView()
+                if (props.isMapExpanded) {
+                  // Bring up the listings list with the correct listing at the top. A short timeout
+                  // is needed so the listings row element can be found in the document.
+                  props.setShowListingsList(true)
+                  setTimeout(() => {
+                    const element = document.getElementsByClassName("listings-row")[marker.key - 1]
+                    element.scrollIntoView()
+                  }, 1)
+                } else {
+                  const element = document.getElementsByClassName("listings-row")[marker.key - 1]
+                  element.scrollIntoView()
+                }
               }
             }}
             key={marker.key.toString()}

--- a/sites/public/src/components/listings/ListingsMap.tsx
+++ b/sites/public/src/components/listings/ListingsMap.tsx
@@ -9,6 +9,7 @@ type ListingsMapProps = {
   listings?: Listing[]
   googleMapsApiKey: string
   desktopMinWidth?: number
+  openMarkerOnClick: boolean
 }
 
 const containerStyle: React.CSSProperties = {
@@ -92,7 +93,7 @@ const ListingsMap = (props: ListingsMapProps) => {
               fontSize: "var(--bloom-font-size-2xs)",
             }}
             onClick={() => {
-              if (isDesktop) {
+              if (isDesktop || props.openMarkerOnClick) {
                 setOpenInfoWindow(true)
                 setInfoWindowIndex(marker.key)
               } else {


### PR DESCRIPTION
# Pull Request Template

## Description

Fix a bug in the mobile listings page when clicking on map pins in the expanded map view. Now when a pin is clicked, the listings list comes up with the clicked on listing. I also considered opening an info window with the listing card (like what is done on desktop), but the listing card style looks bad since it's narrower than the default on mobile and it would need considerable restyling.

This also fixes a bug introduced in https://github.com/metrotranscom/doorway/pull/155 that makes the height of the listings combined component too tall, which means there is vertical scroll on the listings page on mobile. Since there is now a search modal at the top between the header and the ListingsCombined component, we need to subtract its height as well. I checked that its height is always 44.5px, for all devices.

## How Can This Be Tested/Reviewed?

- Bring up the public site and go to the listings page.
- Switch to mobile view by using chrome developer tools device emulator.
- You should be on the hybrid mobile view. Scroll the listings list down to see only the listings map.
- Click on a pin in the listings map. This should not give any error and instead should bring the listings list back up with the listing that was clicked on. So if you clicked on listing 4, listing 4 should be scrolled in rather than listing 1.
- Also verify that there is no vertical scrolling on the listings page on mobile, whether the map view or the list view