### PR TITLE
fix: move map layer initialization in migration

### DIFF
--- a/api/prisma/migrations/00_init/migration.sql
+++ b/api/prisma/migrations/00_init/migration.sql
@@ -697,14 +697,6 @@ CREATE TABLE "user_roles" (
       CONSTRAINT "PK_87b8888186ca9769c960e926870" PRIMARY KEY ("user_id")
 );
 
-CREATE TABLE "map_layers" (
-      "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
-      "name" TEXT NOT NULL,
-      "jurisdiction_id" TEXT NOT NULL,
-      "feature_collection" JSONB NOT NULL DEFAULT '{}',
-      CONSTRAINT "PK_d1bcb10041ba88ffea330dc10d9" PRIMARY KEY ("id")
-);
-
 -- CreateIndex
 CREATE UNIQUE INDEX "REL_5eb038a51b9cd6872359a687b1" ON "alternate_contact"("mailing_address_id");
 

--- a/api/prisma/migrations/01_change_to_prisma/migration.sql
+++ b/api/prisma/migrations/01_change_to_prisma/migration.sql
@@ -1691,5 +1691,3 @@ SET NOT NULL;
 ALTER TABLE "paper_applications"
 ALTER COLUMN "language"
 SET NOT NULL;
-
-ALTER TABLE "map_layers" RENAME CONSTRAINT "PK_d1bcb10041ba88ffea330dc10d9" TO "map_layers_pkey";

--- a/api/prisma/migrations/02_doorway_to_prisma/migration.sql
+++ b/api/prisma/migrations/02_doorway_to_prisma/migration.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "map_layers" (
+      "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+      "name" TEXT NOT NULL,
+      "jurisdiction_id" TEXT NOT NULL,
+      "feature_collection" JSONB NOT NULL DEFAULT '{}',
+      CONSTRAINT "map_layers_pkey" PRIMARY KEY ("id")
+);


### PR DESCRIPTION
Ran into this error when running migrations on staging 

```

Migration name: 01_change_to_prisma
--

Database error code: 42P01

Database error:
ERROR: relation "map_layers" does not exist

```
This is because the geocoding feature was never released on Doorway until now so we need to initialize it for the first time