### PR TITLE
fix: new translations for housing vouchers

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -986,6 +986,7 @@
   "listings.reservedCommunityTypeDescriptions.specialNeeds": "Necesidades especiales",
   "listings.reservedCommunityTypeDescriptions.veteran": "Veterano",
   "listings.reservedCommunityTypes.developmentalDisability": "La discapacidad del desarrollo",
+  "listings.reservedCommunityTypes.housingVoucher": "Vale HCV/Sección 8",
   "listings.reservedCommunityTypes.senior": "Personas mayores",
   "listings.reservedCommunityTypes.senior55": "Personas mayores de 55 años",
   "listings.reservedCommunityTypes.senior62": "Personas mayores de 62 años",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -943,6 +943,7 @@
   "listings.reservedCommunityTypeDescriptions.specialNeeds": "Special Needs",
   "listings.reservedCommunityTypeDescriptions.veteran": "Veteran",
   "listings.reservedCommunityTypes.developmentalDisability": "Developmental Disability",
+  "listings.reservedCommunityTypes.housingVoucher": "HCV/Section 8 Voucher",
   "listings.reservedCommunityTypes.senior": "Seniors",
   "listings.reservedCommunityTypes.senior55": "Seniors 55+",
   "listings.reservedCommunityTypes.senior62": "Seniors 62+",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -951,6 +951,7 @@
   "listings.reservedCommunityTypeDescriptions.specialNeeds": "Espesyal na pangangailangan",
   "listings.reservedCommunityTypeDescriptions.veteran": "Beterano",
   "listings.reservedCommunityTypes.developmentalDisability": "Kapansanan sa Pag-unlad",
+  "listings.reservedCommunityTypes.housingVoucher": "Voucher ng HCV/Seksyon 8",
   "listings.reservedCommunityTypes.senior": "Mga nakatatanda",
   "listings.reservedCommunityTypes.senior55": "Mga nakatatanda 55+",
   "listings.reservedCommunityTypes.senior62": "Mga nakatatanda 62+",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -989,6 +989,7 @@
   "listings.reservedCommunityTypeDescriptions.specialNeeds": "Nhu cầu đặc biệt",
   "listings.reservedCommunityTypeDescriptions.veteran": "Cựu chiến binh",
   "listings.reservedCommunityTypes.developmentalDisability": "Khuyết tật phát triển",
+  "listings.reservedCommunityTypes.housingVoucher": "Phiếu HCV/Phần 8",
   "listings.reservedCommunityTypes.senior": "Người lớn tuổi",
   "listings.reservedCommunityTypes.senior55": "Người cao tuổi 55+",
   "listings.reservedCommunityTypes.senior62": "Người cao tuổi 62+",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -989,6 +989,7 @@
   "listings.reservedCommunityTypeDescriptions.specialNeeds": "特殊需求",
   "listings.reservedCommunityTypeDescriptions.veteran": "老将",
   "listings.reservedCommunityTypes.developmentalDisability": "发育障碍",
+  "listings.reservedCommunityTypes.housingVoucher": "HCV/第 8 节优惠券",
   "listings.reservedCommunityTypes.senior": "老年人",
   "listings.reservedCommunityTypes.senior55": "55 岁以上的老年人",
   "listings.reservedCommunityTypes.senior62": "62 岁以上的老年人",


### PR DESCRIPTION
This PR addresses [#4113](https://github.com/bloom-housing/bloom/issues/4113)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

The new translation keys are needed for the community type added to Alameda

## How Can This Be Tested/Reviewed?

You can't create a listing that has this community type so you will need to pull the prod HBA listings over. 
This can be done by going to `/tasks/import-listings` and run `yarn install && yarn build && yarn import:run:local:prod` 

Then you should see this property:
![image](https://github.com/metrotranscom/doorway/assets/42942267/ee6a64b6-f12c-467b-b8c6-ec3a5a666417)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
