### PR TITLE
feat: change color of landing search buttons when selected

### DIFF
--- a/doorway-ui-components/src/actions/Button.scss
+++ b/doorway-ui-components/src/actions/Button.scss
@@ -191,7 +191,7 @@ button {
 // This is an override to update the style of the landing page buttons when selected.
 // This is not ideal but is needed since the landing page search buttons and the listing
 // search modal buttons have to have different styles when selected.
-.landing-search-button {
+.landing-search-button-group {
   --landing-button-color: var(--bloom-color-primary-lighter);
   --landing-button-hover-color: var(--bloom-color-primary-light);
   --landing-button-active-color: var(--bloom-color-primary);

--- a/doorway-ui-components/src/actions/Button.scss
+++ b/doorway-ui-components/src/actions/Button.scss
@@ -215,23 +215,3 @@ button {
     }
   }
 }
-
-/*
-&.is-secondary {
-    border-color: var(--doorway-color-secondary);
-    background-color: var(--doorway-color-secondary);
-    color: var(--secondary-text-color);
-
-    &:hover {
-      background-color: var(--doorway-color-cyan-500);
-      color: var(--secondary-text-color);
-      border-color: var(--doorway-color-cyan-500);
-    }
-
-    &:active {
-      background-color: var(--doorway-color-cyan-700);
-      color: var(--secondary-text-color);
-      border-color: var(--doorway-color-cyan-700);
-    }
-  }
-*/

--- a/doorway-ui-components/src/actions/Button.scss
+++ b/doorway-ui-components/src/actions/Button.scss
@@ -187,3 +187,13 @@ button {
   transform: translate(-50%, -50%);
   margin-top: 2px;
 }
+
+// This is an override to update the style of the landing page buttons when selected.
+// This is not ideal but is needed since the landing page search buttons and the listing
+// search modal buttons have to have different styles when selected.
+.landing-search-button {
+  .button.is-secondary {
+    background-color: var(--bloom-color-primary-lighter);
+    color: var(--bloom-color-white);
+  }
+}

--- a/doorway-ui-components/src/actions/Button.scss
+++ b/doorway-ui-components/src/actions/Button.scss
@@ -192,8 +192,46 @@ button {
 // This is not ideal but is needed since the landing page search buttons and the listing
 // search modal buttons have to have different styles when selected.
 .landing-search-button {
+  --landing-button-color: var(--bloom-color-primary-lighter);
+  --landing-button-hover-color: var(--bloom-color-primary-light);
+  --landing-button-active-color: var(--bloom-color-primary);
+  --landing-button-text-color: var(--bloom-color-white);
+
   .button.is-secondary {
-    background-color: var(--bloom-color-primary-lighter);
-    color: var(--bloom-color-white);
+    background-color: var(--landing-button-color);
+    border-color: var(--landing-button-color);
+    color: var(--landing-button-text-color);
+
+    &:hover {
+      background-color: var(--landing-button-hover-color);
+      border-color: var(--landing-button-hover-color);
+      color: var(--landing-button-text-color);
+    }
+
+    &:active {
+      background-color: var(--landing-button-active-color);
+      border-color: var(--landing-button-active-color);
+      color: var(--landing-button-text-color);
+    }
   }
 }
+
+/*
+&.is-secondary {
+    border-color: var(--doorway-color-secondary);
+    background-color: var(--doorway-color-secondary);
+    color: var(--secondary-text-color);
+
+    &:hover {
+      background-color: var(--doorway-color-cyan-500);
+      color: var(--secondary-text-color);
+      border-color: var(--doorway-color-cyan-500);
+    }
+
+    &:active {
+      background-color: var(--doorway-color-cyan-700);
+      color: var(--secondary-text-color);
+      border-color: var(--doorway-color-cyan-700);
+    }
+  }
+*/

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -103,7 +103,7 @@ export function LandingSearch(props: LandingSearchProps) {
           options={props.bedrooms}
           onChange={updateValue}
           value={formValues.bedrooms}
-          className="bg-accent-cool-light py-0 px-0 md:pl-12"
+          className="bg-accent-cool-light py-0 px-0 md:pl-12 landing-search-button"
           spacing={ButtonGroupSpacing.left}
         />
       </div>

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -103,7 +103,7 @@ export function LandingSearch(props: LandingSearchProps) {
           options={props.bedrooms}
           onChange={updateValue}
           value={formValues.bedrooms}
-          className="bg-accent-cool-light py-0 px-0 md:pl-12 landing-search-button"
+          className="bg-accent-cool-light py-0 px-0 md:pl-12 landing-search-button-group"
           spacing={ButtonGroupSpacing.left}
         />
       </div>


### PR DESCRIPTION
# Pull Request Template

## Description

- Add an override class for the landing search bedroom size buttons. There is already existing logic to style the buttons with the secondary class when selected, so this override applies to secondary buttons.
- Update the background, border and text color to match the mocks. Add hover and active state colors that are one and two shades darker, respectively.
![image](https://github.com/metrotranscom/doorway/assets/67125998/5bab4e82-dace-4d77-b8cb-d7763e413daa)

## How Can This Be Tested/Reviewed?

- Go to the landing page.
- Verify that the "Any" button is selected by default and has a royal blue background and white text.
- Click on any other bedroom size button and verify that it turns that shade of blue.
- Hover over the button and check that it turns a shade darker.
- Go to the listings page and open the filters modal.
- Verify that the bedroom and bathroom size buttons are still light blue when selected, not royal blue.
