### PR TITLE
fix: map images correctly for external

### DIFF
--- a/tasks/import-listings/src/etl/transform/map.ts
+++ b/tasks/import-listings/src/etl/transform/map.ts
@@ -167,7 +167,9 @@ export const defaultMap: RecordMap = {
     if (listing.listingImages) {
       listingImageData = listing.listingImages
       // `assets` (type: Asset) has to be mapped to `images` (type: AssetUpdateDto)
-      listingImageData.image = listingImageData.assets
+      listingImageData.forEach((image, index) => {
+        listingImageData[index].image = image.assets
+      })
     }
     return jsonOrNull(listingImageData)
   },


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

With the latest mapping of the prisma object for the combined listing the images on the listings page don't work for external listings. This is due to the change from "images" to "assets". The latest change accounted for this, but did not consider that the images are in an array. so the "images" need to be set on each image rather than at the top level

## How Can This Be Tested/Reviewed?

- Make sure that the following env variables are set in backend/core and sites/public: `BLOOM_API_BASE=https://hba-0-3-alameda-staging.herokuapp.com`
- in backend/core run `yarn db:reseed:with-external:dev`. This will pull in the listings from hba staging environment
- Start up the app and on the listings page all external listings should have an image (unless they don't in the staging environment as well)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
