### PR TITLE
feat: add new tables and numbering to the Listing page

### DIFF
--- a/doorway-ui-components/src/blocks/ImageCard.scss
+++ b/doorway-ui-components/src/blocks/ImageCard.scss
@@ -4,7 +4,7 @@
 .image-card {
   /* Component Variables */
   --default-background-color: var(--bloom-color-gray-500);
-  --border-radius: var(--bloom-rounded-md);
+  --border-radius: var(--bloom-rounded-lg);
   --image-height: auto;
   --tags-justify-mobile: center;
   --tags-justify-desktop: flex-start;
@@ -153,7 +153,7 @@
 
   @media (min-width: $screen-md) {
     width: var(--leader-width);
-    padding-block-start: var(--bloom-s8);
+    padding-block-start: 0;
     padding-inline-end: var(--bloom-s8);
   }
 }

--- a/doorway-ui-components/src/blocks/ImageCard.scss
+++ b/doorway-ui-components/src/blocks/ImageCard.scss
@@ -4,7 +4,7 @@
 .image-card {
   /* Component Variables */
   --default-background-color: var(--bloom-color-gray-500);
-  --border-radius: var(--bloom-rounded-lg);
+  --border-radius: var(--doorway-standard-border-radius);
   --image-height: auto;
   --tags-justify-mobile: center;
   --tags-justify-desktop: flex-start;

--- a/doorway-ui-components/src/global/custom_counter.scss
+++ b/doorway-ui-components/src/global/custom_counter.scss
@@ -12,13 +12,15 @@
   @screen md {
     @apply absolute;
     @apply font-serif;
-    @apply text-gray-850;
-    top: 0;
+    @apply text-primary;
+    top: var(--bloom-s6);
     left: -1rem;
     content: counter(step-counter);
+    background: var(--doorway-color-secondary);
+    padding: var(--bloom-s2) var(--bloom-s4);
+    border-radius: var(--bloom-rounded-full);
     margin-right: 5px;
-    font-size: 4.375rem;
-    line-height: 0.85;
+    font-size: var(--bloom-font-size-lg);
   }
 }
 
@@ -26,13 +28,11 @@
   @apply pb-4;
 
   @screen md {
-    @apply -ml-4;
-    @apply pl-4;
     @apply border-solid;
-    @apply border-l-2;
+    border-top-width: var(--bloom-border-1);
     @apply border-gray-450;
-    @apply mb-4;
-    @apply mt-4;
+    @apply mb-6;
+    @apply pt-6;
   }
 }
 

--- a/doorway-ui-components/src/global/tables.scss
+++ b/doorway-ui-components/src/global/tables.scss
@@ -57,6 +57,12 @@ https://www.cssscript.com/pure-html5-css3-responsive-table-solution/ */
   }
 }
 
