### PR TITLE
fix: add last show professional partners spot

### DIFF
--- a/build/docker/Dockerfile.sites-generic
+++ b/build/docker/Dockerfile.sites-generic
@@ -117,6 +117,7 @@ ARG LANGUAGES
 ARG MAPBOX_TOKEN
 ARG GTM_KEY
 ARG FEATURE_LISTINGS_APPROVAL
+ARG SHOW_PROFESSIONAL_PARTNERS
 
 # We need to have this nested 2 layers deep due to hardcoded paths in package.json
 WORKDIR /app/sites/${SITE}


### PR DESCRIPTION
One location was missed when adding the `SHOW_PROFESSIONAL_PARTNERS` arg to the build step. I've tested this in the test pipeline and it successfully turned on the feature in the dev environment