### PR TITLE
fix: build error

### DIFF
--- a/sites/public/src/pages/index.tsx
+++ b/sites/public/src/pages/index.tsx
@@ -17,7 +17,8 @@ import { ConfirmationModal } from "../components/account/ConfirmationModal"
 import { MetaTags } from "../components/shared/MetaTags"
 import { fetchJurisdictionByName } from "../lib/hooks"
 import { runtimeConfig } from "../lib/runtime-config"
-import { FormOption, LandingSearch } from "../components/listings/search/LandingSearch"
+import { LandingSearch } from "../components/listings/search/LandingSearch"
+import { FormOption } from "../components/listings/search/ListingsSearchModal"
 import {
   locations,
   bedroomOptionsForLandingPage,


### PR DESCRIPTION
## Description

- Fixes build error by adding the right import. FormOption was duplicate but I deleted one of them to use the same one across different pages, and the import was not properly updated.

Test: run yarn build for the public site



