### PR TITLE
fix: style listing card for listings list and map info windows

### DIFF
--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -31,6 +31,10 @@
     margin-top: 0;
   }
 
+  &:last-of-type {
+    border-bottom: 0px;
+  }
+
   &:hover {
     background-color: var(--bloom-color-gray-300);
   }

--- a/doorway-ui-components/src/page_components/listing/ListingCard.scss
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.scss
@@ -5,7 +5,7 @@
   --max-width-large-screen: var(--bloom-width-5xl);
   --cell-padding: var(--bloom-s3);
   --wider-cell-padding: var(--bloom-s5);
-  --margin: var(--inter-row-gap);
+  --margin: 0 var(--inter-row-gap);
   --card-tag-padding: var(--bloom-s3) var(--bloom-s5);
   --card-tag-font-weight: inherit;
 
@@ -17,6 +17,7 @@
   position: relative;
   border-bottom: var(--bloom-border-1) solid var(--bloom-color-gray-450);
   padding-bottom: var(--inter-row-gap);
+  padding-top: var(--inter-row-gap);
 
   @media (min-width: $screen-xl) {
     --max-width: var(--max-width-large-screen);


### PR DESCRIPTION
# Pull Request Template

## Description

Fix two related issues for listing cards.

- Replace the vertical margins in between listing cards with just padding. This fixes the hover state for a listing card to be symmetrical vertically. This also fixes a second feedback item which is that the listing card embedded in the map info window is not properly centered.
- Remove the bottom border of the last listing card. This is not present in mocks and also fixes an issue with the info window listing card.

Listings list before:
<img width="1728" alt="Screenshot 2023-06-20 at 5 03 19 PM" src="https://github.com/metrotranscom/doorway/assets/67125998/ae5dda63-d596-441b-a956-07968bbef0ab">

Listings list after:
<img width="1728" alt="Screenshot 2023-06-20 at 5 04 52 PM" src="https://github.com/metrotranscom/doorway/assets/67125998/e7364ee1-f4b3-4ed8-bea2-2293d8806e0c">

Info window before: 
![image](https://github.com/metrotranscom/doorway/assets/67125998/bbd3aaa1-b4c7-45e8-aa35-f53b14b5b35d)

Info window after:
![image](https://github.com/metrotranscom/doorway/assets/67125998/a38280f7-e149-4fa6-a167-1be7acb6f93f)


## How Can This Be Tested/Reviewed?

- Verify both styles in the listings page.