### PR TITLE
fix: rent formatting hack

### DIFF
--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { ListingSearchParams, buildSearchString } from "../../../lib/listings/search"
 import {
   Modal,
@@ -113,7 +113,18 @@ export function LandingSearch(props: LandingSearchProps) {
   const countyFields = mkCountyFields(props.counties)
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register } = useForm()
+  const { register, getValues, setValue, watch } = useForm()
+
+  const monthlyRentFormatted = watch("monthlyRent")
+  useEffect(() => {
+    if (monthlyRentFormatted) {
+      const currencyFormatting = /,|\.\d{2}/g
+      const monthlyRentRaw = monthlyRentFormatted.replaceAll(currencyFormatting, "")
+      updateValue("monthlyRent", monthlyRentRaw)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monthlyRentFormatted])
+
   return (
     <Card className="bg-accent-cool-light">
       <div className={styles["input-section"]}>
@@ -131,18 +142,17 @@ export function LandingSearch(props: LandingSearchProps) {
       <div className={styles["input-section"]}>
         <div className={styles["input-section_title"]}>{t("t.maxMonthlyRent")}</div>
         <Field
-          type="number"
+          type="currency"
+          id="monthlyRent"
           name="monthlyRent"
+          register={register}
+          setValue={setValue}
+          getValues={getValues}
           defaultValue={formValues.monthlyRent}
           placeholder="$"
           className="doorway-field p-0 md:pl-6"
           inputClassName="rent-input"
           labelClassName="input-label"
-          inputMode="numeric"
-          pattern="\d*"
-          onChange={(e: React.FormEvent<HTMLInputElement>) => {
-            updateValue("monthlyRent", e.currentTarget.value)
-          }}
         />
       </div>
 

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -21,7 +21,9 @@ type LandingSearchProps = {
   bedrooms: FormOption[]
   counties: FormOption[]
 }
-
+// TODO: Refactor LandingSearch to utilize react-hook-form. It is currently using a custom form object and custom valueSetters
+// which is mostly functional but fails to leverage UI-C's formatting, accessibility and any other future improvements to the
+// package. To expedite development and avoid excessive workarounds (ie. line 121), a full form refactor should be completed.
 export function LandingSearch(props: LandingSearchProps) {
   // We hold a map of county label to county FormOption
   const countyLabelMap = {}
@@ -115,6 +117,7 @@ export function LandingSearch(props: LandingSearchProps) {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, getValues, setValue, watch } = useForm()
 
+  // workaround to leverage UI-C's currency formatting without full refactor
   const monthlyRentFormatted = watch("monthlyRent")
   useEffect(() => {
     if (monthlyRentFormatted) {

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -202,7 +202,27 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
   const countyFields = mkCountyFields(props.counties)
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register } = useForm()
+  const { register, getValues, setValue, watch } = useForm()
+  const monthlyRentFormatted = watch("monthlyRent")
+  const minRentFormatted = watch("minRent")
+  const currencyFormatting = /,|\.\d{2}/g
+
+  useEffect(() => {
+    if (minRentFormatted) {
+      const minRentRaw = minRentFormatted.replaceAll(currencyFormatting, "")
+      updateValue("minRent", minRentRaw)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [minRentFormatted])
+
+  useEffect(() => {
+    if (monthlyRentFormatted) {
+      const monthlyRentRaw = monthlyRentFormatted.replaceAll(currencyFormatting, "")
+      updateValue("monthlyRent", monthlyRentRaw)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monthlyRentFormatted])
+
   return (
     <Modal
       open={props.open}
@@ -245,35 +265,33 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
         <div style={sectionTitleTopBorder}>{t("t.monthlyRent")}</div>
         <div style={rentStyle}>
           <Field
-            type="number"
+            type="currency"
             name="minRent"
+            id="minRent"
+            register={register}
+            setValue={setValue}
+            getValues={getValues}
             defaultValue={formValues.minRent}
             placeholder={t("t.minPrice")}
             className="doorway-field"
             inputClassName="rent-input"
             labelClassName="input-label"
-            inputMode="numeric"
-            pattern="\d*"
-            onChange={(e: React.FormEvent<HTMLInputElement>) => {
-              updateValue("minRent", e.currentTarget.value)
-            }}
           ></Field>
           <div style={hyphenContainerStyle}>
             <div style={hyphenStyle}>-</div>
           </div>
           <Field
-            type="number"
+            type="currency"
             name="monthlyRent"
+            id="monthlyRent"
+            register={register}
+            setValue={setValue}
+            getValues={getValues}
             defaultValue={formValues.monthlyRent}
             placeholder={t("t.maxPrice")}
             className="doorway-field"
             inputClassName="rent-input"
             labelClassName="input-label"
-            inputMode="numeric"
-            pattern="\d*"
-            onChange={(e: React.FormEvent<HTMLInputElement>) => {
-              updateValue("monthlyRent", e.currentTarget.value)
-            }}
           ></Field>
         </div>
       </div>

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -66,7 +66,9 @@ type ListingsSearchModalProps = {
   onClose: () => void
   onFilterChange: (count: number) => void
 }
-
+// TODO: Refactor ListingSearchModal to utilize react-hook-form. It is currently using a custom form object and custom valueSetters
+// which is mostly functional but fails to leverage UI-C's formatting, accessibility and any other future improvements to the
+// package. To expedite development and avoid excessive workarounds, a full form refactor should be completed.
 export function ListingsSearchModal(props: ListingsSearchModalProps) {
   const searchString = props.searchString || ""
 

--- a/sites/public/src/components/listings/search/ListingsSearchModal.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModal.tsx
@@ -66,9 +66,9 @@ type ListingsSearchModalProps = {
   onClose: () => void
   onFilterChange: (count: number) => void
 }
-// TODO: Refactor ListingSearchModal to utilize react-hook-form. It is currently using a custom form object and custom valueSetters
+// TODO: Refactor ListingsSearchModal to utilize react-hook-form. It is currently using a custom form object and custom valueSetters
 // which is mostly functional but fails to leverage UI-C's formatting, accessibility and any other future improvements to the
-// package. To expedite development and avoid excessive workarounds, a full form refactor should be completed.
+// package. To expedite development and avoid excessive workarounds (ie. lines 213, 221), a full form refactor should be completed.
 export function ListingsSearchModal(props: ListingsSearchModalProps) {
   const searchString = props.searchString || ""
 
@@ -209,6 +209,7 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
   const minRentFormatted = watch("minRent")
   const currencyFormatting = /,|\.\d{2}/g
 
+  // workarounds to leverage UI-C's currency formatting without full refactor
   useEffect(() => {
     if (minRentFormatted) {
       const minRentRaw = minRentFormatted.replaceAll(currencyFormatting, "")


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses [#15](https://github.com/bloom-housing/Bloom-Doorway/issues/15)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

These changes address the fact that rent fields were accepting the negative sign and "e" along with changing via scroll. Also, it was allowing decimal points but that would also break the filtering results.

**Disclaimer:** This is undoubtedly a hacky approach and a more sustainable approach should be implemented [here](https://github.com/bloom-housing/Bloom-Doorway/issues/16). The difficulty came from the fact that our currency formatting utilizes react hook forms but these two forms were made with a custom react state form object and their own updateValue functions. This was the quickest way I found to integrate our formatting with their value setting. Other approaches such as introducing the formatting manually within the onChange function still allows the characters to be typed in the field OR having both react hook forms setValue and their onChange proved that the setValue overrides the onChange. Lastly, I considered handling this solely via react hook forms but that resulted in either too much time required to update the styled button groups to field groups since the typing has to be refactored as well or having two entirely separate form objects which felt more unnatural.

## How Can This Be Tested/Reviewed?

This can be tested by pulling this down locally, go to the landing page, trying to enter negative values or letters unsuccessfully, and noticing how the rent formats when clicking out of the field. Then click view listings and observe that the results and filter reflect the previously entered field. Then go into the listings search modal and perform the same tests.

Note: There's an edge case that if you type in a value like 1200.23 into the landing page, it will show results for 1200 and when opening the listings search modal it will only show 1200. The url search doesn't currently support decimals and it didn't seem worth the time to handle this case.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
