### PR TITLE
245/filter translations

### DIFF
--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import { ListingSearchParams, buildSearchString } from "../../../lib/listings/search"
 import {
   Modal,
@@ -62,6 +62,29 @@ export function LandingSearch(props: LandingSearchProps) {
     // console.log(`${name} has been set to ${value}`) // uncomment to debug
   }
 
+  const bedroomOptions: FormOption[] = [
+    {
+      label: t("listings.unitTypes.any"),
+      value: null,
+    },
+    {
+      label: t("listings.unitTypes.studio"),
+      value: "0",
+    },
+    {
+      label: "1",
+      value: "1",
+    },
+    {
+      label: "2",
+      value: "2",
+    },
+    {
+      label: "3+",
+      value: "3",
+    },
+  ]
+
   const mkCountyFields = (counties: FormOption[]): FieldSingle[] => {
     const countyFields: FieldSingle[] = [] as FieldSingle[]
 
@@ -71,6 +94,10 @@ export function LandingSearch(props: LandingSearchProps) {
       selected[label] = true
     })
     let check = false
+    const dahliaNote = `(${t(
+      "filter.goToDahlia"
+    )} <a href="https://housing.sfgov.org/" target="_blank">DAHLIA</a>)`
+
     counties.forEach((county, idx) => {
       // FieldGroup uses the label attribute to check for selected inputs.
       check = selected[county.label] !== undefined
@@ -85,7 +112,7 @@ export function LandingSearch(props: LandingSearchProps) {
         defaultChecked: check,
         disabled: county.isDisabled || false,
         doubleColumn: county.doubleColumn || false,
-        note: county.labelNoteHTML || "",
+        note: county.label === "San Francisco" ? dahliaNote : county.labelNoteHTML || "",
       } as FieldSingle)
     })
     return countyFields
