### PR TITLE
fix: type fix for s3-file-service

### DIFF
--- a/backend/core/src/shared/uploads/aws/amazon-s3-file-service.ts
+++ b/backend/core/src/shared/uploads/aws/amazon-s3-file-service.ts
@@ -1,7 +1,13 @@
 import { BaseFileService } from "../base-file-service"
 import { ConfigInvalidEnumError, ConfigItemMissingError } from "../errors"
 import { FileUpload, FileServiceConfig, FileService } from "../types"
-import { S3Client, PutObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3"
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  StorageClass,
+  PutObjectCommandInput,
+} from "@aws-sdk/client-s3"
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
 
 enum UrlFormats {
@@ -70,7 +76,7 @@ export class AmazonS3FileService extends BaseFileService implements FileService 
     const rand = Math.round(Math.random() * 1000000)
     const path = `${prefix}/${rand}/${key}/${file.name}`
 
-    const request = {
+    const request: PutObjectCommandInput = {
       Bucket: this.bucket,
       Key: path,
       Body: file.contents,
@@ -79,7 +85,7 @@ export class AmazonS3FileService extends BaseFileService implements FileService 
 
       // The storage class to use
       // Could be an option later, but hardcode as STANDARD for now
-      StorageClass: "STANDARD",
+      StorageClass: StorageClass.STANDARD,
     }
 
     // We don't need the response


### PR DESCRIPTION
The latest release of @aws-sdk makes a typing change that breaks a place in our code. Specifically this commit: https://github.com/aws/aws-sdk-js-v3/commit/7d312220ce4d75c55a63e8ca1b3320fdb9bf152c changes the type from `StorageClass?: StorageClass | string;` to `StorageClass?: StorageClass;`

Due to the way Doorway is getting built for Docker it doesn't always grab the same version of dependencies that we expect. I plan on solving some of these issues with the improvements to the Doorway pipeline. But in the meantime here is a fix for this immediate issue to allow us the ability to release.