### PR TITLE
feat: landing search style fixes

### DIFF
--- a/doorway-ui-components/src/forms/Field.scss
+++ b/doorway-ui-components/src/forms/Field.scss
@@ -1,8 +1,8 @@
 .doorway-field {
   width: 100%;
   margin: 0;
-  padding: 0 0 1.5rem 0;;
-  font-size: .75rem;
+  padding: 0 0 1.5rem 0;
+  font-size: 0.75rem;
   font-weight: 500;
 
   input.rent-input {
@@ -16,11 +16,5 @@
     color: var(--doorway-blue-800);
     font-family: var(--bloom-font-alt-sans);
     text-transform: uppercase;
-    }
-}
-
-.county-input {
-    font-family: var(--bloom-font-alt-sans);
-    text-transform: uppercase;
-    font-weight: 500;
+  }
 }

--- a/doorway-ui-components/src/forms/FieldGroup.scss
+++ b/doorway-ui-components/src/forms/FieldGroup.scss
@@ -3,6 +3,5 @@
     background-color: var(--bloom-color-primary-lighter);
     background-image: url("/images/check.svg");
     box-shadow: 0 0 0 1px var(--bloom-color-primary-lighter);
-    @apply mr-2;
   }
 }

--- a/doorway-ui-components/src/forms/FieldGroup.scss
+++ b/doorway-ui-components/src/forms/FieldGroup.scss
@@ -1,8 +1,8 @@
 .county-checkbox-group {
   .field input[type="checkbox"]:checked + label::before {
-    background-color: var(--bloom-color-blue-500);
+    background-color: var(--bloom-color-primary-lighter);
     background-image: url("/images/check.svg");
-    box-shadow: 0 0 0 1px var(--bloom-color-blue-500);
+    box-shadow: 0 0 0 1px var(--bloom-color-primary-lighter);
     @apply mr-2;
   }
 }

