### PR TITLE
highlight/alert that county is required

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
@@ -141,8 +141,8 @@ const BuildingDetails = ({
   }, [mapPinPosition])
 
   const getAddressErrorMessage = (fieldKey: string, defaultMessage: string) => {
-    if (fieldKey === "buildingAddress.county" && !getValues("buildingAddress.county")){
-      defaultMessage= t("errors.countyError")
+    if (fieldKey === "buildingAddress.county" && !getValues("buildingAddress.county")) {
+      defaultMessage = t("errors.countyError")
       return t("errors.countyError")
     }
     return errors?.buildingAddress && !getValues("buildingAddress.street")
@@ -307,7 +307,8 @@ const BuildingDetails = ({
               options={countyKeys}
               keyPrefix="counties"
               inputProps={{
-                onChange: () => fieldHasError(errors?.buildingAddress?.county) && clearErrors("buildingAddress"),
+                onChange: () =>
+                  fieldHasError(errors?.buildingAddress?.county) && clearErrors("buildingAddress"),
               }}
             />
           </ViewItem>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
@@ -141,6 +141,10 @@ const BuildingDetails = ({
   }, [mapPinPosition])
 
   const getAddressErrorMessage = (fieldKey: string, defaultMessage: string) => {
+    if (fieldKey === "buildingAddress.county" && !getValues("buildingAddress.county")){
+      defaultMessage= t("errors.countyError")
+      return t("errors.countyError")
+    }
     return errors?.buildingAddress && !getValues("buildingAddress.street")
       ? t("errors.partialAddress")
       : defaultMessage
@@ -303,7 +307,7 @@ const BuildingDetails = ({
               options={countyKeys}
               keyPrefix="counties"
               inputProps={{
-                onChange: () => clearErrors("buildingAddress"),
+                onChange: () => fieldHasError(errors?.buildingAddress?.county) && clearErrors("buildingAddress"),
               }}
             />
           </ViewItem>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
County needs to be required on the Partners portal for all new listings. While this doesn't 100% address the problem, it's a step in the right direction. If the county select is empty, it'll highlight it in red w/a message saying County is required. 

What this doesn't do yet is not allow the user to submit/save without county. That's still a WIP.

## How Can This Be Tested/Reviewed?
Using this branch, go to the partner's site, select any currently existing listing and click Edit. Scroll down to the Building Details section and change the County to `Select One`. The box should render red with the alert message `Please enter a county`.
![image](https://github.com/metrotranscom/doorway/assets/12400715/192f75dc-3139-4b7e-ba39-57de00637125)

Technically many of the boxes on in this form should do this, as it's confusing for a user when they're trying to figure out which ones need to be filled out, since the 400 error doesn't highlight that. However, that's out of scope for this PR and can be a recommendation for Exygy to implement in the future.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
