### PR TITLE
refactor: update the SiteHeader component to share a single function [mostly a no-op]

### DIFF
--- a/sites/public/src/layouts/LayoutWithoutFooter.tsx
+++ b/sites/public/src/layouts/LayoutWithoutFooter.tsx
@@ -1,111 +1,18 @@
-import React, { useContext } from "react"
+import React from "react"
 import { useRouter } from "next/router"
 import Head from "next/head"
-import { MenuLink, t, setSiteAlertMessage } from "@bloom-housing/ui-components"
-import { SiteHeader } from "@bloom-housing/doorway-ui-components"
-
-import { AuthContext } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
+import { getSiteHeader } from "../lib/helpers"
 
 const LayoutWithoutFooter = (props) => {
-  const { profile, signOut } = useContext(AuthContext)
   const router = useRouter()
-
-  const languages =
-    router?.locales?.map((item) => ({
-      prefix: item === "en" ? "" : item,
-      label: t(`languages.${item}`),
-    })) || []
-
-  const menuLinks: MenuLink[] = [
-    {
-      title: t("pageTitle.welcome"),
-      href: "/",
-      className: "secondary",
-    },
-    {
-      title: t("nav.browseAllListings"),
-      href: "/listings",
-    },
-    {
-      title: t("nav.helpCenter"),
-      href: "#",
-      subMenuLinks: [
-        {
-          title: "item 1 temp",
-          href: "?temp1",
-        },
-        {
-          title: "item 2 temp",
-          href: "?temp2",
-        },
-      ],
-    },
-  ]
-  if (process.env.housingCounselorServiceUrl) {
-    menuLinks.push({
-      title: t("pageTitle.getAssistance"),
-      href: process.env.housingCounselorServiceUrl,
-    })
-  }
-  if (profile) {
-    menuLinks.push({
-      title: t("nav.myAccount"),
-      subMenuLinks: [
-        {
-          title: t("nav.myDashboard"),
-          href: "/account/dashboard",
-        },
-        {
-          title: t("account.myApplications"),
-          href: "/account/applications",
-        },
-        {
-          title: t("account.accountSettings"),
-          href: "/account/edit",
-        },
-        {
-          title: t("nav.signOut"),
-          onClick: () => {
-            const signOutFxn = async () => {
-              setSiteAlertMessage(t(`authentication.signOut.success`), "notice")
-              await router.push("/sign-in")
-              signOut()
-            }
-            void signOutFxn()
-          },
-        },
-      ],
-    })
-  } else {
-    // TODO: Uncomment when applications are re-enabled
-    // menuLinks.push({
-    //   title: t("nav.signIn"),
-    //   href: "/sign-in",
-    // })
-  }
-
   return (
     <div className="site-wrapper">
       <div className="site-content">
         <Head>
           <title>{t("nav.siteTitle")}</title>
         </Head>
-        <SiteHeader
-          logoSrc="/images/doorway_logo_temp.png"
-          homeURL="/"
-          mainContentId="main-content"
-          languages={languages.map((lang) => {
-            return {
-              label: lang.label,
-              onClick: () =>
-                void router.push(router.asPath, router.asPath, { locale: lang.prefix || "en" }),
-              active: t("config.routePrefix") === lang.prefix,
-            }
-          })}
-          menuLinks={menuLinks}
-          logoWidth={"base_expanded"}
-          strings={{ skipToMainContent: t("t.skipToMainContent") }}
-        />
+        {getSiteHeader(router)}
         <main id="main-content" className="md:overflow-x-hidden">
           {props.children}
         </main>

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -1,119 +1,20 @@
-import React, { useContext } from "react"
+import React from "react"
 import { useRouter } from "next/router"
 import Link from "next/link"
 import Head from "next/head"
-import {
-  SiteFooter,
-  FooterNav,
-  FooterSection,
-  MenuLink,
-  t,
-  setSiteAlertMessage,
-} from "@bloom-housing/ui-components"
-import { SiteHeader } from "@bloom-housing/doorway-ui-components"
-
-import { AuthContext, ExygyFooter } from "@bloom-housing/shared-helpers"
+import { SiteFooter, FooterNav, FooterSection, t } from "@bloom-housing/ui-components"
+import { ExygyFooter } from "@bloom-housing/shared-helpers"
+import { getSiteHeader } from "../lib/helpers"
 
 const Layout = (props) => {
-  const { profile, signOut } = useContext(AuthContext)
   const router = useRouter()
-
-  const languages =
-    router?.locales?.map((item) => ({
-      prefix: item === "en" ? "" : item,
-      label: t(`languages.${item}`),
-    })) || []
-
-  const menuLinks: MenuLink[] = [
-    {
-      title: t("pageTitle.welcome"),
-      href: "/",
-      className: "secondary",
-    },
-    {
-      title: t("nav.browseAllListings"),
-      href: "/listings",
-    },
-    {
-      title: t("nav.helpCenter"),
-      href: "#",
-      subMenuLinks: [
-        {
-          title: "item 1 temp",
-          href: "?temp1",
-        },
-        {
-          title: "item 2 temp",
-          href: "?temp2",
-        },
-      ],
-    },
-  ]
-  if (process.env.housingCounselorServiceUrl) {
-    menuLinks.push({
-      title: t("pageTitle.getAssistance"),
-      href: process.env.housingCounselorServiceUrl,
-    })
-  }
-  if (profile) {
-    menuLinks.push({
-      title: t("nav.myAccount"),
-      subMenuLinks: [
-        {
-          title: t("nav.myDashboard"),
-          href: "/account/dashboard",
-        },
-        {
-          title: t("account.myApplications"),
-          href: "/account/applications",
-        },
-        {
-          title: t("account.accountSettings"),
-          href: "/account/edit",
-        },
-        {
-          title: t("nav.signOut"),
-          onClick: () => {
-            const signOutFxn = async () => {
-              setSiteAlertMessage(t(`authentication.signOut.success`), "notice")
-              await router.push("/sign-in")
-              signOut()
-            }
-            void signOutFxn()
-          },
-        },
-      ],
-    })
-  } else {
-    // TODO: Uncomment when applications are re-enabled
-    // menuLinks.push({
-    //   title: t("nav.signIn"),
-    //   href: "/sign-in",
-    // })
-  }
-
   return (
     <div className="site-wrapper">
       <div className="site-content">
         <Head>
           <title>{t("nav.siteTitle")}</title>
         </Head>
-        <SiteHeader
-          logoSrc="/images/doorway_logo_temp.png"
-          homeURL="/"
-          mainContentId="main-content"
-          languages={languages.map((lang) => {
-            return {
-              label: lang.label,
-              onClick: () =>
-                void router.push(router.asPath, router.asPath, { locale: lang.prefix || "en" }),
-              active: t("config.routePrefix") === lang.prefix,
-            }
-          })}
-          menuLinks={menuLinks}
-          logoWidth={"base_expanded"}
-          strings={{ skipToMainContent: t("t.skipToMainContent") }}
-        />
+        {getSiteHeader(router)}
         <main id="main-content" className="md:overflow-x-hidden">
           {props.children}
         </main>

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import dayjs from "dayjs"
+import { NextRouter } from "next/router"
 import {
   Address,
   Listing,
@@ -8,8 +9,8 @@ import {
   ListingStatus,
   ApplicationMultiselectQuestion,
 } from "@bloom-housing/backend-core/types"
-import { t, ApplicationStatusType, StatusBarType } from "@bloom-housing/ui-components"
-import { ListingCard } from "@bloom-housing/doorway-ui-components"
+import { t, ApplicationStatusType, MenuLink, StatusBarType } from "@bloom-housing/ui-components"
+import { ListingCard, SiteHeader } from "@bloom-housing/doorway-ui-components"
 import { imageUrlFromListing, getSummariesTable } from "@bloom-housing/shared-helpers"
 
 export const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -204,4 +205,105 @@ export const untranslateMultiselectQuestion = (
       }
     }
   })
+}
+
+// FYI when auth/logging in is re-enabled, you'll need to pass in
+// call `const { profile, signOut } = useContext(AuthContext)`
+// from the layout and pass into this function.
+export const getSiteHeader = (router: NextRouter) => {
+  const languages =
+    router?.locales?.map((item) => ({
+      prefix: item === "en" ? "" : item,
+      label: t(`languages.${item}`),
+    })) || []
+
+  const menuLinks: MenuLink[] = [
+    {
+      title: t("pageTitle.welcome"),
+      href: "/",
+    },
+    {
+      title: t("nav.browseAllListings"),
+      href: "/listings",
+    },
+    {
+      title: t("nav.helpCenter"),
+      href: "#",
+      subMenuLinks: [
+        {
+          title: "item 1 temp",
+          href: "?temp1",
+        },
+        {
+          title: "item 2 temp",
+          href: "?temp2",
+        },
+      ],
+    },
+  ]
+  if (process.env.housingCounselorServiceUrl) {
+    menuLinks.push({
+      title: t("pageTitle.getAssistance"),
+      href: process.env.housingCounselorServiceUrl,
+    })
+  }
+  // TODO: Uncomment when applications are re-enabled
+  // if (profile) {
+  //   menuLinks.push({
+  //     title: t("nav.myAccount"),
+  //     subMenuLinks: [
+  //       {
+  //         title: t("nav.myDashboard"),
+  //         href: "/account/dashboard",
+  //       },
+  //       {
+  //         title: t("account.myApplications"),
+  //         href: "/account/applications",
+  //       },
+  //       {
+  //         title: t("account.accountSettings"),
+  //         href: "/account/edit",
+  //       },
+  //       {
+  //         title: t("nav.signOut"),
+  //         onClick: () => {
+  //           const signOutFxn = async () => {
+  //             setSiteAlertMessage(t(`authentication.signOut.success`), "notice")
+  //             await router.push("/sign-in")
+  //             signOut()
+  //           }
+  //           void signOutFxn()
+  //         },
+  //       },
+  //     ],
+  //   })
+  // } else {
+  // menuLinks.push({
+  //   title: t("nav.signIn"),
+  //   href: "/sign-in",
+  // })
+  // }
+  return (
+    <SiteHeader
+      logoSrc="/images/doorway_logo_temp.png"
+      homeURL="/"
+      mainContentId="main-content"
+      languages={languages.map((lang) => {
+        return {
+          label: lang.label,
+          onClick: () =>
+            void router.push(router.asPath, router.asPath, { locale: lang.prefix || "en" }),
+          active: t("config.routePrefix") === lang.prefix,
+        }
+      })}
+      menuLinks={menuLinks.map((menuLink) => {
+        return {
+          ...menuLink,
+          className: router.pathname === menuLink.href ? "secondary" : "",
+        }
+      })}
+      logoWidth={"base_expanded"}
+      strings={{ skipToMainContent: t("t.skipToMainContent") }}
+    />
+  )
 }


### PR DESCRIPTION

This PR does a refactor with two small feature changes:

1.  It highlights the active link vs just always highlighting the welcome link.
2. It fixes #106, the issue where someone logged in will see the logged in menu

It changes the copypasta that was the LayoutWithoutFooter component's <SiteHeader> to live in helpers.tsx.

I did this in anticipation of updating the SiteHeader with the correct links to the help center.

I tested this by making sure that /listings (no footer template) and / (application template) both loaded fine with the right highlighted link.