--- a/doorway-ui-components/src/forms/FieldGroup.scss
+++ b/doorway-ui-components/src/forms/FieldGroup.scss
@@ -1,6 +1,7 @@
 .county-checkbox-group {
   .field input[type="checkbox"]:checked + label::before {
     background-color: var(--bloom-color-blue-500);
+    background-image: url("/images/check.svg");
     box-shadow: 0 0 0 1px var(--bloom-color-blue-500);
     @apply mr-2;
   }

--- a/doorway-ui-components/src/forms/FieldGroup.tsx
+++ b/doorway-ui-components/src/forms/FieldGroup.tsx
@@ -13,6 +13,7 @@ export interface FieldSingle {
   defaultText?: string
   description?: React.ReactNode
   disabled?: boolean
+  doubleColumn?: boolean
   id: string
   inputProps?: Record<string, unknown>
   label: string
@@ -202,7 +203,12 @@ const FieldGroup = ({
 
       <div className={`field ${error ? "error" : ""} ${fieldGroupClassName || ""} mb-0`}>
         {fields?.map((item) => (
-          <div className={`field ${fieldClassName || ""} mb-1`} key={item.id}>
+          <div
+            className={`field ${fieldClassName || ""} ${
+              item.doubleColumn ? "col-span-2" : ""
+            } mb-1`}
+            key={item.id}
+          >
             {getInputSet(item)}
             {item.subFields && checkedInputs.indexOf(item.label) >= 0 && (
               <div className={"ml-8"} key={`${item.value || ""}-subfields`}>

--- a/doorway-ui-components/src/headers/DoorwayHero.scss
+++ b/doorway-ui-components/src/headers/DoorwayHero.scss
@@ -24,6 +24,7 @@
   @apply text-2xl;
   @apply text-primary-dark;
   @apply font-semibold;
+  @apply px-2;
   margin-bottom: var(--doorway-hero-between-margin);
 
   @media (min-width: $screen-md) {

--- a/sites/public/src/components/listings/search/LandingSearch.module.scss
+++ b/sites/public/src/components/listings/search/LandingSearch.module.scss
@@ -1,7 +1,7 @@
 .input-section {
   display: flex;
   flex-direction: column;
-  @apply mb-4;
+  @apply p-2;
   @media (min-width: $screen-md) {
     flex-direction: row;
   }

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -136,7 +136,7 @@ export function LandingSearch(props: LandingSearchProps) {
         />
       </div>
 
-      <div className="flex justify-start">
+      <div className="flex justify-start p-2">
         <LinkButton
           href={createListingsUrl(formValues)}
           className="is-primary bg-primary-dark text-3xs md:text-xs text-white mr-8"

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -131,8 +131,8 @@ export function LandingSearch(props: LandingSearchProps) {
           fields={countyFields}
           onChange={updateValueMulti}
           register={register}
-          fieldGroupClassName="county-checkbox-group grid grid-cols-2 md:pl-16 uppercase"
-          fieldLabelClassName="text-primary-dark font-medium tracking-wider text-2xs"
+          fieldGroupClassName="county-checkbox-group grid grid-cols-2 md:pl-16 "
+          fieldLabelClassName="text-primary-dark font-medium tracking-wider text-2xs uppercase"
         />
       </div>
 

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -139,7 +139,7 @@ export function LandingSearch(props: LandingSearchProps) {
       <div className="flex justify-start p-2">
         <LinkButton
           href={createListingsUrl(formValues)}
-          className="is-primary bg-primary-dark text-3xs md:text-xs text-white mr-8"
+          className="is-primary is-borderless bg-primary-dark text-3xs md:text-xs text-white mr-8"
           size={AppearanceSizeType.small}
         >
           {t("welcome.viewListings")}

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -14,13 +14,7 @@ import {
 import { useForm } from "react-hook-form"
 import { LinkButton, t } from "@bloom-housing/ui-components"
 import styles from "./LandingSearch.module.scss"
-
-export type FormOption = {
-  label: string
-  value: string
-  isDisabled?: boolean
-  labelNoteHTML?: string
-}
+import { FormOption } from "./ListingsSearchModal"
 
 type LandingSearchProps = {
   bedrooms: FormOption[]
@@ -90,6 +84,7 @@ export function LandingSearch(props: LandingSearchProps) {
         value: county.value,
         defaultChecked: check,
         disabled: county.isDisabled || false,
+        doubleColumn: county.doubleColumn || false,
         note: county.labelNoteHTML || "",
       } as FieldSingle)
     })

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -115,7 +115,7 @@ export function LandingSearch(props: LandingSearchProps) {
           name="monthlyRent"
           defaultValue={formValues.monthlyRent}
           placeholder="$"
-          className="doorway-field md:pl-6"
+          className="doorway-field p-0 md:pl-6"
           inputClassName="rent-input"
           labelClassName="input-label"
           onChange={(e: React.FormEvent<HTMLInputElement>) => {

--- a/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
@@ -251,6 +251,7 @@ const locations: FormOption[] = [
     value: "San Francisco",
     isDisabled: true,
     labelNoteHTML: `(For San Francisco listings, please go to <a href="https://housing.sfgov.org/" target="_blank">DAHLIA</a>)`,
+    doubleColumn: true,
   },
 ]
 

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -51,6 +51,7 @@ export type FormOption = {
   value: string
   isDisabled?: boolean
   labelNoteHTML?: string
+  doubleColumn?: boolean
 }
 
 type ListingsSearchModalProps = {
@@ -161,6 +162,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
         value: county.value,
         defaultChecked: check,
         disabled: county.isDisabled || false,
+        doubleColumn: county.doubleColumn || false,
         note: county.labelNoteHTML || "",
       } as FieldSingle)
     })

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -251,7 +251,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
           onChange={updateValueMulti}
           register={register}
           fieldGroupClassName="grid grid-cols-2"
-          fieldLabelClassName="county-input"
+          fieldLabelClassName="text-primary-dark font-medium tracking-wider text-2xs uppercase"
         />
       </div>
     </Modal>


### PR DESCRIPTION
# Pull Request Template

## Description

Make a few styling changes to the landing search component as well as the listings search where necessary. There are still a few styling changes needed that are not included in this PR.
- Make San Francisco county field span both columns. Both for landing search and listings search.
- Change county checkmarks to white. Only for landing page, listings still uses black as intended.
- Fix buttons being cutoff by adding extra padding around components. Only for landing page, was already working fine for listings search.
- Use same style for listings search county names as what is already used for landing search. Updates font size, spacing, color.
- Stop county names from shifting right when clicked. Only for landing page, was already working fine for listings search.
- Removes light blue outline from view listings button. Only for landing search.
- Removes unnecessary padding from rent input box. Only for landing search.

Landing search before: 
![image](https://github.com/metrotranscom/doorway/assets/67125998/82d9dc8a-d500-495e-84d8-71488ff1579c)

Landing search after:
![image](https://github.com/metrotranscom/doorway/assets/67125998/6761d2ba-df2d-4b02-a013-c59fd398311c)

Listings search modal before:
![image](https://github.com/metrotranscom/doorway/assets/67125998/a6299f82-5bcf-4d50-8ad7-3d50276df3c2)

Listings search modal after:
![image](https://github.com/metrotranscom/doorway/assets/67125998/720b34c0-92e1-4aae-849e-e302783c7d47)

## How Can This Be Tested/Reviewed?

Just styling changes, can verify visually by bringing up the landing page and then checking the listings search modal.

