### PR TITLE
feat: prevent scrolling on swipe

### DIFF
--- a/sites/public/src/components/listings/ListingsCombined.tsx
+++ b/sites/public/src/components/listings/ListingsCombined.tsx
@@ -48,6 +48,7 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
         }
       }
     },
+    preventScrollOnSwipe: true,
   })
 
   const getListingsList = () => {


### PR DESCRIPTION
# Pull Request Template

## Description

- Change swiping behavior for listings page on mobile so when the listings list is swiped up, the page doesn't also get scrolled all the way down to the footer.

## How Can This Be Tested/Reviewed?

- On mobile, go to the listings page and you'll see the hybrid page. Swipe up on the listings list. This will show you just the expanded listings list without going to the bottom of the page and showing the footer.


