### PR TITLE
fix: cover empty string case

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -602,7 +602,7 @@ export class ListingService implements OnModuleInit {
 
     let result = mapTo(Listing, listingRaw);
 
-    if (lang !== LanguagesEnum.en) {
+    if (lang && lang !== LanguagesEnum.en) {
       result = await this.translationService.translateListing(result, lang);
     }
 


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #529 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR fixes the issue where the listingsService.retrieve in account/applications.tsx was returning a 500 error from the listing translation services. This was traced back to language [here](https://github.com/metrotranscom/doorway/blob/9ffc4f20f00a6aba3f1b2d3f3affc7d9430ec331/backend/core/src/listings/listings.controller.ts#L117) being an empty string. When that empty string is passed to the service, it is treated as a value and therefore doesn't receive the default value of LanguageEnum.en that is set in the listing.service findOne call ([resource](https://www.studytonight.com/javascript/javascript-default-parameters#:~:text=As%20we%20can%20see%20in,values%20and%20are%20used%20as)). This PR adds an additional check to cover that empty string case.

I haven't yet determined why this header is being set as an empty string (doesn't occur in core) but given the urgency of this fix to test application flows, I think this temporary fix is appropriate

## How Can This Be Tested/Reviewed?

Sign in to an account on the public side, apply to a listing, 
Go to the my applications page and see the listing title and a functional "See Listing" button on the application card


Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
