### PR TITLE
fix: remove reference to bloom_prisma

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
     "test:cov-ci": "yarn db:migration:run && jest --config ./test/jest-with-coverage.config.js --runInBand --logHeapUsage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "db:import-listings": "cd ../tasks/import-listings && yarn install && yarn build && yarn \"import:run:local:${IMPORT_ENV}\" && cd ../../api",
-    "db:resetup": "psql -c 'DROP DATABASE IF EXISTS bloom_prisma;' && psql -c 'CREATE DATABASE bloom_prisma;' && psql -d bloom_prisma -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'",
+    "db:resetup": "psql -c 'DROP DATABASE IF EXISTS bloom;' && psql -c 'CREATE DATABASE bloom;' && psql -d bloom -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'",
     "db:migration:run": "yarn prisma migrate deploy",
     "db:seed:production": "npx prisma db seed -- --environment production",
     "db:seed:staging": "npx prisma db seed -- --environment staging",

--- a/tasks/import-listings/package.json
+++ b/tasks/import-listings/package.json
@@ -9,7 +9,7 @@
     "test": "jest --runInBand --detectOpenHandles",
     "test:cov": "jest --coverage",
     "import:run": "node ./.build/index.js",
-    "import:run:local": "DATABASE_URL=\"${DATABASE_URL:-postgres://localhost/bloom_prisma}\" JURISDICTION_INCLUDE_LIST=\"${JURISDICTION_INCLUDE_LIST:-San Jose,San Mateo,Alameda}\" yarn import:run",
+    "import:run:local": "DATABASE_URL=\"${DATABASE_URL:-postgres://localhost/bloom}\" JURISDICTION_INCLUDE_LIST=\"${JURISDICTION_INCLUDE_LIST:-San Jose,San Mateo,Alameda}\" yarn import:run",
     "import:run:local:dev": "EXTERNAL_API_BASE=https://api.housingbayarea.bloom.exygy.dev LISTING_VIEW=full yarn import:run:local",
     "import:run:local:prod": "EXTERNAL_API_BASE=https://proxy.housingbayarea.org yarn import:run:local"
   },


### PR DESCRIPTION
Dev deployment in AWS is trying to use a database that doesn't exist