+.table-container {
+  overflow-x: auto;
+  border-radius: var(--doorway-standard-border-radius);
+  border-collapse: separate;
+}
+
 table {
   @apply text-gray-750;
 
@@ -70,14 +76,10 @@ table {
 
   thead tr th {
     @apply text-left;
-    @apply uppercase;
-    @apply doorway-bg-primary-light;
+    @apply bg-white;
     @apply p-5;
     @apply font-semibold;
     @apply tracking-wider;
-    @apply border-0;
-    @apply border-b;
-    @apply border-primary;
   }
 
   &.th-plain {
@@ -338,8 +340,14 @@ table {
 }
 
 table tr:nth-of-type(even) {
+  @apply doorway-bg-primary;
+}
+
+table tr:nth-of-type(odd) {
   @apply doorway-bg-primary-light;
 }
+
+
 
 td.reserved {
   @apply font-sans;

--- a/doorway-ui-components/src/global/text.scss
+++ b/doorway-ui-components/src/global/text.scss
@@ -66,6 +66,16 @@ a {
   &.darker {
     @apply text-primary-darker;
   }
+
+  &.lighter-uppercase {
+    text-transform: uppercase;
+    @apply text__caps-spaced;
+    @apply text-primary-lighter;
+
+    &:hover {
+      @apply text-primary;
+    }
+  }
 }
 
 h1.title {

--- a/doorway-ui-components/src/global/tokens/borders.scss
+++ b/doorway-ui-components/src/global/tokens/borders.scss
@@ -16,4 +16,5 @@
   --bloom-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 
   --doorway-standard-border: var(--bloom-border-1) solid var(--bloom-color-gray-450);
+  --doorway-standard-border-radius: var(--bloom-rounded-lg)
 }

--- a/doorway-ui-components/src/tables/GroupedTable.tsx
+++ b/doorway-ui-components/src/tables/GroupedTable.tsx
@@ -79,7 +79,7 @@ export const GroupedTable = (props: GroupedTableProps) => {
   }
 
   return (
-    <div style={{ overflowX: "auto" }}>
+    <div className="table-container">
       <table className={tableClasses.join(" ")}>
         <thead>
           <tr>{headerLabels}</tr>

--- a/doorway-ui-components/src/tables/StandardTable.tsx
+++ b/doorway-ui-components/src/tables/StandardTable.tsx
@@ -255,7 +255,7 @@ export const StandardTable = (props: StandardTableProps) => {
   }
 
   return (
-    <div style={{ overflowX: "auto" }}>
+    <div className="table-container">
       <table id={props.id} className={tableClasses.join(" ")}>
         <thead>
           <tr>{headerLabels}</tr>

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -537,7 +537,11 @@ export const ListingView = (props: ListingProps) => {
           modalCloseInContent
         />
         <div className="py-3 mx-3 mt-4 flex flex-col items-center md:items-start text-center md:text-left">
-          <Heading priority={1} styleType={"largePrimary"} className={"text-black"}>
+          <Heading
+            priority={1}
+            styleType={"largePrimary"}
+            className={"text-primary-dark font-serif font-semibold"}
+          >
             {listing.name}
           </Heading>
           <Heading priority={2} styleType={"mediumNormal"} className={"mb-1"}>

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -17,7 +17,6 @@ import {
   AdditionalFees,
   Description,
   ExpandableText,
-  GroupedTable,
   Heading,
   InfoCard,
   Contact,
@@ -29,7 +28,6 @@ import {
   EventSection,
   PreferencesList,
   ReferralApplication,
-  StandardTable,
   TableHeaders,
   QuantityRowSection,
   t,
@@ -37,7 +35,13 @@ import {
   StandardTableData,
   ExpandableSection,
 } from "@bloom-housing/ui-components"
-import { ApplicationStatus, ImageCard, Icon } from "@bloom-housing/doorway-ui-components"
+import {
+  ApplicationStatus,
+  GroupedTable,
+  ImageCard,
+  Icon,
+  StandardTable,
+} from "@bloom-housing/doorway-ui-components"
 import {
   getOccupancyDescription,
   imageUrlFromListing,

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -19,7 +19,6 @@ import {
   ExpandableText,
   GroupedTable,
   Heading,
-  ImageCard,
   InfoCard,
   Contact,
   ListSection,
@@ -38,7 +37,7 @@ import {
   StandardTableData,
   ExpandableSection,
 } from "@bloom-housing/ui-components"
-import { ApplicationStatus } from "@bloom-housing/doorway-ui-components"
+import { ApplicationStatus, ImageCard } from "@bloom-housing/doorway-ui-components"
 import {
   getOccupancyDescription,
   imageUrlFromListing,
@@ -508,7 +507,7 @@ export const ListingView = (props: ListingProps) => {
   }
 
   return (
-    <article className="flex flex-wrap relative max-w-5xl m-auto">
+    <article className="flex flex-wrap relative max-w-5xl m-auto md:mt-8">
       <header className="image-card--leader">
         <ImageCard
           images={imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize)).map(

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -563,7 +563,7 @@ export const ListingView = (props: ListingProps) => {
               aria-label="Opens in new window"
               className="lighter-uppercase"
             >
-              {t("t.viewOnMap")} <Icon size="small" symbol="link" />
+              {t("t.viewOnMap")} <Icon size="small" symbol="externalLink" />
             </Link>
           </p>
         </div>

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -37,7 +37,7 @@ import {
   StandardTableData,
   ExpandableSection,
 } from "@bloom-housing/ui-components"
-import { ApplicationStatus, ImageCard } from "@bloom-housing/doorway-ui-components"
+import { ApplicationStatus, ImageCard, Icon } from "@bloom-housing/doorway-ui-components"
 import {
   getOccupancyDescription,
   imageUrlFromListing,
@@ -59,6 +59,7 @@ import { DownloadLotteryResults } from "./DownloadLotteryResults"
 import { SubmitApplication } from "./SubmitApplication"
 import { ListingGoogleMap } from "./ListingGoogleMap"
 import getConfig from "next/config"
+import Link from "next/link"
 
 // nextConfig may not be set in some unit tests since it relies on app startup
 const nextConfig = getConfig()
@@ -552,9 +553,14 @@ export const ListingView = (props: ListingProps) => {
           </Heading>
           <p className="text-gray-750 text-base mb-1">{listing.developer}</p>
           <p className="text-base">
-            <a href={googleMapsHref} target="_blank" aria-label="Opens in new window">
-              {t("t.viewOnMap")}
-            </a>
+            <Link
+              href={googleMapsHref}
+              target="_blank"
+              aria-label="Opens in new window"
+              className="lighter-uppercase"
+            >
+              {t("t.viewOnMap")} <Icon size="small" symbol="link" />
+            </Link>
           </p>
         </div>
       </header>


### PR DESCRIPTION
This PR continues the redesign of the listing page. It 

* updates the table component with the figma spec
* updates the H1 to match the spec
* makes both columns start in the same place
* adds the new numbering with the circle numbers, and
* redesigns the link to the map to match the spec (plus an icon that I thought made sense)

Note that the site is still not fully redesigned and things still look strange as child components are updated but parent components are not -- will address in future PRs

https://github.com/metrotranscom/doorway/assets/10789523/b42746bc-6c2d-4464-b636-a7455b536290


https://github.com/metrotranscom/doorway/assets/10789523/49e09eeb-7f1d-460e-9b40-eb7d80994fea