@@ -100,7 +127,7 @@ export function LandingSearch(props: LandingSearchProps) {
         <div className={styles["input-section_title"]}>{t("t.bedrooms")}</div>
         <ButtonGroup
           name="bedrooms"
-          options={props.bedrooms}
+          options={bedroomOptions}
           onChange={updateValue}
           value={formValues.bedrooms}
           className="bg-accent-cool-light py-0 px-0 md:pl-12 landing-search-button-group"

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -15,6 +15,7 @@ import { useForm } from "react-hook-form"
 import { LinkButton, t } from "@bloom-housing/ui-components"
 import styles from "./LandingSearch.module.scss"
 import { FormOption } from "./ListingsSearchModal"
+import { numericSearchFieldGenerator } from "./helpers"
 
 type LandingSearchProps = {
   bedrooms: FormOption[]
@@ -62,7 +63,7 @@ export function LandingSearch(props: LandingSearchProps) {
     // console.log(`${name} has been set to ${value}`) // uncomment to debug
   }
 
-  const bedroomOptions: FormOption[] = [
+  const translatedBedroomOptions: FormOption[] = [
     {
       label: t("listings.unitTypes.any"),
       value: null,
@@ -71,19 +72,8 @@ export function LandingSearch(props: LandingSearchProps) {
       label: t("listings.unitTypes.studio"),
       value: "0",
     },
-    {
-      label: "1",
-      value: "1",
-    },
-    {
-      label: "2",
-      value: "2",
-    },
-    {
-      label: "3+",
-      value: "3",
-    },
   ]
+  const bedroomOptions = [...numericSearchFieldGenerator(1, 3), translatedBedroomOptions]
 
   const mkCountyFields = (counties: FormOption[]): FieldSingle[] => {
     const countyFields: FieldSingle[] = [] as FieldSingle[]

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -73,7 +73,10 @@ export function LandingSearch(props: LandingSearchProps) {
       value: "0",
     },
   ]
-  const bedroomOptions = [...numericSearchFieldGenerator(1, 3), translatedBedroomOptions]
+  const bedroomOptions: FormOption[] = [
+    ...translatedBedroomOptions,
+    ...numericSearchFieldGenerator(1, 3),
+  ]
 
   const mkCountyFields = (counties: FormOption[]): FieldSingle[] => {
     const countyFields: FieldSingle[] = [] as FieldSingle[]

--- a/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
@@ -143,83 +143,6 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
   )
 }
 
-// Input values/options below are passed into the form to make it easier to
-// reuse it in multiple places. This may not ultimately be necessary, but it's
-// easier to add it in at the beginning than it is to try to add make the change
-// later.
-const bedroomOptionsForLandingPage: FormOption[] = [
-  {
-    label: "Any",
-    value: null,
-  },
-  {
-    label: "Studio",
-    value: "0",
-  },
-  {
-    label: "1",
-    value: "1",
-  },
-  {
-    label: "2",
-    value: "2",
-  },
-  {
-    label: "3+",
-    value: "3",
-  },
-]
-
-const bedroomOptions: FormOption[] = [
-  {
-    label: "Any",
-    value: null,
-  },
-  {
-    label: "Studio",
-    value: "0",
-  },
-  {
-    label: "1",
-    value: "1",
-  },
-  {
-    label: "2",
-    value: "2",
-  },
-  {
-    label: "3",
-    value: "3",
-  },
-  {
-    label: "4+",
-    value: "4",
-  },
-]
-
-const bathroomOptions: FormOption[] = [
-  {
-    label: "Any",
-    value: null,
-  },
-  {
-    label: "1",
-    value: "1",
-  },
-  {
-    label: "2",
-    value: "2",
-  },
-  {
-    label: "3",
-    value: "3",
-  },
-  {
-    label: "4+",
-    value: "4",
-  },
-]
-
 const locations: FormOption[] = [
   {
     label: "Alameda",
@@ -257,15 +180,8 @@ const locations: FormOption[] = [
     label: "San Francisco",
     value: "San Francisco",
     isDisabled: true,
-    labelNoteHTML: `(For San Francisco listings, please go to <a href="https://housing.sfgov.org/" target="_blank">DAHLIA</a>)`,
     doubleColumn: true,
   },
 ]
 
-export {
-  ListingsSearchCombined as default,
-  locations,
-  bedroomOptions,
-  bedroomOptionsForLandingPage,
-  bathroomOptions,
-}
+export { ListingsSearchCombined as default, locations }

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -160,8 +160,14 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
     },
   ]
 
-  const bedroomOptions = [...translatedBedroomOptions, ...numericSearchFieldGenerator(1, 4)]
-  const bathroomOptions = [...translatedBathroomOptions, ...numericSearchFieldGenerator(1, 4)]
+  const bedroomOptions: FormOption[] = [
+    ...translatedBedroomOptions,
+    ...numericSearchFieldGenerator(1, 4),
+  ]
+  const bathroomOptions: FormOption[] = [
+    ...translatedBathroomOptions,
+    ...numericSearchFieldGenerator(1, 4),
+  ]
   const mkCountyFields = (counties: FormOption[]): FieldSingle[] => {
     const countyFields: FieldSingle[] = [] as FieldSingle[]
 

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -11,6 +11,7 @@ import {
   FieldSingle,
 } from "@bloom-housing/doorway-ui-components"
 import { useForm } from "react-hook-form"
+import { numericSearchFieldGenerator } from "./helpers"
 
 const inputSectionStyle: React.CSSProperties = {
   margin: "0px 15px",
@@ -141,6 +142,26 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
     // console.log(`${name} has been set to ${value}`) // uncomment to debug
   }
 
+  const translatedBedroomOptions: FormOption[] = [
+    {
+      label: t("listings.unitTypes.any"),
+      value: null,
+    },
+    {
+      label: t("listings.unitTypes.studio"),
+      value: "0",
+    },
+  ]
+
+  const translatedBathroomOptions: FormOption[] = [
+    {
+      label: t("listings.unitTypes.any"),
+      value: null,
+    },
+  ]
+
+  const bedroomOptions = [...translatedBedroomOptions, ...numericSearchFieldGenerator(1, 4)]
+  const bathroomOptions = [...translatedBathroomOptions, ...numericSearchFieldGenerator(1, 4)]
   const mkCountyFields = (counties: FormOption[]): FieldSingle[] => {
     const countyFields: FieldSingle[] = [] as FieldSingle[]
 
@@ -150,6 +171,9 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
       selected[label] = true
     })
     let check = false
+    const dahliaNote = `(${t(
+      "filter.goToDahlia"
+    )} <a href="https://housing.sfgov.org/" target="_blank">DAHLIA</a>)`
     counties.forEach((county, idx) => {
       // FieldGroup uses the label attribute to check for selected inputs.
       check = selected[county.label] !== undefined
@@ -164,7 +188,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
         defaultChecked: check,
         disabled: county.isDisabled || false,
         doubleColumn: county.doubleColumn || false,
-        note: county.labelNoteHTML || "",
+        note: county.label === "San Francisco" ? dahliaNote : county.labelNoteHTML || "",
       } as FieldSingle)
     })
     return countyFields
@@ -194,7 +218,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
         <div style={sectionTitle}>{t("t.bedrooms")}</div>
         <ButtonGroup
           name="bedrooms"
-          options={props.bedrooms}
+          options={bedroomOptions}
           onChange={updateValue}
           value={formValues.bedrooms}
           spacing={ButtonGroupSpacing.left}
@@ -205,7 +229,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
         <div style={sectionTitle}>{t("t.bathrooms")}</div>
         <ButtonGroup
           name="bathrooms"
-          options={props.bathrooms}
+          options={bathroomOptions}
           onChange={updateValue}
           value={formValues.bathrooms}
           spacing={ButtonGroupSpacing.left}

