### PR TITLE
fix: input font size to avoid mobile zoom

### DIFF
--- a/doorway-ui-components/src/global/forms.scss
+++ b/doorway-ui-components/src/global/forms.scss
@@ -199,7 +199,7 @@
     @apply bg-gray-200;
     @apply text-gray-950;
     @apply leading-tight;
-    @apply py-4;
+    @apply py-2;
     @apply px-3;
     height: 3em;
     font-family: inherit;

--- a/doorway-ui-components/src/global/forms.scss
+++ b/doorway-ui-components/src/global/forms.scss
@@ -87,12 +87,11 @@
 
     input.input {
       padding-inline: var(--bloom-s3);
-      padding-block: var(--bloom-s4);
+      padding-block: var(--bloom-s3_5);
       border-width: 2px;
       background-color: var(--bloom-color-gray-200);
       border-color: var(--bloom-color-gray-500);
       border-radius: var(--bloom-rounded-lg);
-      font-size: 0.9rem;
     }
 
     .prepend {
@@ -202,9 +201,8 @@
     @apply leading-tight;
     @apply py-4;
     @apply px-3;
-    height: 3.5em;
+    height: 3em;
     font-family: inherit;
-    font-size: 0.9rem !important;
     line-height: normal;
     -moz-appearance: none;
     -webkit-appearance: none;


### PR DESCRIPTION
This PR addresses #690 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The font size of text and select fields was smaller than body base, causing mobile browsers to zoom in when a field is selected. This resets those font sizes to the base size (aka `1rem`).

**Note:** the styling of form fields in UIC (and Doorway's duplicate) is pretty wonky right now, so this code isn't pretty. We can revisit the issue entirely once the Seeds forms effort starts up.

## How Can This Be Tested/Reviewed?

Check out search, login/signup, and common app on the public site.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
