### PR TITLE
fix: prevent helper text from showing on custom apps

### DIFF
--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -322,7 +322,7 @@ export const ListingView = (props: ListingProps) => {
 
   const getOnlineApplicationURL = () => {
     let onlineApplicationURL
-    let isExternal
+    let isCustomApp
     if (hasMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.Internal)) {
       let urlBase
       if (props.isExternal) {
@@ -332,14 +332,14 @@ export const ListingView = (props: ListingProps) => {
         urlBase = ""
       }
       onlineApplicationURL = `${urlBase}/applications/start/choose-language?listingId=${listing.id}&source=dhp`
-      isExternal = false
+      isCustomApp = false
     } else if (hasMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)) {
       onlineApplicationURL =
         getMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)
           ?.externalReference || ""
-      isExternal = true
+      isCustomApp = true
     }
-    return { url: onlineApplicationURL, isExternal }
+    return { url: onlineApplicationURL, isCustomApp }
   }
 
   const getPaperApplications = () => {
@@ -376,7 +376,7 @@ export const ListingView = (props: ListingProps) => {
     process.env.showMandatedAccounts &&
     initialStateLoaded &&
     !profile &&
-    !onlineApplicationURLInfo.isExternal
+    !onlineApplicationURLInfo.isCustomApp
 
   const applySidebar = () => (
     <>
@@ -401,7 +401,7 @@ export const ListingView = (props: ListingProps) => {
         preview={props.preview}
         listingName={listing.name}
         listingId={listing.id}
-        isExternal={props.isExternal ?? onlineApplicationURLInfo.isExternal}
+        isExternal={props.isExternal}
         listingStatus={listing.status}
       />
       {!(

--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -74,6 +74,7 @@ export default function ListingPage(props: ListingProps) {
         listing={listing as ListingViewListing}
         jurisdiction={props.jurisdiction}
         googleMapsApiKey={props.googleMapsApiKey}
+        isExternal={false}
       />
     </Layout>
   )

--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -43,6 +43,7 @@ export default function ListingPage(props: ListingProps) {
         preview={true}
         jurisdiction={props.jurisdiction}
         googleMapsApiKey={props.googleMapsApiKey}
+        isExternal={false}
       />
     </Layout>
   )


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #575 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This is a follow up to https://github.com/metrotranscom/doorway/pull/576. I undid some of the changes so the external helper text (specific to HBA external listings and not all custom applications) shows when appropriate.

## How Can This Be Tested/Reviewed?

This can be tested by taking an existing public listing adding a custom online application, and testing to see if the preview link and public link don't force you to sign in. Note, you must open these links in separate windows so you're not using the user profile of the logged in partner user. Additionally observe that no helper text appears in either case!

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
