### PR TITLE
fix: add show professional partners to build public

### DIFF
--- a/ci/buildspec/build_public.yml
+++ b/ci/buildspec/build_public.yml
@@ -38,6 +38,7 @@ phases:
         --build-arg "LANGUAGES=${LANGUAGES}"
         --build-arg "MAPBOX_TOKEN=${MAPBOX_TOKEN}"
         --build-arg "GTM_KEY=${GTM_KEY}"
+        --build-arg "SHOW_PROFESSIONAL_PARTNERS=$SHOW_PROFESSIONAL_PARTNERS"
         --target test
         -t sites/public:test
         .
@@ -60,6 +61,7 @@ phases:
         --build-arg "LANGUAGES=${LANGUAGES}"
         --build-arg "MAPBOX_TOKEN=${MAPBOX_TOKEN}"
         --build-arg "GTM_KEY=${GTM_KEY}"
+        --build-arg "SHOW_PROFESSIONAL_PARTNERS=$SHOW_PROFESSIONAL_PARTNERS"
         --target run
         -t sites/public:run-candidate
         .


### PR DESCRIPTION
Hopefully the last change needed all the professional partners flag flipped