--- a/sites/public/src/components/listings/search/helpers.ts
+++ b/sites/public/src/components/listings/search/helpers.ts
@@ -1,0 +1,19 @@
+// ie. [{label : "1" value: "1"}, {label : "2+" value: "2"} if includeMore is true
+export const numericSearchFieldGenerator = (start: number, end: number, includeMore = true) => {
+  const fieldValues = []
+  for (let i = start; i <= end; i++) {
+    const numString = i.toString()
+    if (i < start || !includeMore) {
+      fieldValues.push({
+        label: numString,
+        value: numString,
+      })
+    } else {
+      fieldValues.push({
+        label: `${numString}+`,
+        value: numString,
+      })
+    }
+  }
+  return fieldValues
+}

--- a/sites/public/src/components/listings/search/helpers.ts
+++ b/sites/public/src/components/listings/search/helpers.ts
@@ -9,7 +9,7 @@ export const numericSearchFieldGenerator = (
   const fieldValues = []
   for (let i = start; i <= end; i++) {
     const numString = i.toString()
-    if (i < start || !includeMore) {
+    if (i < end || !includeMore) {
       fieldValues.push({
         label: numString,
         value: numString,

--- a/sites/public/src/components/listings/search/helpers.ts
+++ b/sites/public/src/components/listings/search/helpers.ts
@@ -9,17 +9,10 @@ export const numericSearchFieldGenerator = (
   const fieldValues = []
   for (let i = start; i <= end; i++) {
     const numString = i.toString()
-    if (i < end || !includeMore) {
-      fieldValues.push({
-        label: numString,
-        value: numString,
-      })
-    } else {
-      fieldValues.push({
-        label: `${numString}+`,
-        value: numString,
-      })
-    }
+    fieldValues.push({
+      label: i < end || !includeMore ? numString : `${numString}+`,
+      value: numString,
+    })
   }
   return fieldValues
 }

--- a/sites/public/src/components/listings/search/helpers.ts
+++ b/sites/public/src/components/listings/search/helpers.ts
@@ -1,5 +1,11 @@
+import { FormOption } from "@bloom-housing/doorway-ui-components"
+
 // ie. [{label : "1" value: "1"}, {label : "2+" value: "2"} if includeMore is true
-export const numericSearchFieldGenerator = (start: number, end: number, includeMore = true) => {
+export const numericSearchFieldGenerator = (
+  start: number,
+  end: number,
+  includeMore = true
+): FormOption[] => {
   const fieldValues = []
   for (let i = start; i <= end; i++) {
     const numString = i.toString()

--- a/sites/public/src/pages/index.tsx
+++ b/sites/public/src/pages/index.tsx
@@ -19,10 +19,7 @@ import { fetchJurisdictionByName } from "../lib/hooks"
 import { runtimeConfig } from "../lib/runtime-config"
 import { LandingSearch } from "../components/listings/search/LandingSearch"
 import { FormOption } from "../components/listings/search/ListingsSearchModal"
-import {
-  locations,
-  bedroomOptionsForLandingPage,
-} from "../components/listings/search/ListingsSearchCombined"
+import { locations } from "../components/listings/search/ListingsSearchCombined"
 
 interface IndexProps {
   jurisdiction: Jurisdiction
@@ -202,7 +199,6 @@ export async function getServerSideProps() {
   return {
     props: {
       jurisdiction,
-      bedrooms: bedroomOptionsForLandingPage,
       counties: locations,
     },
   }

--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -4,8 +4,6 @@ import { t } from "@bloom-housing/ui-components"
 import { MetaTags } from "../components/shared/MetaTags"
 import ListingsSearchCombined, {
   locations,
-  bedroomOptions,
-  bathroomOptions,
 } from "../components/listings/search/ListingsSearchCombined"
 import { FormOption } from "../components/listings/search/ListingsSearchModal"
 import { runtimeConfig } from "../lib/runtime-config"
@@ -70,8 +68,6 @@ export async function getServerSideProps() {
       // show Bloom counties by default
       initialSearch:
         "counties:Alameda,Contra Costa,Marin,Napa,San Francisco,San Mateo,Santa Clara,Solano,Sonoma",
-      bedrooms: bedroomOptions,
-      bathrooms: bathroomOptions,
       locations: locations,
     },
   }


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #245 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR moves the translation strings within the bedroomOptions and bathroomOptions into the components for which they are used. Previously, the translation strings were loading incorrectly since the t function was called in isolation in a separate file and then passed within an object via props into the component which doesn't follow the translation pattern used within bloom. 

Additionally, I noticed that most of these options were just generic number fields so I created a helper function that helps to reduce clutter within the component since they now include the bedroom and bathroom options.

Lastly, I felt comfortable using more of a one-off solution for the Dahlia note since I don't imagine it will be a broad pattern but if that assumption is incorrect, it could easily be brought into the components themselves. Just wanted to keep clutter to a minimum for now.
  
## How Can This Be Tested/Reviewed?

This can be tested by pulling this branch down locally
1) Start on the homepage and change the language
2) Notice that "Any", "Studio" and the Dahlia field note all have translations
3) Go to the listings page
4) Change the language and then open the filter form, checking for those same three translations
5) Repeat step 4 for each of the languages

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
