### PR TITLE
Fix: Agree To Terms Saves Correctly

### DIFF
--- a/sites/public/src/pages/applications/review/terms.tsx
+++ b/sites/public/src/pages/applications/review/terms.tsx
@@ -42,7 +42,7 @@ const ApplicationTerms = () => {
   const { register, handleSubmit, errors } = useForm()
   const onSubmit = (data) => {
     setSubmitting(true)
-    const acceptedTerms = data.agree === "agree"
+    const acceptedTerms = data.agree
     conductor.currentStep.save({ acceptedTerms })
     application.acceptedTerms = acceptedTerms
     application.completedSections = 6


### PR DESCRIPTION
634

# Pull Request Template

## Issue Overview

This PR addresses [#issue](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/634)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
`data.agree` was already a boolean so comparing it to a string caused the new variable to always be false. Should assign the existing boolean to the new variable for sending to the api.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.
Go through the online application flow, at the last step open up network tab, agree to the terms and submit, check that the submit call had `acceptedTerms` set to `true` and that the response has the same, confirm in the db that it is set correctly.

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.
Manually tested and ran public side unit and e2e tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
