### PR TITLE
feat: update colors on the listing page to be more reasonable

### DIFF
--- a/doorway-ui-components/src/global/app-css.scss
+++ b/doorway-ui-components/src/global/app-css.scss
@@ -64,6 +64,7 @@ main {
 @import "homepage.scss";
 @import "print.scss";
 @import "vendor/ag_grid.scss";
+@import "doorway/backgrounds.scss";
 /* ***********/
 /* Additional stylesheets are contained within individual component folders */
 /* ***********/

--- a/doorway-ui-components/src/global/blocks.scss
+++ b/doorway-ui-components/src/global/blocks.scss
@@ -57,7 +57,7 @@ details.disclosure {
   @apply -mx-4;
 
   &.is-tinted {
-    @apply bg-primary-lighter;
+    @apply doorway-bg-primary-lighter;
     @apply border-t;
   }
   &:not(.is-tinted) + &.is-tinted {
@@ -113,7 +113,7 @@ details.disclosure {
   @apply mb-12;
   @apply text-center;
   @apply p-4;
-  @apply bg-primary-lighter;
+  @apply doorway-bg-primary-lighter;
 }
 
 $shadow-left-slight: -3px 0px 3px -1px rgba(0, 0, 0, 0.1);

--- a/doorway-ui-components/src/global/doorway/backgrounds.scss
+++ b/doorway-ui-components/src/global/doorway/backgrounds.scss
@@ -1,0 +1,15 @@
+// These classes are meant to replace Doorway usage of the "bg-[color-name]" tailwind class.
+// For some (likely complicated due to Node packaging reasons) Tailwind extensions don't
+// work in Doorway UIC :(
+
+.doorway-bg-primary {
+  background-color: var(--doorway-color-primary-background);
+}
+
+.doorway-bg-primary-light {
+  background-color: var(--doorway-color-secondary-background);
+}
+
+.doorway-bg-primary-lighter {
+  background-color: var(--bloom-color-white);
+}

--- a/doorway-ui-components/src/global/doorway/backgrounds.scss
+++ b/doorway-ui-components/src/global/doorway/backgrounds.scss
@@ -1,6 +1,6 @@
 // These classes are meant to replace Doorway usage of the "bg-[color-name]" tailwind class.
-// For some (likely complicated due to Node packaging reasons) Tailwind extensions don't
-// work in Doorway UIC :(
+// For some (likely complicated due to Node packaging) reasons Tailwind extensions come from
+// the original UIC package and so updates to Doorway UIC don't do anything.
 
 .doorway-bg-primary {
   background-color: var(--doorway-color-primary-background);

--- a/doorway-ui-components/src/global/tables.scss
+++ b/doorway-ui-components/src/global/tables.scss
@@ -18,7 +18,7 @@ https://www.cssscript.com/pure-html5-css3-responsive-table-solution/ */
     }
 
     td:nth-of-type(even) {
-      @apply bg-primary-lighter;
+      @apply doorway-bg-primary-light;
     }
 
     td {
@@ -71,7 +71,7 @@ table {
   thead tr th {
     @apply text-left;
     @apply uppercase;
-    @apply bg-primary-lighter;
+    @apply doorway-bg-primary-light;
     @apply p-5;
     @apply font-semibold;
     @apply tracking-wider;
@@ -338,7 +338,7 @@ table {
 }
 
 table tr:nth-of-type(even) {
-  @apply bg-primary-lighter;
+  @apply doorway-bg-primary-light;
 }
 
 td.reserved {

--- a/doorway-ui-components/src/global/tokens/colors.scss
+++ b/doorway-ui-components/src/global/tokens/colors.scss
@@ -111,4 +111,6 @@
   --primary-appearance-hover-border-color: var(--bloom-color-primary-dark);
 
   ---text-large-primary--color: var(--bloom-color-primary);
+  --doorway-color-primary-background: var(--bloom-color-primary-lightest);
+  --doorway-color-secondary-background: var(--bloom-color-blue-100);
 }

--- a/doorway-ui-components/src/notifications/ApplicationStatus.tsx
+++ b/doorway-ui-components/src/notifications/ApplicationStatus.tsx
@@ -41,7 +41,7 @@ const ApplicationStatus = (props: ApplicationStatusProps) => {
 
   switch (status) {
     case ApplicationStatusType.Open:
-      bgColor = vivid ? "bg-primary" : "bg-primary-light"
+      bgColor = vivid ? "doorway-bg-primary" : "doorway-bg-primary-light"
       break
     case ApplicationStatusType.Closed:
       bgColor = vivid ? "bg-alert" : "bg-alert-light"

--- a/doorway-ui-components/src/page_components/listing/ContentAccordion.scss
+++ b/doorway-ui-components/src/page_components/listing/ContentAccordion.scss
@@ -1,5 +1,5 @@
 .accordion-blue-theme__bar {
-  @apply bg-primary-light;
+  background-color: var(--doorway-color-secondary-background);
   @apply p-4;
   @apply border-b;
   @apply border-primary;

--- a/shared-helpers/src/views/summaryTables.tsx
+++ b/shared-helpers/src/views/summaryTables.tsx
@@ -4,9 +4,9 @@ import {
   StandardTableData,
   t,
   numberOrdinal,
-  ContentAccordion,
   getTranslationWithArguments,
 } from "@bloom-housing/ui-components"
+import { ContentAccordion } from "@bloom-housing/doorway-ui-components"
 import { MinMax, UnitSummary, Unit, ListingReviewOrder } from "@bloom-housing/backend-core/types"
 
 const getTranslationFromCurrencyString = (value: string) => {

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -15,7 +15,6 @@ import {
 } from "@bloom-housing/backend-core/types"
 import {
   AdditionalFees,
-  ApplicationStatus,
   Description,
   ExpandableText,
   GroupedTable,
@@ -39,6 +38,7 @@ import {
   StandardTableData,
   ExpandableSection,
 } from "@bloom-housing/ui-components"
+import { ApplicationStatus } from "@bloom-housing/doorway-ui-components"
 import {
   getOccupancyDescription,
   imageUrlFromListing,

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -623,7 +623,7 @@ export const ListingView = (props: ListingProps) => {
           imageSrc="/images/listing-eligibility.svg"
           title={t("listings.sections.eligibilityTitle")}
           subtitle={t("listings.sections.eligibilitySubtitle")}
-          desktopClass="bg-primary-lighter"
+          desktopClass="doorway-bg-primary-light"
         >
           <ul>
             {listing.reservedCommunityType && (
@@ -899,7 +899,7 @@ export const ListingView = (props: ListingProps) => {
           imageSrc="/images/listing-neighborhood.svg"
           title={t("t.neighborhood")}
           subtitle={t("listings.sections.neighborhoodSubtitle")}
-          desktopClass="bg-primary-lighter"
+          desktopClass="doorway-bg-primary-lighter"
         >
           <div className="listing-detail-panel">
             <ListingGoogleMap


### PR DESCRIPTION
This PR introduces some new CSS background variables that are more reasonable for the various views on the listing page and uses them to style the listing page, effectively making it not look ridiculously broken.

This is the beginning of restyling the page based on the spec and followup PRs will continue to add styling. The benefit of doing this first is that it adds a new precedent for doorway background colors and makes the listing page look decent for demos and other things.

https://github.com/metrotranscom/doorway/assets/10789523/cbe01835-b0dd-4e45-8fe4-c29eb84c00d2



https://github.com/metrotranscom/doorway/assets/10789523/e522fefc-cc38-483a-909e-d0b8dc52c07c

