### PR TITLE
feat: makes the pass key a contingent header

### DIFF
--- a/sites/partners/src/pages/api/adapter/[...backendUrl].ts
+++ b/sites/partners/src/pages/api/adapter/[...backendUrl].ts
@@ -17,16 +17,20 @@ const zipEndpoints = ["listings/csv"]
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const jar = new CookieJar()
+  const headers: Record<string, string | string[]> = {
+    jurisdictionName: req.headers.jurisdictionname,
+    language: req.headers.language,
+    appUrl: req.headers.appurl,
+    "x-forwarded-for": req.headers["x-forwarded-for"] || "",
+  }
+
+  if (process.env.API_PASS_KEY) {
+    headers.passkey = process.env.API_PASS_KEY
+  }
   const axios = wrapper(
     axiosStatic.create({
       baseURL: process.env.BACKEND_API_BASE,
-      headers: {
-        jurisdictionName: req.headers.jurisdictionname,
-        language: req.headers.language,
-        appUrl: req.headers.appurl,
-        "x-forwarded-for": req.headers["x-forwarded-for"] || "",
-        passkey: process.env.API_PASS_KEY,
-      },
+      headers,
       paramsSerializer: (params) => {
         return qs.stringify(params)
       },

--- a/sites/partners/src/pages/api/adapter/upload.ts
+++ b/sites/partners/src/pages/api/adapter/upload.ts
@@ -25,15 +25,22 @@ export const config = {
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const jar = new CookieJar()
+
+  const headers: Record<string, string | string[]> = {
+    jurisdictionName: req.headers.jurisdictionname,
+    language: req.headers.language,
+    appUrl: req.headers.appurl,
+    "x-forwarded-for": req.headers["x-forwarded-for"] || "",
+  }
+
+  if (process.env.API_PASS_KEY) {
+    headers.passkey = process.env.API_PASS_KEY
+  }
+
   const axios = wrapper(
     axiosStatic.create({
       baseURL: process.env.BACKEND_API_BASE,
-      headers: {
-        jurisdictionName: req.headers.jurisdictionname,
-        language: req.headers.language,
-        appUrl: req.headers.appurl,
-        passkey: process.env.API_PASS_KEY,
-      },
+      headers,
       paramsSerializer: (params) => {
         return qs.stringify(params)
       },

--- a/sites/partners/src/pages/listings/[id]/edit.tsx
+++ b/sites/partners/src/pages/listings/[id]/edit.tsx
@@ -66,15 +66,17 @@ const EditListing = (props: { listing: Listing }) => {
 export async function getServerSideProps(context: { params: Record<string, string>; req: any }) {
   let response
   const backendUrl = `/listings/${context.params.id}`
+  const headers: Record<string, string> = {
+    "x-forwarded-for": context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
+  }
 
+  if (process.env.API_PASS_KEY) {
+    headers.passkey = process.env.API_PASS_KEY
+  }
   try {
     logger.info(`GET - ${backendUrl}`)
     response = await axios.get(`${process.env.backendApiBase}${backendUrl}`, {
-      headers: {
-        passkey: process.env.API_PASS_KEY,
-        "x-forwarded-for":
-          context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
-      },
+      headers,
     })
   } catch (e) {
     if (e.response) {

--- a/sites/partners/src/pages/listings/[id]/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/index.tsx
@@ -135,12 +135,16 @@ export async function getServerSideProps(context: { params: Record<string, strin
 
   try {
     logger.info(`GET - ${backendUrl}`)
+    const headers: Record<string, string> = {
+      "x-forwarded-for": context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
+    }
+
+    if (process.env.API_PASS_KEY) {
+      headers.passkey = process.env.API_PASS_KEY
+    }
+
     response = await axios.get(`${process.env.backendApiBase}${backendUrl}`, {
-      headers: {
-        passkey: process.env.API_PASS_KEY,
-        "x-forwarded-for":
-          context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
-      },
+      headers,
     })
   } catch (e) {
     if (e.response) {

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -167,13 +167,18 @@ export async function fetchJurisdictionByName(
       return jurisdiction
     }
 
+    const headers: Record<string, string> = {
+      "x-forwarded-for": req.headers["x-forwarded-for"] ?? req.socket.remoteAddress,
+    }
+
+    if (process.env.API_PASS_KEY) {
+      headers.passkey = process.env.API_PASS_KEY
+    }
+
     const jurisdictionRes = await axios.get(
       `${backendApiBase}/jurisdictions/byName/${jurisdictionName}`,
       {
-        headers: {
-          passkey: process.env.API_PASS_KEY,
-          "x-forwarded-for": req.headers["x-forwarded-for"] ?? req.socket.remoteAddress,
-        },
+        headers,
       }
     )
     jurisdiction = jurisdictionRes?.data

--- a/sites/public/src/pages/api/adapter/[...backendUrl].ts
+++ b/sites/public/src/pages/api/adapter/[...backendUrl].ts
@@ -14,16 +14,20 @@ import { logger } from "../../../logger"
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const jar = new CookieJar()
+  const headers: Record<string, string | string[]> = {
+    jurisdictionName: req.headers.jurisdictionname,
+    language: req.headers.language,
+    appUrl: req.headers.appurl,
+    "x-forwarded-for": req.headers["x-forwarded-for"] || "",
+  }
+
+  if (process.env.API_PASS_KEY) {
+    headers.passkey = process.env.API_PASS_KEY
+  }
   const axios = wrapper(
     axiosStatic.create({
       baseURL: process.env.BACKEND_API_BASE,
-      headers: {
-        jurisdictionName: req.headers.jurisdictionname,
-        language: req.headers.language,
-        appUrl: req.headers.appurl,
-        "x-forwarded-for": req.headers["x-forwarded-for"] || "",
-        passkey: process.env.API_PASS_KEY,
-      },
+      headers,
       paramsSerializer: (params) => {
         return qs.stringify(params)
       },

--- a/sites/public/src/pages/listing/[id].tsx
+++ b/sites/public/src/pages/listing/[id].tsx
@@ -21,12 +21,15 @@ export async function getServerSideProps(context: {
   const listingServiceUrl = runtimeConfig.getListingServiceUrl()
 
   try {
+    const headers: Record<string, string> = {
+      "x-forwarded-for": context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
+    }
+
+    if (process.env.API_PASS_KEY) {
+      headers.passkey = process.env.API_PASS_KEY
+    }
     response = await axios.get(`${listingServiceUrl}/${context.params.id}`, {
-      headers: {
-        passkey: process.env.API_PASS_KEY,
-        "x-forwarded-for":
-          context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
-      },
+      headers,
     })
   } catch (e) {
     return { notFound: true }

--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -131,14 +131,16 @@ export async function getServerSideProps(context: {
   const listingServiceUrl = runtimeConfig.getListingServiceUrl()
 
   try {
-    response = await axios.get(`${listingServiceUrl}/${context.params.id}`, {
-      headers: {
-        language: context.locale,
-        passkey: process.env.API_PASS_KEY,
+    const headers: Record<string, string> = {
+      "x-forwarded-for": context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
+      language: context.locale,
+    }
 
-        "x-forwarded-for":
-          context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
-      },
+    if (process.env.API_PASS_KEY) {
+      headers.passkey = process.env.API_PASS_KEY
+    }
+    response = await axios.get(`${listingServiceUrl}/${context.params.id}`, {
+      headers,
     })
   } catch (e) {
     return { notFound: true }

--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -56,12 +56,15 @@ export async function getServerSideProps(context: { params: Record<string, strin
   const listingServiceUrl = runtimeConfig.getListingServiceUrl()
 
   try {
+    const headers: Record<string, string> = {
+      "x-forwarded-for": context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
+    }
+
+    if (process.env.API_PASS_KEY) {
+      headers.passkey = process.env.API_PASS_KEY
+    }
     response = await axios.get(`${listingServiceUrl}/${context.params.id}`, {
-      headers: {
-        passkey: process.env.API_PASS_KEY,
-        "x-forwarded-for":
-          context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
-      },
+      headers,
     })
   } catch (e) {
     return { notFound: true }


### PR DESCRIPTION
This makes the api pass key header on the public and partner sites optional. They will only be sent if the api pass key env variable is present