### PR TITLE
fix: use default value for accept TOS checkbox

### DIFF
--- a/sites/public/src/pages/create-account.tsx
+++ b/sites/public/src/pages/create-account.tsx
@@ -328,6 +328,9 @@ export default () => {
                         onChange={() => setChecked(!notChecked)}
                         className={accountStyles["create-account-terms-checkbox"]}
                         labelClassName={accountStyles["create-account-terms-label"]}
+                        inputProps={{
+                          defaultChecked: !notChecked,
+                        }}
                       />
                     </>
                   </Dialog.Content>


### PR DESCRIPTION
This PR addresses #664 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

passes default value to TOS checkbox input

## How Can This Be Tested/Reviewed?

On `http://localhost:3000/create-account` .
1. fill form 
2. press create account
3. check checkbox and close modal,
4. press create account

checkbox should have checkbox "checked" and ready to "finish"

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
