### PR TITLE
feat: scroll bottom instead of top of listing card into view

### DIFF
--- a/sites/public/src/components/listings/ListingsMap.tsx
+++ b/sites/public/src/components/listings/ListingsMap.tsx
@@ -104,11 +104,11 @@ const ListingsMap = (props: ListingsMapProps) => {
                   props.setShowListingsList(true)
                   setTimeout(() => {
                     const element = document.getElementsByClassName("listings-row")[marker.key - 1]
-                    element.scrollIntoView()
+                    element.scrollIntoView(false)
                   }, 1)
                 } else {
                   const element = document.getElementsByClassName("listings-row")[marker.key - 1]
-                  element.scrollIntoView()
+                  element.scrollIntoView(false)
                 }
               }
             }}


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes issues related to how listings are displayed on mobile when a map pin is displayed by scrolling the appropriate listing to the bottom of the page, not the top. The behavior of clicking on a map pin on mobile was broken when the footer was added back to the listings page and looked like this, putting the listing at the top and including the footer
![image](https://github.com/metrotranscom/doorway/assets/67125998/b64d12f7-e400-48a0-bb91-4cc8ea426a38)

By passing false for the alignToTop input, now the listing card is aligned at the bottom of the page. Now when a map pin is clicked on, either from the hybrid view or from the map view, the map is still visible and the listings list is scrolled to the listing card, aligned with the bottom.
![image](https://github.com/metrotranscom/doorway/assets/67125998/06c7c321-cb92-4e29-a38a-276a58da88c1)
This kills two birds with one stone because the "See details" button is always visible now. The downside is that for listings with many bedroom sizes, the listing name is cropped off in the initial view. I personally prefer this tradeoff.
![image](https://github.com/metrotranscom/doorway/assets/67125998/90836f18-134f-4514-bc96-3b9bf902afd9)

## How Can This Be Tested/Reviewed?

- On mobile, go to the listings page.
- Click on a map pin. This should still show the map in the top half and the listings list in the bottom half, and the "see details" button should be visible at the bottom of the page.
- Try that again with different listings to see the display for listings with several bedroom sizes.
- Swipe the listings list component down to go to the listings map.
- Click on a map pin and verify the display looks the same.

