### PR TITLE
fix: office hours in email template

### DIFF
--- a/api/src/views/confirmation.hbs
+++ b/api/src/views/confirmation.hbs
@@ -60,8 +60,10 @@
               {{listing.leasingAgentPhone}}<br />
               {{listing.leasingAgentEmail}}<br />
             </p>
-            <h3>{{t "leasingAgent.officeHours"}}</h3>
-            <p>{{listing.leasingAgentOfficeHours}}</p>
+            {{#if listing.leasingAgentOfficeHours}}
+              <h3>{{t "leasingAgent.officeHours"}}</h3>
+              <p>{{listing.leasingAgentOfficeHours}}</p>
+            {{/if}}
           </div>
         </td>
       </tr>


### PR DESCRIPTION
This PR addresses #653 
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

hides `office hours` section when no office hours available.
Tbh couldn't test it locally, but it seem fairly straightforward

## How Can This Be Tested/Reviewed?

Fill application for listing with office hours, and then without.
You should receive email with / without `office hours` section.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
