### PR TITLE
fix: remove view listing button from closed listings

### DIFF
--- a/sites/public/__tests__/components/applications/StatusItem.test.tsx
+++ b/sites/public/__tests__/components/applications/StatusItem.test.tsx
@@ -22,10 +22,9 @@ describe("<StatusItem>", () => {
     expect(getByText(t("listings.applicationDeadline"), { exact: false })).not.toBeNull()
     expect(getByText(t("application.yourLotteryNumber"), { exact: false })).not.toBeNull()
   })
-  it("renders without a confirmation number or due date if not provided", () => {
+  it("renders without a confirmation number, application url or due date if not provided", () => {
     const { getByText, queryByText } = render(
       <StatusItem
-        applicationURL={"application/1234abcd"}
         applicationUpdatedAt={"March 8th, 2022"}
         listingName={"Listing Name"}
         listingURL={"/listing/abcd1234/listing-name"}
@@ -34,6 +33,7 @@ describe("<StatusItem>", () => {
 
     expect(getByText("Listing Name")).not.toBeNull()
     expect(queryByText(t("listings.applicationDeadline"), { exact: false })).toBeNull()
+    expect(queryByText(t("application.viewApplication"), { exact: false })).toBeNull()
     expect(queryByText(t("application.yourLotteryNumber"))).toBeNull()
   })
 })

--- a/sites/public/src/components/account/StatusItem.tsx
+++ b/sites/public/src/components/account/StatusItem.tsx
@@ -6,7 +6,7 @@ import accountStyles from "../../pages/account/account.module.scss"
 
 interface StatusItemProps {
   applicationDueDate?: string
-  applicationURL: string
+  applicationURL?: string
   applicationUpdatedAt: string
   confirmationNumber?: string
   listingName: string
@@ -62,11 +62,13 @@ const StatusItem = (props: StatusItemProps) => {
         </section>
 
         <footer className={styles["status-item__footer"]}>
-          <div>
-            <Button href={props.applicationURL} variant="primary-outlined" size="sm">
-              {props.strings?.viewApplication ?? t("application.viewApplication")}
-            </Button>
-          </div>
+          {props.applicationURL && (
+            <div>
+              <Button href={props.applicationURL} variant="primary-outlined" size="sm">
+                {props.strings?.viewApplication ?? t("application.viewApplication")}
+              </Button>
+            </div>
+          )}
           <div>
             <Button href={props.listingURL} variant="primary-outlined" size="sm">
               {props.strings?.seeListing ?? t("t.seeListing")}

--- a/sites/public/src/pages/account/StatusItemWrapper.tsx
+++ b/sites/public/src/pages/account/StatusItemWrapper.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import dayjs from "dayjs"
 import { StatusItem } from "../../components/account/StatusItem"
-import { Application, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  Application,
+  Listing,
+  ListingsStatusEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 export interface AppWithListing extends Application {
   fullListing?: Listing
@@ -12,11 +16,12 @@ interface StatusItemWrapperProps {
 
 const StatusItemWrapper = (props: StatusItemWrapperProps) => {
   const applicationDueDate = props.application?.fullListing?.applicationDueDate
+  const isListingClosed = props.application?.fullListing?.status === ListingsStatusEnum.closed
 
   return (
     <StatusItem
       applicationDueDate={applicationDueDate && dayjs(applicationDueDate).format("MMMM D, YYYY")}
-      applicationURL={`application/${props.application?.id}`}
+      applicationURL={!isListingClosed && `application/${props.application?.id}`}
       applicationUpdatedAt={dayjs(props.application?.updatedAt).format("MMMM D, YYYY")}
       confirmationNumber={props.application?.confirmationCode || props.application?.id}
       listingName={props.application?.fullListing?.name}


### PR DESCRIPTION
This PR addresses #704

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Hides "view application" button on `/account/applications` when listing is closed.

## How Can This Be Tested/Reviewed?

File application, it should show `view application` button on `/account/applications`. Close listing, the button should be hidden.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
