### PR TITLE
fix: clear filters button on empty listings results

### DIFF
--- a/sites/public/src/components/listings/ListingsCombined.tsx
+++ b/sites/public/src/components/listings/ListingsCombined.tsx
@@ -11,6 +11,8 @@ type ListingsCombinedProps = {
   lastPage: number
   onPageChange: (page: number) => void
   googleMapsApiKey: string
+  setClearButtonState?: React.Dispatch<React.SetStateAction<boolean>>
+  clearButtonState?: boolean
 }
 
 const ListingsCombined = (props: ListingsCombinedProps) => {
@@ -70,6 +72,8 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
             currentPage={props.currentPage}
             lastPage={props.lastPage}
             onPageChange={props.onPageChange}
+            setClearButtonState={props.setClearButtonState}
+            clearButtonState={props.clearButtonState}
           ></ListingsList>
         </div>
       </div>
@@ -114,6 +118,8 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
               currentPage={props.currentPage}
               lastPage={props.lastPage}
               onPageChange={props.onPageChange}
+              setClearButtonState={props.setClearButtonState}
+              clearButtonState={props.clearButtonState}
             ></ListingsList>
           </div>
         </div>

--- a/sites/public/src/components/listings/ListingsList.tsx
+++ b/sites/public/src/components/listings/ListingsList.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React, { useState, useEffect } from "react"
 import { getListings } from "../../lib/helpers"
 import { Listing } from "@bloom-housing/backend-core"
 import {
@@ -15,15 +15,34 @@ type ListingsListProps = {
   currentPage: number
   lastPage: number
   onPageChange: (page: number) => void
+  setClearButtonState?: (boolean) => void
+  clearButtonState?: boolean
 }
 
 const ListingsList = (props: ListingsListProps) => {
+  // Flip the state and call the callers setClearButtonState,
+  // which is intended to cause a reset on the filters
+  // and then reload the page with no query filters applied.
+  const [initialClear, setInitialClear] = useState(props.clearButtonState)
+  const { setClearButtonState } = props
+  useEffect(() => {
+    // On state change, use the function the caller passed in with the new state.
+    if (!setClearButtonState) {
+      return
+    }
+    setClearButtonState(initialClear)
+  }, [initialClear, setClearButtonState])
+  const clearFilter = () => {
+    // Invert the state stored in this component.
+    setInitialClear(!initialClear)
+  }
+
   const listingsDiv =
     props.listings.length > 0 ? (
       <div className="listingsList">{getListings(props.listings)}</div>
     ) : (
       <ZeroListingsItem title={t("t.noMatchingListings")} description={t("t.tryRemovingFilters")}>
-        <Button>{t("t.clearAllFilters")}</Button>
+        <Button onClick={clearFilter}>{t("t.clearAllFilters")}</Button>
       </ZeroListingsItem>
     )
 

--- a/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
@@ -98,6 +98,7 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
   const updateFilterCount = (count: number) => {
     setFilterCount(count)
   }
+  const [clearButton, setClearButton] = useState(false)
 
   return (
     <div>
@@ -123,6 +124,7 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
         onSubmit={onFormSubmit}
         onClose={onModalClose}
         onFilterChange={updateFilterCount}
+        clearButtonState={clearButton}
       />
 
       <ListingsCombined
@@ -131,6 +133,8 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
         lastPage={searchResults.lastPage}
         googleMapsApiKey={props.googleMapsApiKey}
         onPageChange={onPageChange}
+        setClearButtonState={setClearButton}
+        clearButtonState={clearButton}
       />
     </div>
   )

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -64,6 +64,7 @@ type ListingsSearchModalProps = {
   onSubmit: (params: ListingSearchParams) => void
   onClose: () => void
   onFilterChange: (count: number) => void
+  clearButtonState?: boolean
 }
 
 export function ListingsSearchModal(props: ListingsSearchModalProps) {
@@ -102,7 +103,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
   const filterChange = props.onFilterChange
   useEffect(() => {
     filterChange(countFilters(formValues))
-  }, [formValues, filterChange, countFilters])
+  }, [formValues, countFilters])
 
   // Run this once immediately after first render
   // Empty array is intentional; it's how we make sure it only runs once
@@ -115,11 +116,24 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
   }, [])
 
   const clearValues = () => {
-    // TODO: fix this
-    // This code gets called but the UI doesn't update in response to state change
     setFormValues(nullState)
   }
 
+  // props.clearButtonState is passed in from an ancestor component and used to reset the query filters
+  // from a button on an ancestor's child component. TODO: move logic to the ancestor component
+  // so we can avoid checking states across the component graph.
+  useEffect(() => {
+    if (props.clearButtonState === undefined) {
+      return
+    }
+    // Clear the component's formValues, which will correct the search modal's query form state.
+    clearValues()
+    // Call the parent's onSubmit handler with nullState, which will reload the page with the
+    // results of the nullState query.
+    props.onSubmit(nullState)
+  }, [props.clearButtonState])
+
+  // Used to clear the filters from a button on this component.
   const onSubmit = () => {
     props.onSubmit(formValues)
     props.onClose()


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses empty listings clear filters button clears the filters and reloads the page with an empty, default query.

emtpy results:
![before](https://github.com/metrotranscom/doorway/assets/51137263/116e14f5-d1d7-4d99-93c6-a8caba95b8eb)

clicking clear all filters
![after](https://github.com/metrotranscom/doorway/assets/51137263/6c7bba5d-9d33-4187-b22b-ebe3c0c7f4b9)


- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Please include a summary of the change and which issue(s) is addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
