### PR TITLE
fix: move ts-node to dependencies

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -82,6 +82,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "~7.8.1",
     "swagger-axios-codegen": "~0.15.12",
+    "ts-node": "^10.0.0",
     "twilio": "^4.15.0",
     "winston": "^3.13.0"
   },
@@ -110,7 +111,6 @@
     "supertest": "^6.1.3",
     "ts-jest": "~29.1.1",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^5.1.6"
   },


### PR DESCRIPTION
The reseed command in Doorway dev environment is failing because the ts-node package doesn't exist. I believe this is because we are only downloading the production node modules. 

This PR moves the ts-node package to the dependencies instead of devDependencies.