### PR TITLE
fix: align checkboxes

### DIFF
--- a/doorway-ui-components/src/forms/FieldGroup.scss
+++ b/doorway-ui-components/src/forms/FieldGroup.scss
@@ -5,3 +5,9 @@
     box-shadow: 0 0 0 1px var(--bloom-color-primary-lighter);
   }
 }
+
+.doorway-field-group {
+  input[type="checkbox"] + label::before {
+    line-height: 1rem;
+  }
+}

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -153,7 +153,7 @@ export function LandingSearch(props: LandingSearchProps) {
           fields={countyFields}
           onChange={updateValueMulti}
           register={register}
-          fieldGroupClassName="county-checkbox-group grid grid-cols-2 md:pl-16 "
+          fieldGroupClassName="county-checkbox-group doorway-field-group grid grid-cols-2 md:pl-16 "
           fieldLabelClassName="text-primary-dark font-medium tracking-wider text-2xs uppercase"
         />
       </div>

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -285,7 +285,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
           fields={countyFields}
           onChange={updateValueMulti}
           register={register}
-          fieldGroupClassName="grid grid-cols-2"
+          fieldGroupClassName="doorway-field-group grid grid-cols-2"
           fieldLabelClassName="text-primary-dark font-medium tracking-wider text-2xs uppercase"
         />
       </div>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses [#18](https://github.com/bloom-housing/Bloom-Doorway/issues/18)

- [x] This change addresses the issue in full

## Description

Currently, the checkboxes on the home page in the search box and the listings page in the filter drawer have their label text misaligned.

## How Can This Be Tested/Reviewed?

The label text on these two forms should be centered with the check. The cause was new custom styles added to the checkboxes. The long term solution would be CSS variable overrides once Doorway is on UIC.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
