### PR TITLE
fix: include check for address type (#4136)

### DIFF
--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -381,6 +381,12 @@ export const ListingView = (props: ListingProps) => {
     !props.isExternal &&
     !props.preview
 
+  const submissionAddressExists =
+    listing.listingsApplicationMailingAddress ||
+    listing.applicationMailingAddressType === ApplicationAddressTypeEnum.leasingAgent ||
+    listing.listingsApplicationDropOffAddress ||
+    listing.applicationDropOffAddressType === ApplicationAddressTypeEnum.leasingAgent
+
   const applySidebar = () => (
     <>
       <GetApplication
@@ -407,10 +413,7 @@ export const ListingView = (props: ListingProps) => {
         isExternal={props.isExternal}
         listingStatus={listing.status}
       />
-      {!(
-        listing.status === ListingsStatusEnum.closed ||
-        !(listing.listingsApplicationMailingAddress || listing.listingsApplicationDropOffAddress)
-      ) && (
+      {listing.status !== ListingsStatusEnum.closed && submissionAddressExists && (
         <SubmitApplication
           applicationMailingAddress={getAddress(listing.applicationMailingAddressType, "mailIn")}
           applicationDropOffAddress={getAddress(listing.applicationDropOffAddressType, "dropOff")}


### PR DESCRIPTION
This PR addresses #4135

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the logic to show the submit application section to account for the mailing and dropoff addresses to be undefined but the address type is same as leasing agent.

## How Can This Be Tested/Reviewed?

Create a listing with "Are postmarks considered?" marked as Yes, a paper app attached, indicate a received by date & time, and with both the mailing address and the drop-off address marked as same as the leasingAgentAddress... the submit application section should show on the public side with the corresponding postmark information.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
