### PR TITLE
fix: hide do you work question

### DIFF
--- a/sites/public/cypress/e2e/pages/application/contact/address.spec.ts
+++ b/sites/public/cypress/e2e/pages/application/contact/address.spec.ts
@@ -35,7 +35,6 @@ describe("applications/contact/address", function () {
     cy.getByTestId("app-primary-address-zip").type("94112")
 
     cy.getByTestId("app-primary-contact-preference").eq(0).check()
-    cy.getByTestId("app-primary-work-in-region-no").check()
 
     cy.goNext()
     cy.getByTestId("app-found-address-label").should("be.visible")
@@ -56,7 +55,6 @@ describe("applications/contact/address", function () {
     cy.getByTestId("app-primary-address-zip").type("oqr8buoi@@hn")
 
     cy.getByTestId("app-primary-contact-preference").eq(0).check()
-    cy.getByTestId("app-primary-work-in-region-no").check()
 
     cy.goNext()
 

--- a/sites/public/cypress/e2e/pages/application/household/member.spec.ts
+++ b/sites/public/cypress/e2e/pages/application/household/member.spec.ts
@@ -21,11 +21,6 @@ describe("applications/household/member", function () {
     cy.getByTestId("app-household-member-address-street").should("be.visible")
   })
 
-  it("should show member work address if user indicates they work in the region", function () {
-    cy.getByTestId("app-household-member-work-in-region").eq(0).check()
-    cy.getByTestId("app-household-member-work-address-street").should("be.visible")
-  })
-
   it("should go back to members screen without adding current member when user cancels", function () {
     cy.getByID("app-household-member-cancel").click()
     cy.location("pathname").should("include", "/applications/household/add-members")

--- a/sites/public/cypress/support/commands.js
+++ b/sites/public/cypress/support/commands.js
@@ -144,27 +144,6 @@ Cypress.Commands.add("step2PrimaryApplicantAddresses", (application) => {
     cy.getByTestId("app-primary-contact-preference").eq(contactPreferenceIndex).check()
   })
 
-  if (application.applicant.workInRegion === "yes") {
-    cy.getByTestId("app-primary-work-in-region-yes").check()
-    cy.getByTestId("app-primary-work-address-street").type(
-      application.applicant.applicantWorkAddress.street
-    )
-    cy.getByTestId("app-primary-work-address-street2").type(
-      application.applicant.applicantWorkAddress.street2
-    )
-    cy.getByTestId("app-primary-work-address-city").type(
-      application.applicant.applicantWorkAddress.city
-    )
-    cy.getByTestId("app-primary-work-address-state").select(
-      application.applicant.applicantWorkAddress.state
-    )
-    cy.getByTestId("app-primary-work-address-zip").type(
-      application.applicant.applicantWorkAddress.zipCode
-    )
-  } else {
-    cy.getByTestId("app-primary-work-in-region-no").check()
-  }
-
   cy.goNext()
   cy.checkErrorAlert("not.exist")
   cy.checkErrorMessages("not.exist")
@@ -279,27 +258,6 @@ Cypress.Commands.add("step7AddHouseholdMembers", (application) => {
       )
     } else {
       cy.getByTestId("app-household-member-same-address").eq(0).check()
-    }
-
-    if (householdMember.workInRegion === "yes") {
-      cy.getByTestId("app-household-member-work-in-region").eq(0).check()
-      cy.getByTestId("app-household-member-work-address-street").type(
-        householdMember.householdMemberWorkAddress.street
-      )
-      cy.getByTestId("app-household-member-work-address-street2").type(
-        householdMember.householdMemberWorkAddress.street2
-      )
-      cy.getByTestId("app-household-member-work-address-city").type(
-        householdMember.householdMemberWorkAddress.city
-      )
-      cy.getByTestId("app-household-member-work-address-state").select(
-        householdMember.householdMemberWorkAddress.state
-      )
-      cy.getByTestId("app-household-member-work-address-zip").type(
-        householdMember.householdMemberWorkAddress.zipCode
-      )
-    } else {
-      cy.getByTestId("app-household-member-work-in-region").eq(1).check()
     }
 
     cy.getByTestId("app-household-member-relationship").select(householdMember.relationship)

--- a/sites/public/cypress/support/commands.js
+++ b/sites/public/cypress/support/commands.js
@@ -473,18 +473,7 @@ Cypress.Commands.add("step18Summary", (application, verify) => {
       id: "app-summary-applicant-address",
       fieldValue: `${application.applicant.applicantAddress.city}, ${application.applicant.applicantAddress.state} ${application.applicant.applicantAddress.zipCode}`,
     },
-    {
-      id: "app-summary-applicant-work-address",
-      fieldValue: application.applicant.applicantWorkAddress.street,
-    },
-    {
-      id: "app-summary-applicant-work-address",
-      fieldValue: application.applicant.applicantWorkAddress.street2,
-    },
-    {
-      id: "app-summary-applicant-work-address",
-      fieldValue: `${application.applicant.applicantWorkAddress.city}, ${application.applicant.applicantWorkAddress.state} ${application.applicant.applicantWorkAddress.zipCode}`,
-    },
+
     {
       id: "app-summary-contact-preference-type",
       fieldValue: application.contactPreferences[0],

--- a/sites/public/src/pages/applications/contact/address.tsx
+++ b/sites/public/src/pages/applications/contact/address.tsx
@@ -88,13 +88,12 @@ const ApplicationAddress = () => {
       application.additionalPhoneNumber = ""
       application.additionalPhoneNumberType = ""
     }
-    if (!application.applicant.workInRegion) {
-      application.applicant.applicantWorkAddress = blankApplication.applicant.applicantWorkAddress
-    }
     if (!application.sendMailToMailingAddress) {
       application.applicationsMailingAddress = blankApplication.applicationsMailingAddress
     }
-
+    if (!application.applicant.workInRegion) {
+      application.applicant.applicantWorkAddress = blankApplication.applicant.applicantWorkAddress
+    }
     conductor.sync()
 
     conductor.routeToNextOrReturnUrl()

--- a/sites/public/src/pages/applications/contact/address.tsx
+++ b/sites/public/src/pages/applications/contact/address.tsx
@@ -52,7 +52,6 @@ const ApplicationAddress = () => {
       additionalPhone: application.additionalPhone,
       "applicant.phoneNumberType": application.applicant.phoneNumberType,
       sendMailToMailingAddress: application.sendMailToMailingAddress,
-      "applicant.workInRegion": application.applicant.workInRegion,
       "applicant.applicantAddress.state": application.applicant.applicantAddress.state,
     },
     shouldFocusError: false,
@@ -91,9 +90,7 @@ const ApplicationAddress = () => {
     if (!application.sendMailToMailingAddress) {
       application.applicationsMailingAddress = blankApplication.applicationsMailingAddress
     }
-    if (!application.applicant.workInRegion) {
-      application.applicant.applicantWorkAddress = blankApplication.applicant.applicantWorkAddress
-    }
+
     conductor.sync()
 
     conductor.routeToNextOrReturnUrl()
@@ -109,7 +106,6 @@ const ApplicationAddress = () => {
   }
   const additionalPhone = watch("additionalPhone")
   const sendMailToMailingAddress = watch("sendMailToMailingAddress")
-  const workInRegion = watch("applicant.workInRegion")
   const clientLoaded = OnClientSide()
 
   const contactPreferencesOptions = contactPreferencesKeys?.map((item) => ({
@@ -500,150 +496,6 @@ const ApplicationAddress = () => {
                   dataTestId={"app-primary-contact-preference"}
                 />
               </fieldset>
-            </CardSection>
-
-            <CardSection>
-              <fieldset>
-                <legend
-                  className={`text__caps-spaced ${
-                    errors?.applicant?.workInRegion ? "text-alert" : ""
-                  }`}
-                >
-                  {t("application.contact.doYouWorkIn", {
-                    county:
-                      listing?.listingsBuildingAddress?.county || listing?.jurisdictions?.name,
-                  })}
-                </legend>
-
-                <Field
-                  className="mb-1"
-                  type="radio"
-                  id="workInRegionYes"
-                  name="applicant.workInRegion"
-                  label={t("t.yes")}
-                  register={register}
-                  validation={{ required: true }}
-                  error={errors?.applicant?.workInRegion}
-                  inputProps={{
-                    value: "yes",
-                    defaultChecked: application.applicant.workInRegion == "yes",
-                  }}
-                  dataTestId={"app-primary-work-in-region-yes"}
-                />
-
-                <Field
-                  className="mb-1"
-                  type="radio"
-                  id="workInRegionNo"
-                  name="applicant.workInRegion"
-                  label={t("t.no")}
-                  register={register}
-                  validation={{ required: true }}
-                  error={errors?.applicant?.workInRegion}
-                  inputProps={{
-                    value: "no",
-                    defaultChecked: application.applicant.workInRegion == "no",
-                  }}
-                  dataTestId={"app-primary-work-in-region-no"}
-                />
-                {errors?.applicant?.workInRegion && (
-                  <FormErrorMessage id="applicant.workInRegion-error">
-                    {t("errors.selectOption")}
-                  </FormErrorMessage>
-                )}
-              </fieldset>
-
-              {(workInRegion == "yes" ||
-                (!workInRegion && application.applicant.workInRegion == "yes")) && (
-                <div className="form-card__group mx-0 px-0 mt-2">
-                  <fieldset>
-                    <legend className="text__caps-spaced">
-                      {t("application.contact.workAddress")}
-                    </legend>
-
-                    <Field
-                      id="applicantWorkAddressStreet"
-                      name="applicant.applicantWorkAddress.street"
-                      defaultValue={application.applicant.applicantWorkAddress.street}
-                      validation={{ required: true, maxLength: 64 }}
-                      error={errors.applicant?.applicantWorkAddress?.street}
-                      errorMessage={
-                        errors.applicant?.applicantWorkAddress?.street?.type === "maxLength"
-                          ? t("errors.maxLength")
-                          : t("errors.streetError")
-                      }
-                      register={register}
-                      dataTestId={"app-primary-work-address-street"}
-                      label={t("application.contact.streetAddress")}
-                    />
-
-                    <Field
-                      id="applicantWorkAddressStreet2"
-                      name="applicant.applicantWorkAddress.street2"
-                      label={t("application.contact.apt")}
-                      defaultValue={application.applicant.applicantWorkAddress.street2}
-                      register={register}
-                      error={errors.applicant?.applicantWorkAddress?.street2}
-                      validation={{ maxLength: 64 }}
-                      errorMessage={"errors.maxLength"}
-                      dataTestId={"app-primary-work-address-street2"}
-                    />
-
-                    <div className="flex max-w-2xl">
-                      <Field
-                        id="applicantWorkAddressCity"
-                        name="applicant.applicantWorkAddress.city"
-                        label={t("application.contact.city")}
-                        defaultValue={application.applicant.applicantWorkAddress.city}
-                        validation={{ required: true, maxLength: 64 }}
-                        error={errors.applicant?.applicantWorkAddress?.city}
-                        errorMessage={
-                          errors.applicant?.applicantWorkAddress?.city?.type === "maxLength"
-                            ? t("errors.maxLength")
-                            : t("errors.cityError")
-                        }
-                        register={register}
-                        dataTestId={"app-primary-work-address-city"}
-                      />
-
-                      <Select
-                        id="applicantWorkAddressState"
-                        name="applicant.applicantWorkAddress.state"
-                        label={t("application.contact.state")}
-                        defaultValue={application.applicant.applicantWorkAddress.state}
-                        validation={{ required: true, maxLength: 64 }}
-                        error={errors.applicant?.applicantWorkAddress?.state}
-                        errorMessage={
-                          errors.applicant?.applicantWorkAddress?.state?.type === "maxLength"
-                            ? t("errors.maxLength")
-                            : t("errors.stateError")
-                        }
-                        register={register}
-                        controlClassName="control"
-                        options={stateKeys}
-                        keyPrefix="states"
-                        dataTestId={"app-primary-work-address-state"}
-                      />
-                    </div>
-
-                    <Field
-                      id="applicantWorkAddressZipCode"
-                      name="applicant.applicantWorkAddress.zipCode"
-                      label={t("application.contact.zip")}
-                      defaultValue={application.applicant.applicantWorkAddress.zipCode}
-                      validation={{ required: true, maxLength: 64 }}
-                      error={errors.applicant?.applicantWorkAddress?.zipCode}
-                      errorMessage={
-                        errors.applicant?.applicantWorkAddress?.zipCode?.type === "maxLength"
-                          ? t("errors.maxLength")
-                          : t("errors.zipCodeError")
-                      }
-                      register={register}
-                      dataTestId={"app-primary-work-address-zip"}
-                    />
-                  </fieldset>
-                </div>
-              )}
             </CardSection>
           </div>
           <CardSection>

--- a/sites/public/src/pages/applications/contact/address.tsx
+++ b/sites/public/src/pages/applications/contact/address.tsx
@@ -52,6 +52,7 @@ const ApplicationAddress = () => {
       additionalPhone: application.additionalPhone,
       "applicant.phoneNumberType": application.applicant.phoneNumberType,
       sendMailToMailingAddress: application.sendMailToMailingAddress,
+      "applicant.workInRegion": application.applicant.workInRegion,
       "applicant.applicantAddress.state": application.applicant.applicantAddress.state,
     },
     shouldFocusError: false,
@@ -86,6 +87,9 @@ const ApplicationAddress = () => {
     if (!application.additionalPhone) {
       application.additionalPhoneNumber = ""
       application.additionalPhoneNumberType = ""
+    }
+    if (!application.applicant.workInRegion) {
+      application.applicant.applicantWorkAddress = blankApplication.applicant.applicantWorkAddress
     }
     if (!application.sendMailToMailingAddress) {
       application.applicationsMailingAddress = blankApplication.applicationsMailingAddress

--- a/sites/public/src/pages/applications/household/member.tsx
+++ b/sites/public/src/pages/applications/household/member.tsx
@@ -73,6 +73,7 @@ export class Member implements HouseholdMemberUpdate {
   }
   sameAddress?: YesNoEnum
   relationship?: string
+  workInRegion?: YesNoEnum
 }
 
 const ApplicationMember = () => {

--- a/sites/public/src/pages/applications/household/member.tsx
+++ b/sites/public/src/pages/applications/household/member.tsx
@@ -73,7 +73,6 @@ export class Member implements HouseholdMemberUpdate {
   }
   sameAddress?: YesNoEnum
   relationship?: string
-  workInRegion?: YesNoEnum
 }
 
 const ApplicationMember = () => {
@@ -127,7 +126,6 @@ const ApplicationMember = () => {
   }
 
   const sameAddress = watch("sameAddress")
-  const workInRegion = watch("workInRegion")
 
   const sameAddressOptions = [
     {
@@ -141,21 +139,6 @@ const ApplicationMember = () => {
       label: t("t.no"),
       value: "no",
       defaultChecked: member?.sameAddress === "no",
-    },
-  ]
-
-  const workInRegionOptions = [
-    {
-      id: "workInRegionYes",
-      label: t("t.yes"),
-      value: "yes",
-      defaultChecked: member?.workInRegion === "yes",
-    },
-    {
-      id: "workInRegionNo",
-      label: t("t.no"),
-      value: "no",
-      defaultChecked: member?.workInRegion === "no",
     },
   ]
 
@@ -362,115 +345,6 @@ const ApplicationMember = () => {
                   }
                   register={register}
                   dataTestId={"app-household-member-address-zip"}
-                />
-              </fieldset>
-            )}
-          </CardSection>
-
-          <CardSection divider={"inset"}>
-            <fieldset>
-              <legend className="text__caps-spaced">
-                {t("application.household.member.workInRegion", {
-                  county: listing?.listingsBuildingAddress?.county || listing?.jurisdictions?.name,
-                })}
-              </legend>
-              <FieldGroup
-                name="workInRegion"
-                fieldGroupClassName="grid grid-cols-1"
-                fieldClassName="ml-0"
-                type="radio"
-                register={register}
-                validation={{ required: true }}
-                error={errors.workInRegion}
-                errorMessage={t("errors.selectOption")}
-                fields={workInRegionOptions}
-                dataTestId={"app-household-member-work-in-region"}
-              />
-            </fieldset>
-
-            {(workInRegion == "yes" || (!workInRegion && member.workInRegion == "yes")) && (
-              <fieldset className="mt-8">
-                <legend className="text__caps-spaced">{t("application.contact.address")}</legend>
-
-                <Field
-                  id="householdMemberWorkAddress.street"
-                  name="householdMemberWorkAddress.street"
-                  label={t("application.contact.streetAddress")}
-                  defaultValue={member.householdMemberWorkAddress.street}
-                  validation={{ required: true, maxLength: 64 }}
-                  error={errors.workAddress?.street}
-                  errorMessage={
-                    errors.workAddress?.street?.type === "maxLength"
-                      ? t("errors.maxLength")
-                      : t("errors.streetError")
-                  }
-                  register={register}
-                  dataTestId={"app-household-member-work-address-street"}
-                />
-
-                <Field
-                  id="householdMemberWorkAddress.street2"
-                  name="householdMemberWorkAddress.street2"
-                  label={t("application.contact.apt")}
-                  defaultValue={member.householdMemberWorkAddress.street2}
-                  error={errors.workAddress?.street2}
-                  errorMessage={t("errors.maxLength")}
-                  validation={{ maxLength: 64 }}
-                  register={register}
-                  dataTestId={"app-household-member-work-address-street2"}
-                />
-
-                <div className="flex max-w-2xl">
-                  <Field
-                    id="householdMemberWorkAddress.city"
-                    name="householdMemberWorkAddress.city"
-                    label={t("application.contact.city")}
-                    defaultValue={member.householdMemberWorkAddress.city}
-                    validation={{ required: true, maxLength: 64 }}
-                    error={errors.workAddress?.city}
-                    errorMessage={
-                      errors.workAddress?.city?.type === "maxLength"
-                        ? t("errors.maxLength")
-                        : t("errors.cityError")
-                    }
-                    register={register}
-                    dataTestId={"app-household-member-work-address-city"}
-                  />
-
-                  <Select
-                    id="householdMemberWorkAddress.state"
-                    name="householdMemberWorkAddress.state"
-                    label={t("application.contact.state")}
-                    defaultValue={member.householdMemberWorkAddress.state}
-                    validation={{ required: true, maxLength: 64 }}
-                    error={errors.workAddress?.state}
-                    errorMessage={
-                      errors.workAddress?.state?.type === "maxLength"
-                        ? t("errors.maxLength")
-                        : t("errors.stateError")
-                    }
-                    register={register}
-                    controlClassName="control"
-                    options={stateKeys}
-                    keyPrefix="states"
-                    dataTestId={"app-household-member-work-address-state"}
-                  />
-                </div>
-
-                <Field
-                  id="householdMemberWorkAddress.zipCode"
-                  name="householdMemberWorkAddress.zipCode"
-                  label={t("application.contact.zip")}
-                  defaultValue={member.householdMemberWorkAddress.zipCode}
-                  validation={{ required: true, maxLength: 64 }}
-                  error={errors.workAddress?.zipCode}
-                  errorMessage={
-                    errors.workAddress?.zipCode?.type === "maxLength"
-                      ? t("errors.maxLength")
-                      : t("errors.zipCodeError")
-                  }
-                  register={register}
-                  dataTestId={"app-household-member-work-address-zip"}
                 />
               </fieldset>
             )}


### PR DESCRIPTION
This PR addresses #677 
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR is meant to hide the "Do you work in" question from the common application with the least amount of changes. Given the turnaround on release on Monday, I only focused on hiding it on the applicant information and household member information page. 
## How Can This Be Tested/Reviewed?

This can be tested by filling out the common app and noticing that the question doesn't appear on the address page nor the household member section.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
