### PR TITLE
fix: change ami update migration

### DIFF
--- a/backend/core/src/migration/1692890494691-ami-120-updates.ts
+++ b/backend/core/src/migration/1692890494691-ami-120-updates.ts
@@ -94,12 +94,14 @@ export class ami120Updates1692890494691 implements MigrationInterface {
         FROM ami_chart
         WHERE name='${amiUpdate.name}'`
       )
-      const combinedItems = [...currentItems, ...amiUpdate.items]
-      await queryRunner.query(
-        `UPDATE ami_chart 
+      if (currentItems[0]) {
+        const combinedItems = [...currentItems[0].items, ...amiUpdate.items]
+        await queryRunner.query(
+          `UPDATE ami_chart 
         SET items='${JSON.stringify(combinedItems)}'
         WHERE name='${amiUpdate.name}'`
-      )
+        )
+      }
     })
   }
   public async down(queryRunner: QueryRunner): Promise<void> {}

--- a/sites/public/cypress/e2e/pages/submit-application.spec.ts
+++ b/sites/public/cypress/e2e/pages/submit-application.spec.ts
@@ -2,13 +2,9 @@ import { coliseumApplication, minimalDataApplication } from "../../mockData/appl
 
 describe("Submit", function () {
   it("should submit an application for the Test: Coliseum listing", function () {
-    cy.submitApplication("1. [doorway] Test: Coliseum", coliseumApplication, false)
+    cy.submitApplication("[doorway] Test: Coliseum", coliseumApplication, false)
   })
   it("should submit a minimal application for the Test: Default, No Preferences", function () {
-    cy.submitApplication(
-      "3. [doorway] Test: Default, No Preferences",
-      minimalDataApplication,
-      false
-    )
+    cy.submitApplication("[doorway] Test: Default, No Preferences", minimalDataApplication, false)
   })
 })


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #311 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This fixes a small bug in the ami 120% script. The Select statement returns an array of items so we need to get the first one in order to get the correct "items".

Note: This migration has not run on production, but has on staging. I will delete the row for this migration in staging before merging

## How Can This Be Tested/Reviewed?

Since the AMI charts mentioned in the migration are not in the seeded data I'd recommend the following steps to test this.

- Go to main branch locally and go back one commit (Should not have `fix: add 120% ami info` commit on your machine)
- Do a reseed
- Pull in the code from this branch
- Change one of the names of the AMI in this new migration file to one we have in the seeding (e.g "San Jose TCAC 2021") 
- run `yarn db:migration:run`
- Check that the database has the updated fields. Or even easier is to start up the app and see if the new fields in the api chart you updated are visible in the 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
