### PR TITLE
feat: update listing page (3/n)

### DIFF
--- a/doorway-ui-components/src/blocks/ImageCard.scss
+++ b/doorway-ui-components/src/blocks/ImageCard.scss
@@ -150,11 +150,13 @@
 .image-card--leader {
   --leader-width: var(--bloom-width-2-3rd);
   width: 100%;
+  margin: 0 var(--bloom-s4);
 
   @media (min-width: $screen-md) {
     width: var(--leader-width);
     padding-block-start: 0;
     padding-inline-end: var(--bloom-s8);
+    margin: 0;
   }
 }
 

--- a/doorway-ui-components/src/blocks/ImageCard.tsx
+++ b/doorway-ui-components/src/blocks/ImageCard.tsx
@@ -81,6 +81,7 @@ const ImageCard = (props: ImageCardProps) => {
           iconType={status.iconType}
           vivid
           key={index}
+          className="mt-1"
         />
       )
     })

--- a/doorway-ui-components/src/global/blocks.scss
+++ b/doorway-ui-components/src/global/blocks.scss
@@ -45,7 +45,7 @@ details.disclosure {
 
 .listing-detail-panel {
   @screen md {
-    @apply ml-16;
+    @apply ml-0;
     @apply pb-8;
   }
 }

--- a/doorway-ui-components/src/global/custom_counter.scss
+++ b/doorway-ui-components/src/global/custom_counter.scss
@@ -1,7 +1,7 @@
 .custom-counter__item {
   @screen md {
     @apply mb-12;
-    @apply ml-8;
+    @apply ml-4;
     @apply pl-12;
     @apply relative;
     counter-increment: step-counter;

--- a/doorway-ui-components/src/global/tables.scss
+++ b/doorway-ui-components/src/global/tables.scss
@@ -13,12 +13,9 @@ https://www.cssscript.com/pure-html5-css3-responsive-table-solution/ */
       @apply mb-6;
     }
 
-    tr:nth-of-type(even) {
+    tr:nth-of-type(even),
+    tr:nth-of-type(odd) {
       background: inherit;
-    }
-
-    td:nth-of-type(even) {
-      @apply doorway-bg-primary-light;
     }
 
     td {
@@ -346,8 +343,6 @@ table tr:nth-of-type(even) {
 table tr:nth-of-type(odd) {
   @apply doorway-bg-primary-light;
 }
-
-
 
 td.reserved {
   @apply font-sans;

--- a/doorway-ui-components/src/global/text.scss
+++ b/doorway-ui-components/src/global/text.scss
@@ -127,6 +127,7 @@ h1.title {
 :root {
   --text-large-primary-font-weight: 500;
   --text-large-primary-font-size: var(--bloom-font-size-xl);
+  --text-underline-weighted-border-bottom: var(--doorway-standard-border);
 }
 
 .text__large-primary {
@@ -186,7 +187,7 @@ h1.title {
   margin-bottom: var(--text-underline-weighted-bottom-margin, var(--bloom-s5));
   padding-bottom: var(--text-underline-weighted-bottom-padding, var(--bloom-s2));
   border: var(--text-underline-weighted-border, 0);
-  border-bottom: var(--text-underline-weighted-border, 4px solid var(--bloom-color-primary));
+  border-bottom: var(--text-underline-weighted-border-bottom, 2px solid var(--bloom-color-primary));
   font-weight: var(--text-underline-weighted-font-weight, 600);
   color: var(--text-underline-weighted-color, var(--bloom-text-color-dark));
   letter-spacing: var(--text-underline-weighted-letter-spacing, var(--bloom-letter-spacing-widest));

--- a/doorway-ui-components/src/notifications/ApplicationStatus.scss
+++ b/doorway-ui-components/src/notifications/ApplicationStatus.scss
@@ -2,4 +2,5 @@
   @apply p-4;
   @apply flex;
   gap: 0.45rem;
+  border-radius: var(--doorway-standard-border-radius);
 }

--- a/doorway-ui-components/src/notifications/ApplicationStatus.tsx
+++ b/doorway-ui-components/src/notifications/ApplicationStatus.tsx
@@ -31,17 +31,10 @@ const ApplicationStatus = (props: ApplicationStatusProps) => {
   let textColor = vivid ? "text-white" : "text-gray-800"
   const textSize = vivid ? "text-2xs" : "text-xs"
 
-  const icon = withIcon && (
-    <Icon
-      size="medium"
-      symbol={iconType}
-      fill={iconColor || (vivid ? IconFillColors.white : undefined)}
-    />
-  )
-
   switch (status) {
     case ApplicationStatusType.Open:
       bgColor = vivid ? "doorway-bg-primary" : "doorway-bg-primary-light"
+      textColor = "text-gray-800"
       break
     case ApplicationStatusType.Closed:
       bgColor = vivid ? "bg-alert" : "bg-alert-light"
@@ -57,8 +50,9 @@ const ApplicationStatus = (props: ApplicationStatusProps) => {
     default:
       bgColor = "bg-primary"
   }
+  const icon = withIcon && <Icon size="medium" symbol={iconType} fill={iconColor || textColor} />
 
-  const classNames = ["application-status", textSize, textColor, bgColor]
+  const classNames = ["application-status", "text__light-weighted", textSize, textColor, bgColor]
   if (className) {
     classNames.push(className)
   }

--- a/doorway-ui-components/src/page_components/listing/ContentAccordion.scss
+++ b/doorway-ui-components/src/page_components/listing/ContentAccordion.scss
@@ -2,7 +2,8 @@
   background-color: var(--doorway-color-secondary-background);
   @apply p-4;
   @apply border-b;
-  @apply border-primary;
+  @apply border-0;
+  border-radius: var(--doorway-standard-border-radius) var(--doorway-standard-border-radius) 0 0;
   @apply flex;
   @apply justify-between;
   @apply font-sans;
@@ -37,4 +38,5 @@
   @apply font-sans;
   @apply text-sm;
   @apply text-gray-800;
+  @apply font-bold;
 }

--- a/doorway-ui-components/src/page_components/listing/ListingDetailHeader.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingDetailHeader.scss
@@ -6,6 +6,7 @@
   --title-mobile-font-size: var(--bloom-font-size-sm);
   --title-desktop-font-family: var(--bloom-font-serif);
   --title-mobile-font-family: var(--bloom-font-alt-sans);
+  --title-font-weight: 700;
   position: relative;
   padding: var(--bloom-s4) var(--bloom-s4) var(--bloom-s6) var(--bloom-s4);
   border-bottom: 1px solid var(--bloom-color-gray-400);
@@ -16,6 +17,7 @@
   @media (min-width: $screen-md) {
     padding-top: 0;
     padding-bottom: var(--bloom-s8);
+    padding-left: 0;
     border: none;
     color: var(--bloom-color-gray-800);
   }
@@ -40,15 +42,15 @@
 }
 
 .detail-header__hgroup {
-  margin-left: var(--bloom-s12);
-  padding-left: var(--bloom-s4);
+  margin-left: 0;
+  padding-left: 0;
 
   @media (min-width: $screen-md) {
-    border-left: 2px solid var(--bloom-color-primary);
+    border-left: none;
   }
 
   [dir="rtl"] & {
-    margin-right: var(--bloom-s4);
+    margin-right: 0;
   }
 
   .ui-icon {
@@ -78,6 +80,7 @@
   font-size: var(--title-mobile-font-size);
   letter-spacing: 0.1rem;
   color: var(--text-color);
+  font-weight: var(--title-font-weight);
   @media (min-width: $screen-md) {
     font-family: var(--title-desktop-font-family);
     font-size: var(--title-desktop-font-size);

--- a/doorway-ui-components/src/page_components/listing/ListingDetailHeader.tsx
+++ b/doorway-ui-components/src/page_components/listing/ListingDetailHeader.tsx
@@ -3,8 +3,6 @@ import { Icon } from "../../icons/Icon"
 import "./ListingDetailHeader.scss"
 
 export interface ListingDetailHeaderProps {
-  imageAlt: string
-  imageSrc: string
   subtitle: string
   title: string
   children?: React.ReactNode
@@ -14,9 +12,6 @@ export interface ListingDetailHeaderProps {
 
 const ListingDetailHeader = (props: ListingDetailHeaderProps) => (
   <header className={`detail-header ${props.hideHeader ? "md:hidden" : ""}`}>
-    <span className={"detail-header__image-container"}>
-      <img alt={props.imageAlt} className="detail-header__image " src={props.imageSrc} />
-    </span>
     <hgroup className="detail-header__hgroup">
       <h2 className="detail-header__title">{props.title}</h2>
       <span className="detail-header__subtitle">{props.subtitle}</span>

--- a/doorway-ui-components/src/page_components/listing/ListingDetails.tsx
+++ b/doorway-ui-components/src/page_components/listing/ListingDetails.tsx
@@ -20,8 +20,6 @@ export const ListingDetailItem = (props: ListingDetailHeaderProps) => (
       <ListingDetailHeader
         title={props.title}
         subtitle={props.subtitle}
-        imageSrc={props.imageSrc}
-        imageAlt={props.imageAlt}
         hideHeader={props.hideHeader}
       />
     </ResponsiveContentItemHeader>

--- a/doorway-ui-components/src/text/Description.scss
+++ b/doorway-ui-components/src/text/Description.scss
@@ -3,8 +3,10 @@
 .column-definition-list {
   @include clearfix;
 
-  --title-font-family: var(--bloom-font-serif);
-  --title-font-size-desktop: var(--bloom-font-size-xl);
+  --title-font-family: var(--bloom-font-sans-serif);
+  --title-font-weight-desktop: 600;
+  --title-font-weight-mobile: 500;
+  --title-font-size-desktop: var(--bloom-font-size-sm);
   --title-font-size-mobile: var(--bloom-font-size-lg);
   --title-text-color: var(--bloom-color-gray-800);
   --body-font-size: var(--bloom-font-size-sm);
@@ -14,25 +16,27 @@
   @media (min-width: $screen-md) {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    column-gap: var(--bloom-s4);
-    grid-row-gap: 0.15rem;
+    column-gap: var(--bloom-s6);
+    grid-row-gap: var(--bloom-s4);
   }
 
   .description__title {
     font-family: var(--title-font-family);
     font-size: var(--title-font-size-mobile);
     color: var(--title-text-color);
+    font-weight: var(--title-font-weight-mobile);
     margin-bottom: var(--bloom-s1);
     clear: left;
     height: auto;
     width: 100%;
 
     @media (min-width: $screen-md) {
-      padding-left: var(--bloom-s4);
-      border-left: 2px solid var(--border-color);
+      padding-left: 0;
+      border-left: 0;
       float: left;
       margin-bottom: var(--bloom-s3);
       font-size: var(--title-font-size-desktop);
+      font-weight: var(--title-font-weight-desktop);
     }
   }
 

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -757,7 +757,7 @@ export const ListingView = (props: ListingProps) => {
           hideHeader={true}
           desktopClass="header-hidden"
         >
-          <aside className="w-full static md:absolute md:right-0 md:w-1/3 md:top-0 sm:w-2/3 md:ml-2 h-full md:border border-gray-400 bg-white">
+          <aside className="w-full static md:absolute md:right-0 md:w-1/3 md:top-0 sm:w-2/3 md:ml-2 h-full bg-white">
             <div className="hidden md:block">
               <ApplicationStatus content={appStatusContent} subContent={appStatusSubContent} />
               <DownloadLotteryResults

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -21,8 +21,6 @@ import {
   InfoCard,
   Contact,
   ListSection,
-  ListingDetailItem,
-  ListingDetails,
   Message,
   OneLineAddress,
   EventSection,
@@ -40,6 +38,8 @@ import {
   GroupedTable,
   ImageCard,
   Icon,
+  ListingDetails,
+  ListingDetailItem,
   StandardTable,
 } from "@bloom-housing/doorway-ui-components"
 import {
@@ -446,7 +446,7 @@ export const ListingView = (props: ListingProps) => {
 
   const additionalInformationCard = (cardTitle: string, cardData: string) => {
     return (
-      <div className="info-card">
+      <div className="info-card md:mx-0">
         <h3 className="text-serif-xl">{cardTitle}</h3>
         <p className="text-xs text-gray-700 break-words">
           <Markdown children={cardData} options={{ disableParsingRawHTML: true }} />
@@ -540,7 +540,7 @@ export const ListingView = (props: ListingProps) => {
           })}
           modalCloseLabel={t("t.backToListing")}
         />
-        <div className="py-3 mx-3 mt-4 flex flex-col items-center md:items-start text-center md:text-left">
+        <div className="py-3 mt-4 flex flex-col items-center md:items-start text-center md:text-left">
           <Heading
             priority={1}
             styleType={"largePrimary"}
@@ -568,7 +568,7 @@ export const ListingView = (props: ListingProps) => {
         </div>
       </header>
 
-      <div className="w-full md:w-2/3 md:mt-6 md:mb-6 md:px-3 md:pr-8">
+      <div className="w-full md:w-2/3 md:mt-6 md:mb-6 md:pr-8">
         {listing.reservedCommunityType && (
           <Message warning={true}>
             {t("listings.reservedFor", {
@@ -631,11 +631,8 @@ export const ListingView = (props: ListingProps) => {
       </div>
       <ListingDetails>
         <ListingDetailItem
-          imageAlt={t("listings.eligibilityNotebook")}
-          imageSrc="/images/listing-eligibility.svg"
           title={t("listings.sections.eligibilityTitle")}
           subtitle={t("listings.sections.eligibilitySubtitle")}
-          desktopClass="doorway-bg-primary-light"
         >
           <ul>
             {listing.reservedCommunityType && (
@@ -750,8 +747,6 @@ export const ListingView = (props: ListingProps) => {
         </ListingDetailItem>
 
         <ListingDetailItem
-          imageAlt={t("listings.processInfo")}
-          imageSrc="/images/listing-process.svg"
           title={t("listings.sections.processTitle")}
           subtitle={t("listings.sections.processSubtitle")}
           hideHeader={true}
@@ -840,8 +835,6 @@ export const ListingView = (props: ListingProps) => {
         </ListingDetailItem>
 
         <ListingDetailItem
-          imageAlt={t("listings.featuresCards")}
-          imageSrc="/images/listing-features.svg"
           title={t("listings.sections.featuresTitle")}
           subtitle={t("listings.sections.featuresSubtitle")}
         >
@@ -907,8 +900,6 @@ export const ListingView = (props: ListingProps) => {
         </ListingDetailItem>
 
         <ListingDetailItem
-          imageAlt={t("listings.neighborhoodBuildings")}
-          imageSrc="/images/listing-neighborhood.svg"
           title={t("t.neighborhood")}
           subtitle={t("listings.sections.neighborhoodSubtitle")}
           desktopClass="doorway-bg-primary-lighter"
@@ -924,8 +915,6 @@ export const ListingView = (props: ListingProps) => {
 
         {(listing.requiredDocuments || listing.programRules || listing.specialNotes) && (
           <ListingDetailItem
-            imageAlt={t("listings.additionalInformationEnvelope")}
-            imageSrc="/images/listing-legal.svg"
             title={t("listings.additionalInformation")}
             subtitle={t("listings.sections.additionalInformationSubtitle")}
           >


### PR DESCRIPTION
This CL continues styling the listing page. I will likely move onto the other pages after this point given that I think we're pretty close on vibe at this point and I want to make sure that we make time for the help center.

It updates the backgrounds to make things look even less broken, as well as changes the titles to match the spec and updates some spacing to align with the rounded image.

I really wanted to build the rounded cards but the implementation of that is non-trivial and there are some design edge cases that we need to consider that we don't have time to. Thus I think that the new headers is a reasonable place to go.



https://github.com/metrotranscom/doorway/assets/10789523/60a4f81a-78a5-484b-9f9b-4d096669b70d


https://github.com/metrotranscom/doorway/assets/10789523/b49b03a7-af55-44ae-8598-5a2040c80955

