### PR TITLE
fix: update backend docker

### DIFF
--- a/build/docker/Dockerfile.backend
+++ b/build/docker/Dockerfile.backend
@@ -101,7 +101,8 @@ WORKDIR /app
 # Pull in package files again
 COPY --from=source --chown=node:node \
     /app/api/package*.json \
-    /app/api/tsconfig*.json ./
+    /app/api/tsconfig*.json \
+    /app/api/prisma ./
 
 # Add only dependencies required to run the application
 COPY --from=optimize --chown=node:node /app/node_modules ./node_modules


### PR DESCRIPTION

## Description

The AWS pipeline is broken due to docker build step of the backend failing. This adds an additional step to pull over the prisma files when building the run container

## How Can This Be Tested/Reviewed?

In order to test this you must have docker installed and running and then run the following command:
`docker build . -f build/docker/Dockerfile.backend --target run -t api:run-candidate`

The build should complete successfullly

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
