### PR TITLE
fix: get maps api key from server

### DIFF
--- a/sites/public/next.config.js
+++ b/sites/public/next.config.js
@@ -42,7 +42,6 @@ module.exports = withBundleAnalyzer(
     env: {
       backendApiBase: BACKEND_API_BASE, // this has to be set for tests
       backendProxyBase: process.env.BACKEND_PROXY_BASE,
-      googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY,
       listingsQuery: LISTINGS_QUERY,
       listingPhotoSize: process.env.LISTING_PHOTO_SIZE || "1302",
       mapBoxToken: MAPBOX_TOKEN,

--- a/sites/public/src/components/listings/ListingsList.tsx
+++ b/sites/public/src/components/listings/ListingsList.tsx
@@ -29,19 +29,21 @@ const ListingsList = (props: ListingsListProps) => {
   const infoCards =
     props.currentPage == props.lastPage || props.lastPage == 0 ? (
       <div>
-        <InfoCard
-          title={t("t.signUpForAlerts")}
-          subtitle={t("t.subscribeToListingAlerts")}
-          className="is-normal-primary-lighter"
-        >
-          <LinkButton
-            href={process.env.notificationsSignUpUrl}
-            newTab={true}
-            className="is-primary"
+        {process.env.notificationsSignUpUrl && (
+          <InfoCard
+            title={t("t.signUpForAlerts")}
+            subtitle={t("t.subscribeToListingAlerts")}
+            className="is-normal-primary-lighter"
           >
-            {t("t.signUp")}
-          </LinkButton>
-        </InfoCard>
+            <LinkButton
+              href={process.env.notificationsSignUpUrl}
+              newTab={true}
+              className="is-primary"
+            >
+              {t("t.signUp")}
+            </LinkButton>
+          </InfoCard>
+        )}
         <InfoCard
           title={t("t.needHelp")}
           subtitle={t("t.emergencyShelter")}

--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -6,6 +6,7 @@ import ListingsSearchCombined, {
   locations,
 } from "../components/listings/search/ListingsSearchCombined"
 import { FormOption } from "../components/listings/search/ListingsSearchModal"
+import { runtimeConfig } from "../lib/runtime-config"
 
 import Layout from "../layouts/application"
 
@@ -27,7 +28,6 @@ export default function ListingsPage(props: ListingsProps) {
   const listingsEndpoint = `${process.env.backendProxyBase || process.env.backendApiBase}${
     process.env.listingsQuery
   }`
-  const googleMapsApiKey = process.env.googleMapsApiKey
 
   // override the search value if present in url
   if (searchParam) {
@@ -42,7 +42,7 @@ export default function ListingsPage(props: ListingsProps) {
       <MetaTags title={t("nav.siteTitle")} image={metaImage} description={metaDescription} />
       <ListingsSearchCombined
         listingsEndpoint={listingsEndpoint}
-        googleMapsApiKey={googleMapsApiKey}
+        googleMapsApiKey={props.googleMapsApiKey}
         searchString={searchString}
         bedrooms={props.bedrooms}
         bathrooms={props.bathrooms}
@@ -50,4 +50,13 @@ export default function ListingsPage(props: ListingsProps) {
       />
     </Layout>
   )
+}
+
+export function getServerSideProps() {
+  return {
+    props: {
+      listingsEndpoint: runtimeConfig.getListingServiceUrl(),
+      googleMapsApiKey: runtimeConfig.getGoogleMapsApiKey(),
+    },
+  }
 }


### PR DESCRIPTION
The map on the listings page of Doorway dev and staging stopped working after the most recent changes.

This is because we are not setting the google maps api key as a build env variable in the build step but rather just a runtime env variable. The latest change is now looking for the api key in a place that can only read the build time variables.

This change reverts the part of the change that is causing this. Ideally we would have all env variables be only runtime, but that will be a bigger endeavor 

How to test:
The listings page should work the same it usually does and the map should appear
