### PR TITLE
feat: add extra margin in application section for paper application

### DIFF
--- a/sites/public/src/components/listing/GetApplication.tsx
+++ b/sites/public/src/components/listing/GetApplication.tsx
@@ -104,7 +104,7 @@ const GetApplication = (props: ApplicationsProps) => {
             styleType={
               !props.preview && props.onlineApplicationURL ? AppearanceStyleType.primary : undefined
             }
-            className="w-full mb-2"
+            className="w-full mb-2 mt-4"
             onClick={toggleDownload}
             disabled={props.preview}
           >


### PR DESCRIPTION
# Pull Request Template

## Description

Increase the spacing in between text and button for the application section of the listing page when there is a paper application.

Before: 
![image](https://github.com/metrotranscom/doorway/assets/67125998/c84ea8ce-e72f-46b3-b3d2-325757537359)

After: 
![image](https://github.com/metrotranscom/doorway/assets/67125998/bfc8c0fb-a790-4f5d-9b61-7a158d3e3420)

## How Can This Be Tested/Reviewed?

I don't have any seeded listings with paper applications so I made the change directly on dev to test it. There is also a GetApplication component in UIC https://github.com/metrotranscom/doorway/blob/main/doorway-ui-components/src/page_components/listing/listing_sidebar/GetApplication.tsx but that is not what is used, the listing view component uses the GetApplication component from the public site.
