### PR TITLE
fix: switch to HTML text inputs with numeric validation

### DIFF
--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
@@ -5,12 +5,13 @@ import { vouchersOrRentalAssistanceKeys } from "@bloom-housing/shared-helpers"
 import { useFormContext } from "react-hook-form"
 import { IncomePeriodEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
+import { fieldHasError } from "../../../../lib/helpers"
 
 const FormHouseholdIncome = () => {
   const formMethods = useFormContext()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, setValue, watch } = formMethods
+  const { errors, register, setValue, trigger, watch } = formMethods
 
   const incomeVouchersOptions = vouchersOrRentalAssistanceKeys.map((item) => ({
     id: item,
@@ -65,19 +66,22 @@ const FormHouseholdIncome = () => {
           <Grid.Cell>
             <Field
               id="incomeYear"
-              type="number"
+              type="text"
               name="incomeYear"
               label={t("application.details.annualIncome")}
               placeholder={t("t.enterAmount")}
               register={register}
               disabled={incomePeriodValue !== IncomePeriodEnum.perYear}
+              validation={{ pattern: /^[0-9]+$/ }}
+              error={fieldHasError(errors?.incomeYear)}
+              errorMessage={t("errors.numberError")}
             />
           </Grid.Cell>
 
           <Grid.Cell>
             <Field
               id="incomeMonth"
-              type="number"
+              type="text"
               name="incomeMonth"
               label={t("application.details.monthlyIncome")}
               placeholder={t("t.enterAmount")}

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -84,13 +84,13 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
           name={fieldName}
           label={t("t.minimumIncome")}
           register={register}
-          type="number"
+          type="text"
           prepend="$"
           readerOnly
           className={errors[fieldName] ? "error" : ""}
           error={errors[fieldName]}
           errorMessage={t("errors.requiredFieldError")}
-          validation={{ required: !!amiChartID }}
+          validation={{ required: !!amiChartID, pattern: /^[0-9]+$/ }}
           inputProps={{
             onChange: () => {
               clearErrors(fieldName)
@@ -450,7 +450,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                   placeholder={t("listings.unit.squareFootage")}
                   register={register}
                   readerOnly
-                  type="number"
+                  type="text"
+                  validation={{ pattern: /^[0-9]+$/ }}
+                  error={fieldHasError(errors?.sqFeet)}
+                  errorMessage={t("errors.numberError")}
                 />
               </FieldValue>
 
@@ -587,8 +590,11 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                       label={t("t.monthlyMinimumIncome")}
                       placeholder="0.00"
                       register={register}
-                      type="number"
+                      type="text"
                       prepend="$"
+                      validation={{ pattern: /^[0-9]+$/ }}
+                      error={fieldHasError(errors?.monthlyIncomeMin)}
+                      errorMessage={t("errors.numberError")}
                     />
                   </Grid.Cell>
 
@@ -599,8 +605,11 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                       label={t("listings.unit.monthlyRent")}
                       placeholder="0.00"
                       register={register}
-                      type="number"
+                      type="text"
                       prepend="$"
+                      validation={{ pattern: /^[0-9]+$/ }}
+                      error={fieldHasError(errors?.monthlyRent)}
+                      errorMessage={t("errors.numberError")}
                     />
                   </Grid.Cell>
                 </>
@@ -613,7 +622,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                     label={t("listings.unit.%incomeRent")}
                     placeholder={t("listings.unit.percentage")}
                     register={register}
-                    type="number"
+                    type="text"
+                    validation={{ pattern: /^[0-9]+$/ }}
+                    error={fieldHasError(errors?.monthlyRentAsPercentOfIncome)}
+                    errorMessage={t("errors.numberError")}
                   />
                 </Grid.Cell>
               )}

--- a/sites/partners/src/components/settings/PreferenceDrawer.tsx
+++ b/sites/partners/src/components/settings/PreferenceDrawer.tsx
@@ -700,10 +700,10 @@ const PreferenceDrawer = ({
                         name="radiusSize"
                         label={t("settings.preferenceValidatingAddress.howManyMiles")}
                         register={register}
-                        validation={{ required: true, min: 0 }}
+                        validation={{ required: true, min: 0, pattern: /^[0-9]+$/ }}
                         error={errors.radiusSize}
                         errorMessage={t("errors.requiredFieldError")}
-                        type="number"
+                        type="text"
                         readerOnly
                         defaultValue={optionData?.radiusSize ?? null}
                         dataTestId={"preference-option-radius-size"}


### PR DESCRIPTION
This PR addresses #658 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The working theory is the issue with numbers changing randomly in the unit editing is due to `input type="number"` weirdness around mouse/trackpad scrolling. This PR switches to `input type="text"` and uses React Hook Form validation to verify integer input.

## How Can This Be Tested/Reviewed?

Try editing units for a listing, income, or the miles radius on preferences.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
