### PR TITLE
Fix: Edit Application Fails to Render

### DIFF
--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -375,7 +375,7 @@ export const mapApiToForm = (applicationData: ApplicationUpdate, listing: Listin
         applicationData?.accessibility && applicationData?.accessibility[feature] === true
     )
 
-    if (demographics.spokenLanguage.startsWith("notListed:")) {
+    if (demographics.spokenLanguage?.startsWith("notListed:")) {
       const [spokenLanguage, customValue] = demographics.spokenLanguage.split(":")
       demographics.spokenLanguage = spokenLanguage
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses [#issue](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/632)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
Attempting to edit an applications fails to render the edit form page and displays page not found and an error message. This is caused by an if statement checking on `demographics.spokenLanguage` which may not be set at the time of edit. By allowing for spokenLanguage to be null, the edit page correctly renders.

## How Can This Be Tested/Reviewed?
Sign into partners site, navigate to a listing with applications submitted or submit an application of any type as long as spoken language is not set, go to the listings applications tab, click on an application, click `Edit`, edit form page should render.

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.
All partners unit and e2e tests ran and passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
