### PR TITLE
fix: remove last reference to backend in docker

### DIFF
--- a/build/docker/Dockerfile.sites-generic
+++ b/build/docker/Dockerfile.sites-generic
@@ -192,7 +192,6 @@ COPY --from=optimize --chown=node:node /app/node_modules ./node_modules
 COPY --from=optimize --chown=node:node /app/sites/${SITE}/node_modules ./sites/${SITE}/node_modules
 
 # Bring in our local dependencies
-COPY --from=build /app/backend/core ./backend/core
 COPY --from=build /app/shared-helpers ./shared-helpers
 COPY --from=build /app/doorway-ui-components ./doorway-ui-components
 

--- a/sites/partners/__tests__/pages/listings/index.test.tsx
+++ b/sites/partners/__tests__/pages/listings/index.test.tsx
@@ -8,28 +8,6 @@ import React from "react"
 import { listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { mockNextRouter } from "../../testUtils"
 
-//Mock the jszip package used for Export
-const mockFile = jest.fn()
-let mockFolder: jest.Mock
-function mockJszip() {
-  mockFolder = jest.fn(mockJszip)
-  return {
-    folder: mockFolder,
-    file: mockFile,
-    generateAsync: jest.fn().mockImplementation(() => {
-      const blob = {}
-      const response = { blob }
-      return Promise.resolve(response)
-    }),
-  }
-}
-jest.mock("jszip", () => {
-  return {
-    __esModule: true,
-    default: mockJszip,
-  }
-})
-
 const server = setupServer()
 
 beforeAll(() => {


### PR DESCRIPTION
I missed one spot where backend/core is still referenced in the docker file. 

Also by pulling out backend/core we no longer have to mock a dependency on one of the test