### PR TITLE
fix: add hba jurisdiction data transfers

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "~29.6.2",
     "jest-environment-jsdom": "~29.6.2",
+    "jest-mock-extended": "2.0.4",
     "prettier": "^2.3.2",
     "source-map-support": "~0.5.20",
     "supertest": "^6.1.3",

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -54,25 +54,25 @@ export const stagingSeed = async (
   const additionalJurisdiction = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Contra Costa', [UserRoleEnum.admin]),
   });
-  await prismaClient.jurisdictions.create({
+  const marinCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Marin', [UserRoleEnum.admin]),
   });
-  await prismaClient.jurisdictions.create({
+  const napaCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Napa', [UserRoleEnum.admin]),
   });
-  await prismaClient.jurisdictions.create({
+  const sanMateoCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('San Mateo', [UserRoleEnum.admin]),
   });
-  await prismaClient.jurisdictions.create({
+  const santaClaraCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Santa Clara', [UserRoleEnum.admin]),
   });
-  await prismaClient.jurisdictions.create({
+  const solanaCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Solano', [UserRoleEnum.admin]),
   });
-  await prismaClient.jurisdictions.create({
+  const sonomaCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Sonoma', [UserRoleEnum.admin]),
   });
-  await prismaClient.jurisdictions.create({
+  const sanFranciscoCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('San Francisco', [UserRoleEnum.admin]),
   });
   // create admin user
@@ -81,7 +81,17 @@ export const stagingSeed = async (
       roles: { isAdmin: true },
       email: 'admin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [jurisdiction.id, additionalJurisdiction.id],
+      jurisdictionIds: [
+        jurisdiction.id,
+        additionalJurisdiction.id,
+        marinCounty.id,
+        napaCounty.id,
+        sanMateoCounty.id,
+        santaClaraCounty.id,
+        solanaCounty.id,
+        sonomaCounty.id,
+        sanFranciscoCounty.id,
+      ],
       acceptedTerms: true,
       password: 'abcdef',
     }),

--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -34,17 +34,36 @@ export class ScirptRunnerController {
     return await this.scriptRunnerService.example(req);
   }
 
-  @Put('dataTransfer')
+  @Put('transferJurisdictionData')
   @ApiOperation({
     summary: 'A script that pulls data from one source into the current db',
-    operationId: 'dataTransfer',
+    operationId: 'transferJurisdictionData',
   })
   @ApiOkResponse({ type: SuccessDTO })
-  async dataTransfer(
+  async transferJurisdictionData(
     @Body() dataTransferDTO: DataTransferDTO,
     @Request() req: ExpressRequest,
   ): Promise<SuccessDTO> {
-    return await this.scriptRunnerService.dataTransfer(req, dataTransferDTO);
+    return await this.scriptRunnerService.transferJurisdictionData(
+      req,
+      dataTransferDTO,
+    );
+  }
+
+  @Put('transferJurisdictionListingsData')
+  @ApiOperation({
+    summary: 'A script that pulls data from one source into the current db',
+    operationId: 'transferJurisdictionListingsData',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async transferJurisdictionListingsData(
+    @Body() dataTransferDTO: DataTransferDTO,
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.transferJurisdictionListingData(
+      req,
+      dataTransferDTO,
+    );
   }
 
   @Put('amiChartImport')

--- a/api/src/dtos/script-runner/data-transfer.dto.ts
+++ b/api/src/dtos/script-runner/data-transfer.dto.ts
@@ -9,4 +9,10 @@ export class DataTransferDTO {
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })
   @ApiProperty()
   connectionString: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  jurisdiction: string;
 }

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import {
+  MultiselectQuestionsApplicationSectionEnum,
+  PrismaClient,
+} from '@prisma/client';
 import { Request as ExpressRequest } from 'express';
 import { PrismaService } from './prisma.service';
 import { SuccessDTO } from '../dtos/shared/success.dto';
@@ -28,34 +31,543 @@ export class ScriptRunnerService {
    * @returns successDTO
    * @description transfers data from foreign data into the database this api normally connects to
    */
-  async dataTransfer(
+  async transferJurisdictionData(
     req: ExpressRequest,
     dataTransferDTO: DataTransferDTO,
+    prisma?: PrismaClient,
   ): Promise<SuccessDTO> {
     // script runner standard start up
     const requestingUser = mapTo(User, req['user']);
-    await this.markScriptAsRunStart('data transfer', requestingUser);
+    await this.markScriptAsRunStart(
+      `data transfer ${dataTransferDTO.jurisdiction}`,
+      requestingUser,
+    );
 
     // connect to foreign db based on incoming connection string
-    const client = new PrismaClient({
-      datasources: {
-        db: {
-          url: dataTransferDTO.connectionString,
+    const client =
+      prisma ||
+      new PrismaClient({
+        datasources: {
+          db: {
+            url: dataTransferDTO.connectionString,
+          },
         },
-      },
-    });
+      });
     await client.$connect();
 
-    // get data
-    const res =
-      await client.$queryRaw`SELECT id, name FROM jurisdictions WHERE name = 'San Mateo'`;
-    console.log(res);
+    const doorwayJurisdiction = await this.prisma.jurisdictions.findFirst({
+      where: { name: dataTransferDTO.jurisdiction },
+    });
+
+    if (!doorwayJurisdiction) {
+      throw new Error(
+        `${dataTransferDTO.jurisdiction} county doesn't exist in Doorway database`,
+      );
+    }
+
+    // get jurisdiction
+    const jurisdiction: { id: string }[] =
+      await client.$queryRaw`SELECT id, name FROM jurisdictions WHERE name = ${dataTransferDTO.jurisdiction}`;
+
+    if (!jurisdiction?.length) {
+      throw new Error(
+        `${dataTransferDTO.jurisdiction} county doesn't exist in foreign database`,
+      );
+    }
+
+    // get ami charts
+    const amiQuery = `SELECT items, name, id FROM ami_chart WHERE jurisdiction_id = '${jurisdiction[0].id}'`;
+    const amiCharts: { items: any; name: string }[] =
+      await client.$queryRawUnsafe(amiQuery);
+
+    // save ami charts
+    if (amiCharts?.length) {
+      console.log(`migrating ${amiCharts.length} ami charts`);
+      await this.prisma.amiChart.createMany({
+        data: amiCharts.map((data) => {
+          return { ...data, jurisdictionId: doorwayJurisdiction.id };
+        }),
+      });
+    }
+
+    // get multiselect questions
+    const multiselectQuery = `SELECT mq.id, mq.text, mq.sub_text, mq.description, mq.links, mq.options, mq.opt_out_text, mq.hide_from_listing, mq.application_section
+    FROM multiselect_questions mq, "_JurisdictionsToMultiselectQuestions" jmq
+    WHERE jmq."A" = '${jurisdiction[0].id}'
+    AND jmq."B" = mq.id`;
+    const multiselectQuestions: {
+      id: string;
+      text: string;
+      sub_text: string;
+      description: string;
+      links: string;
+      options: string;
+      hide_from_listing: boolean;
+      application_section: MultiselectQuestionsApplicationSectionEnum;
+      opt_out_text: string;
+    }[] = await client.$queryRawUnsafe(multiselectQuery);
+
+    // save multiselect questions
+    if (multiselectQuestions?.length) {
+      console.log(
+        `migrating ${multiselectQuestions.length} multiselect questions`,
+      );
+      multiselectQuestions.forEach(async (question) => {
+        await this.prisma.multiselectQuestions.create({
+          data: {
+            id: question.id,
+            text: question.text,
+            subText: question.sub_text,
+            description: question.description,
+            hideFromListing: question.hide_from_listing,
+            applicationSection: question.application_section,
+            links: question.links,
+            options: question.options,
+            optOutText: question.opt_out_text,
+            jurisdictions: {
+              connect: {
+                id: doorwayJurisdiction.id,
+              },
+            },
+          },
+        });
+      });
+    }
 
     // disconnect from foreign db
     await client.$disconnect();
 
     // script runner standard spin down
-    await this.markScriptAsComplete('data transfer', requestingUser);
+    await this.markScriptAsComplete(
+      `data transfer ${dataTransferDTO.jurisdiction}`,
+      requestingUser,
+    );
+    return { success: true };
+  }
+
+  createAddress(dbAddress, jurisdictionName?: string) {
+    return {
+      createdAt: dbAddress[0]['created_at'],
+      placeName: dbAddress[0]['place_name'],
+      city: dbAddress[0]['city'],
+      county: dbAddress[0]['county'] || jurisdictionName,
+      state: dbAddress[0]['state'],
+      street: dbAddress[0]['street'],
+      street2: dbAddress[0]['street2'],
+      zipCode: dbAddress[0]['zip_code'],
+      latitude: dbAddress[0]['latitude'],
+      longitude: dbAddress[0]['longitude'],
+    };
+  }
+
+  /**
+   *
+   * @param req incoming request object
+   * @param dataTransferDTO data transfer endpoint args. Should contain foreign db connection string
+   * @returns successDTO
+   * @description transfers data from foreign data into the database this api normally connects to
+   */
+  async transferJurisdictionListingData(
+    req: ExpressRequest,
+    dataTransferDTO: DataTransferDTO,
+    prisma?: PrismaClient,
+  ): Promise<SuccessDTO> {
+    // script runner standard start up
+    const requestingUser = mapTo(User, req['user']);
+    await this.markScriptAsRunStart(
+      `data transfer listings ${dataTransferDTO.jurisdiction}`,
+      requestingUser,
+    );
+
+    // connect to foreign db based on incoming connection string
+    const client =
+      prisma ||
+      new PrismaClient({
+        datasources: {
+          db: {
+            url: dataTransferDTO.connectionString,
+          },
+        },
+      });
+    await client.$connect();
+
+    const doorwayJurisdiction = await this.prisma.jurisdictions.findFirst({
+      where: { name: dataTransferDTO.jurisdiction },
+    });
+
+    if (!doorwayJurisdiction) {
+      throw new Error(
+        `${dataTransferDTO.jurisdiction} county doesn't exist in Doorway database`,
+      );
+    }
+
+    // get jurisdiction
+    const jurisdiction: { id: string }[] =
+      await client.$queryRaw`SELECT id, name FROM jurisdictions WHERE name = ${dataTransferDTO.jurisdiction}`;
+
+    if (!jurisdiction) {
+      throw new Error(
+        `${dataTransferDTO.jurisdiction} county doesn't exist in foreign database`,
+      );
+    }
+
+    const listingQuery = `SELECT * FROM listings WHERE jurisdiction_id = '${jurisdiction[0].id}'`;
+    const listings: any[] = await client.$queryRawUnsafe(listingQuery);
+
+    if (listings?.length) {
+      const priorityTypes: { id: string; name: string }[] =
+        await client.$queryRaw`SELECT * FROM unit_accessibility_priority_types`;
+      const doorwayPriorityTypes =
+        await this.prisma.unitAccessibilityPriorityTypes.findMany();
+      const rentTypes: { id: string; name: string }[] =
+        await client.$queryRaw`SELECT * FROM unit_types`;
+      const doorwayRentTypes = await this.prisma.unitRentTypes.findMany();
+      console.log(`migrating ${listings.length} listings`);
+      listings.forEach(async (listing) => {
+        console.log(`migrating ${listing['name']} listing`);
+
+        let buildingAddress;
+        if (listing['building_address_id']) {
+          buildingAddress = await client.$queryRawUnsafe(
+            `SELECT * FROM address WHERE id = '${listing['building_address_id']}'`,
+          );
+        }
+        let leasingAgentAddress;
+        if (listing['leasing_agent_address_id']) {
+          leasingAgentAddress = await client.$queryRawUnsafe(
+            `SELECT * FROM address WHERE id = '${listing['leasing_agent_address_id']}'`,
+          );
+        }
+        let applicationPickUpAddress;
+        if (listing['application_pick_up_address_id']) {
+          applicationPickUpAddress = await client.$queryRawUnsafe(
+            `SELECT * FROM address WHERE id = '${listing['application_pick_up_address_id']}'`,
+          );
+        }
+        let applicationDropOffAddress;
+        if (listing['application_drop_off_address_id']) {
+          applicationDropOffAddress = await client.$queryRawUnsafe(
+            `SELECT * FROM address WHERE id = '${listing['application_drop_off_address_id']}'`,
+          );
+        }
+        let applicationMailingAddress;
+        if (listing['application_mailing_address_id']) {
+          applicationMailingAddress = await client.$queryRawUnsafe(
+            `SELECT * FROM address WHERE id = '${listing['application_mailing_address_id']}'`,
+          );
+        }
+        let reservedCommunityType;
+        if (listing['reserved_community_type_id']) {
+          reservedCommunityType = await client.$queryRawUnsafe(
+            `SELECT * FROM reserved_community_types WHERE id = '${listing['reserved_community_type_id']}'`,
+          );
+          if (reservedCommunityType.length) {
+            const reservedCommunityTypes =
+              await this.prisma.reservedCommunityTypes.findMany();
+            const name = reservedCommunityType[0]['name'];
+            const foundReservedCommunityType = reservedCommunityTypes.find(
+              (communityType) =>
+                communityType.name === name ||
+                (name === 'senior' && communityType.name === 'senior55'),
+            );
+            if (foundReservedCommunityType) {
+              reservedCommunityType = foundReservedCommunityType;
+            }
+          }
+        }
+
+        const createdListing = await this.prisma.listings.create({
+          data: {
+            id: listing['id'],
+            listingsBuildingAddress: buildingAddress?.length
+              ? {
+                  create: this.createAddress(
+                    buildingAddress,
+                    dataTransferDTO.jurisdiction,
+                  ),
+                }
+              : undefined,
+            listingsLeasingAgentAddress: leasingAgentAddress?.length
+              ? {
+                  create: this.createAddress(leasingAgentAddress),
+                }
+              : undefined,
+            listingsApplicationPickUpAddress: applicationPickUpAddress?.length
+              ? { create: this.createAddress(applicationPickUpAddress) }
+              : undefined,
+            listingsApplicationDropOffAddress: applicationDropOffAddress?.length
+              ? { create: this.createAddress(applicationDropOffAddress) }
+              : undefined,
+            listingsApplicationMailingAddress: applicationMailingAddress?.length
+              ? { create: this.createAddress(applicationMailingAddress) }
+              : undefined,
+            jurisdictions: {
+              connect: {
+                id: doorwayJurisdiction.id,
+              },
+            },
+            reservedCommunityTypes: reservedCommunityType
+              ? {
+                  connectOrCreate: {
+                    where: { id: reservedCommunityType.id },
+                    create: {
+                      name: reservedCommunityType['name'],
+                      description: reservedCommunityType['description'],
+                      jurisdictions: {
+                        connect: { id: doorwayJurisdiction.id },
+                      },
+                    },
+                  },
+                }
+              : undefined,
+            createdAt: listing['created_at'],
+            additionalApplicationSubmissionNotes:
+              listing['additional_application_submission_notes'],
+            digitalApplication: listing['digital_application'],
+            commonDigitalApplication: listing['common_digital_application'],
+            paperApplication: listing['paper_application'],
+            referralOpportunity: listing['referral_opportunity'],
+            assets: listing['assets'],
+            accessibility: listing['accessibility'],
+            amenities: listing['amenities'],
+            buildingTotalUnits: listing['building_total_units'],
+            developer: listing['developer'],
+            householdSizeMax: listing['household_size_max'],
+            householdSizeMin: listing['household_size_min'],
+            neighborhood: listing['neighborhood'],
+            petPolicy: listing['pet_policy'],
+            smokingPolicy: listing['smoking_policy'],
+            unitsAvailable: listing['units_available'],
+            unitAmenities: listing['unit_amenities'],
+            servicesOffered: listing['services_offered'],
+            yearBuilt: listing['year_built'],
+            applicationDueDate: listing['application_due_date'],
+            applicationOpenDate: listing['application_open_date'],
+            applicationFee: listing['application_fee'],
+            applicationOrganization: listing['application_organization'],
+            applicationPickUpAddressOfficeHours:
+              listing['application_pick_up_address_office_hours'],
+            applicationDropOffAddressOfficeHours:
+              listing['application_drop_off_address_office_hours'],
+            buildingSelectionCriteria: listing['building_selection_criteria'],
+            costsNotIncluded: listing['costs_not_included'],
+            creditHistory: listing['credit_history'],
+            criminalBackground: listing['criminal_background'],
+            depositMin: listing['deposit_min'],
+            depositMax: listing['deposit_max'],
+            depositHelperText: listing['deposit_helper_text'],
+            disableUnitsAccordion: listing['disable_units_accordion'],
+            leasingAgentEmail: listing['leasing_agent_email'],
+            leasingAgentName: listing['leasing_agent_name'],
+            leasingAgentOfficeHours: listing['leasing_agent_office_hours'],
+            leasingAgentPhone: listing['leasing_agent_phone'],
+            leasingAgentTitle: listing['leasing_agent_title'],
+            name: listing['name'],
+            postmarkedApplicationsReceivedByDate:
+              listing['postmarked_applications_received_by_date'],
+            programRules: listing['program_rules'],
+            rentalAssistance: listing['rental_assistance'],
+            rentalHistory: listing['rental_history'],
+            requiredDocuments: listing['required_documents'],
+            specialNotes: listing['special_notes'],
+            waitlistCurrentSize: listing['waitlist_current_size'],
+            waitlistMaxSize: listing['waitlist_current_size'],
+            whatToExpect: listing['what_to_expect'],
+            status: listing['status'],
+            reviewOrderType: listing['review_order_type'],
+            displayWaitlistSize: listing['display_waitlist_size'],
+            reservedCommunityDescription:
+              listing['reserved_community_description'],
+            reservedCommunityMinAge: listing['reserved_community_min_age'],
+            resultLink: listing['result_link'],
+            isWaitlistOpen: listing['is_waitlist_open'],
+            waitlistOpenSpots: listing['waitlist_open_spots'],
+            customMapPin: listing['custom_map_pin'],
+            publishedAt: listing['published_at'],
+            closedAt: listing['closed_at'],
+            afsLastRunAt: listing['afs_last_run'],
+            lastApplicationUpdateAt: listing['last_application_update_at'],
+            requestedChanges: listing['requested_changes'],
+            requestedChangesDate: listing['requested_changes_date'],
+            // NOTE: add requested changes user ID not be carried over
+            amiPercentageMax: listing['ami_percentage_max'],
+            amiPercentageMin: listing['ami_percentage_min'],
+            homeType: listing['home_type'],
+            hrdId: listing['hrd_id'],
+            isVerified: listing['is_verified'],
+            managementCompany: listing['management_company'],
+            managementWebsite: listing['management_website'],
+            marketingType: listing['marketing_type'],
+            ownerCompany: listing['owner_company'],
+            phoneNumber: listing['phone_number'],
+            applicationPickUpAddressType:
+              listing['application_pick_up_address_type'],
+            applicationDropOffAddressType:
+              listing['application_drop_off_address_type'],
+            applicationMailingAddressType:
+              listing['application_mailing_address_type'],
+            contentUpdatedAt: listing['content_updated_at'],
+          },
+        });
+
+        // upload units
+        const units: any[] = await client.$queryRawUnsafe(
+          `SELECT u.*, ut.name FROM units u, unit_types ut WHERE ut.id = u.unit_type_id AND u.listing_id = '${listing['id']}'`,
+        );
+        units?.forEach(async (unit) => {
+          let doorwayAmiChart;
+          let unitType;
+          let priorityType: { id: string; name: string };
+          let rentType;
+          // We need to get the amiChart from Doorway because it might not have been carried over from HBA
+          // Example might be the ami chart in HBA is tied to the wrong jurisdiction
+          if (unit['ami_chart_id']) {
+            doorwayAmiChart = await this.prisma.amiChart.findFirst({
+              where: { id: unit['ami_chart_id'] },
+            });
+            if (!doorwayAmiChart) {
+              // logging any missed ami chart so we can manually consolidate it later
+              console.log(
+                `Ami chart not found in Doorway: ${unit['ami_chart_id']} for listing ${listing['name']}`,
+              );
+            }
+          }
+          if (unit['name']) {
+            unitType = await this.prisma.unitTypes.findFirst({
+              select: {
+                id: true,
+              },
+              where: {
+                name: unit['name'],
+              },
+            });
+          }
+          if (unit['priority_type_id']) {
+            const fullPriorityType = priorityTypes.find(
+              (type) => type.id === unit['priority_type_id'],
+            );
+            priorityType = doorwayPriorityTypes.find(
+              (type) => type.name === fullPriorityType.name,
+            );
+          }
+          if (unit['unit_rent_type_id']) {
+            const fullRentType = rentTypes.find(
+              (type) => type.id === unit['unit_rent_type_id'],
+            );
+            rentType = doorwayRentTypes.find(
+              (type) => type.name === fullRentType.name,
+            );
+          }
+
+          await this.prisma.units.create({
+            data: {
+              listings: {
+                connect: {
+                  id: createdListing.id,
+                },
+              },
+              amiChart: doorwayAmiChart
+                ? {
+                    connect: {
+                      id: doorwayAmiChart.id,
+                    },
+                  }
+                : undefined,
+              unitTypes: unitType
+                ? {
+                    connect: {
+                      id: unitType.id,
+                    },
+                  }
+                : undefined,
+              unitAccessibilityPriorityTypes: priorityType
+                ? { connect: { id: priorityType.id } }
+                : undefined,
+              unitRentTypes: rentType
+                ? { connect: { id: rentType.id } }
+                : undefined,
+              amiPercentage: unit['ami_percentage'],
+              annualIncomeMin: unit['annual_income_min'],
+              annualIncomeMax: unit['annual_income_max'],
+              floor: unit['floor'],
+              monthlyIncomeMin: unit['monthly_income_min'],
+              maxOccupancy: unit['max_occupancy'],
+              minOccupancy: unit['min_occupancy'],
+              monthlyRent: unit['monthly_rent'],
+              numBathrooms: unit['num_bathrooms'],
+              numBedrooms: unit['num_bedrooms'],
+              number: unit['number'],
+              sqFeet: unit['sq_feet'],
+              monthlyRentAsPercentOfIncome:
+                unit['monthly_rent_as_percent_of_income'],
+              bmrProgramChart: unit['bmr_program_chart'],
+              status: unit['status'],
+            },
+          });
+        });
+
+        // Migrate the listing to multiselect question mapping
+        const listingMultiselectQuestions: {
+          ordinal: number;
+          listing_id: string;
+          multiselect_question_id: string;
+        }[] = await client.$queryRawUnsafe(
+          `SELECT * FROM listing_multiselect_questions WHERE listing_id = '${listing['id']}'`,
+        );
+        if (listingMultiselectQuestions?.length) {
+          console.log(
+            `migrating ${listingMultiselectQuestions.length} listing multiselect questions`,
+          );
+          listingMultiselectQuestions.forEach(async (lmq) => {
+            try {
+              await this.prisma.listingMultiselectQuestions.create({
+                data: {
+                  ordinal: lmq.ordinal,
+                  listingId: createdListing.id,
+                  multiselectQuestionId: lmq.multiselect_question_id,
+                },
+              });
+            } catch (e) {
+              // Log the failed ones so we can manually add them later if need be
+              console.log(
+                `unable to migrate listing multiselect question ${lmq.multiselect_question_id} to listing ${createdListing.id}`,
+              );
+            }
+          });
+        }
+
+        // Migrate all events that don't have a file associated to it
+        const listingEvents: any[] = await client.$queryRawUnsafe(
+          `SELECT * FROM listing_events WHERE listing_id = '${listing['id']}' AND file_id IS NULL`,
+        );
+        if (listingEvents?.length) {
+          console.log(`migrating ${listingEvents.length} listing events`);
+          await this.prisma.listingEvents.createMany({
+            data: listingEvents.map((event) => {
+              return {
+                type: event['type'],
+                url: event['url'],
+                listingId: createdListing.id,
+                note: event['note'],
+                label: event['label'],
+                startTime: event['start_time'],
+                endTime: event['end_time'],
+                startDate: event['start_date'],
+              };
+            }),
+          });
+        }
+      });
+    }
+
+    // disconnect from foreign db
+    await client.$disconnect();
+
+    // script runner standard spin down
+    await this.markScriptAsComplete(
+      `data transfer listings ${dataTransferDTO.jurisdiction}`,
+      requestingUser,
+    );
     return { success: true };
   }
 

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -219,8 +219,8 @@ describe('Testing script runner service', () => {
             id: listingId,
             name: 'sample listing',
             created_at: new Date(),
-            digital_application: false,
-            common_digital_application: false,
+            digital_application: true,
+            common_digital_application: true,
             paper_application: false,
             referral_opportunity: false,
             assets: [],
@@ -241,6 +241,7 @@ describe('Testing script runner service', () => {
         .mockResolvedValueOnce([createAddress('leasing agent')])
         .mockResolvedValueOnce([createAddress('application pick up')])
         .mockResolvedValueOnce([createAddress('application drop up')])
+        .mockResolvedValueOnce([{ type: 'Internal' }]) // application methods
         .mockResolvedValueOnce([]); // units
       const createdListingId = randomUUID();
       const mockListingSave = jest
@@ -279,6 +280,18 @@ describe('Testing script runner service', () => {
           applicationDueDate: undefined,
           applicationFee: undefined,
           applicationMailingAddressType: undefined,
+          applicationMethods: {
+            createMany: {
+              data: [
+                {
+                  acceptsPostmarkedApplications: undefined,
+                  label: undefined,
+                  phoneNumber: undefined,
+                  type: 'Internal',
+                },
+              ],
+            },
+          },
           applicationOpenDate: undefined,
           applicationOrganization: undefined,
           applicationPickUpAddressOfficeHours: undefined,
@@ -287,7 +300,7 @@ describe('Testing script runner service', () => {
           buildingSelectionCriteria: undefined,
           buildingTotalUnits: undefined,
           closedAt: undefined,
-          commonDigitalApplication: false,
+          commonDigitalApplication: true,
           contentUpdatedAt: undefined,
           costsNotIncluded: undefined,
           createdAt: expect.anything(),
@@ -298,7 +311,7 @@ describe('Testing script runner service', () => {
           depositMax: undefined,
           depositMin: undefined,
           developer: 'developer',
-          digitalApplication: false,
+          digitalApplication: true,
           disableUnitsAccordion: undefined,
           displayWaitlistSize: false,
           homeType: undefined,
@@ -474,7 +487,8 @@ describe('Testing script runner service', () => {
           },
         ])
         .mockResolvedValueOnce([{ name: 'senior' }])
-        .mockResolvedValueOnce([]);
+        .mockResolvedValueOnce([]) // application methods
+        .mockResolvedValueOnce([]); // units
       prisma.reservedCommunityTypes.findMany = jest.fn().mockResolvedValueOnce([
         { name: 'sample reserved type', id: randomUUID() },
         { name: 'senior55', id: doorwayReservedCommunityTypeID },
@@ -658,6 +672,7 @@ describe('Testing script runner service', () => {
             status: 'active',
           },
         ])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([
           {
             name: 'oneBdr',
@@ -843,6 +858,7 @@ describe('Testing script runner service', () => {
             status: 'active',
           },
         ])
+        .mockResolvedValueOnce([]) // no application methods for this test
         .mockResolvedValueOnce([]) // no units for this test
         .mockResolvedValueOnce([
           {
@@ -936,6 +952,7 @@ describe('Testing script runner service', () => {
             status: 'active',
           },
         ])
+        .mockResolvedValueOnce([]) // no application methods
         .mockResolvedValueOnce([]) // no units for this test
         .mockResolvedValueOnce([]) // no multiselect questions
         .mockResolvedValueOnce([

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -240,7 +240,8 @@ describe('Testing script runner service', () => {
         .mockResolvedValueOnce([createAddress('building')])
         .mockResolvedValueOnce([createAddress('leasing agent')])
         .mockResolvedValueOnce([createAddress('application pick up')])
-        .mockResolvedValueOnce([createAddress('application drop up')]);
+        .mockResolvedValueOnce([createAddress('application drop up')])
+        .mockResolvedValueOnce([]); // units
       const createdListingId = randomUUID();
       const mockListingSave = jest
         .fn()
@@ -472,7 +473,8 @@ describe('Testing script runner service', () => {
             reserved_community_type_id: randomUUID(),
           },
         ])
-        .mockResolvedValueOnce([{ name: 'senior' }]);
+        .mockResolvedValueOnce([{ name: 'senior' }])
+        .mockResolvedValueOnce([]);
       prisma.reservedCommunityTypes.findMany = jest.fn().mockResolvedValueOnce([
         { name: 'sample reserved type', id: randomUUID() },
         { name: 'senior55', id: doorwayReservedCommunityTypeID },
@@ -578,19 +580,8 @@ describe('Testing script runner service', () => {
           reservedCommunityDescription: undefined,
           reservedCommunityMinAge: undefined,
           reservedCommunityTypes: {
-            connectOrCreate: {
-              create: {
-                description: undefined,
-                jurisdictions: {
-                  connect: {
-                    id: jurisdictionId,
-                  },
-                },
-                name: 'senior55',
-              },
-              where: {
-                id: doorwayReservedCommunityTypeID,
-              },
+            connect: {
+              id: doorwayReservedCommunityTypeID,
             },
           },
           resultLink: undefined,
@@ -852,7 +843,7 @@ describe('Testing script runner service', () => {
             status: 'active',
           },
         ])
-        .mockResolvedValueOnce(null) // no units for this test
+        .mockResolvedValueOnce([]) // no units for this test
         .mockResolvedValueOnce([
           {
             ordinal: 1,

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -7,6 +7,13 @@ import { ScriptRunnerService } from '../../../src/services/script-runner.service
 import { PrismaService } from '../../../src/services/prisma.service';
 import { User } from '../../../src/dtos/users/user.dto';
 import { AmiChartService } from '../../../src/services/ami-chart.service';
+import {
+  MultiselectQuestionsApplicationSectionEnum,
+  PrismaClient,
+} from '@prisma/client';
+import { mockDeep } from 'jest-mock-extended';
+
+const externalPrismaClient = mockDeep<PrismaClient>();
 
 describe('Testing script runner service', () => {
   let service: ScriptRunnerService;
@@ -26,47 +33,964 @@ describe('Testing script runner service', () => {
     prisma = module.get<PrismaService>(PrismaService);
   });
 
-  // because of how doorway ci env variables work we can't publicly expose a db for us to connect to
-  it.skip('should transfer data', async () => {
-    prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
-    prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
-    prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+  describe('transferJurisdictionData', () => {
+    it('should not transfer jurisdiction data if jurisdiction does not exist', async () => {
+      prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
+      const id = randomUUID();
+      await expect(
+        service.transferJurisdictionData(
+          {
+            user: {
+              id,
+            } as unknown as User,
+          } as unknown as ExpressRequest,
+          {
+            connectionString: 'sample',
+            jurisdiction: 'Sample jurisdiction',
+          },
+          externalPrismaClient,
+        ),
+      ).rejects.toThrowError(
+        "Sample jurisdiction county doesn't exist in Doorway database",
+      );
 
-    const id = randomUUID();
-    const scriptName = 'data transfer';
-
-    const res = await service.dataTransfer(
-      {
-        user: {
-          id,
-        } as unknown as User,
-      } as unknown as ExpressRequest,
-      {
-        connectionString: process.env.TEST_CONNECTION_STRING,
-      },
-    );
-
-    expect(res.success).toBe(true);
-
-    expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
-      where: {
-        scriptName,
-      },
+      prisma.jurisdictions.findFirst = jest
+        .fn()
+        .mockResolvedValue([{ name: 'sample jurisdiction', id: randomUUID() }]);
+      await expect(
+        service.transferJurisdictionData(
+          {
+            user: {
+              id,
+            } as unknown as User,
+          } as unknown as ExpressRequest,
+          {
+            connectionString: 'sample',
+            jurisdiction: 'Sample jurisdiction',
+          },
+          externalPrismaClient,
+        ),
+      ).rejects.toThrowError(
+        "Sample jurisdiction county doesn't exist in foreign database",
+      );
     });
-    expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
-      data: {
-        scriptName,
-        triggeringUser: id,
-      },
+
+    it('should transfer ami and multiselect questions', async () => {
+      prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
+      const jurisdictionId = randomUUID();
+      prisma.jurisdictions.findFirst = jest
+        .fn()
+        .mockResolvedValue({ name: 'sample jurisdiction', id: jurisdictionId });
+      externalPrismaClient.$queryRaw.mockResolvedValueOnce([
+        { name: 'sample jurisdiction', id: randomUUID() },
+      ]);
+      externalPrismaClient.$queryRawUnsafe
+        .mockResolvedValueOnce([
+          {
+            id: randomUUID(),
+            items: [],
+            name: 'sample jurisdiction AMI CHART 1',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: randomUUID(),
+            text: 'multiselect question',
+            sub_text: 'sub text',
+            description: 'multiselect question description',
+            options: [{ text: 'multiselect question option', ordinal: 1 }],
+            hide_from_listing: false,
+            application_section:
+              MultiselectQuestionsApplicationSectionEnum.preferences,
+            opt_out_text: "I don't want to be considered",
+          },
+        ]);
+      const mockAMIChartCalls = jest.fn().mockResolvedValue(null);
+      prisma.amiChart.createMany = mockAMIChartCalls;
+      const mockMultiselectQuestionCalls = jest.fn().mockResolvedValue(null);
+      prisma.multiselectQuestions.create = mockMultiselectQuestionCalls;
+      const userId = randomUUID();
+      const res = await service.transferJurisdictionData(
+        {
+          user: {
+            id: userId,
+          } as unknown as User,
+        } as unknown as ExpressRequest,
+        {
+          connectionString: 'sample',
+          jurisdiction: 'Sample jurisdiction',
+        },
+        externalPrismaClient,
+      );
+      expect(mockAMIChartCalls).toBeCalledTimes(1);
+      expect(mockAMIChartCalls).toBeCalledWith({
+        data: [
+          {
+            id: expect.anything(),
+            items: [],
+            jurisdictionId: jurisdictionId,
+            name: 'sample jurisdiction AMI CHART 1',
+          },
+        ],
+      });
+      expect(mockMultiselectQuestionCalls).toBeCalledTimes(1);
+      expect(mockMultiselectQuestionCalls).toBeCalledWith({
+        data: {
+          id: expect.anything(),
+          applicationSection: 'preferences',
+          jurisdictions: {
+            connect: { id: jurisdictionId },
+          },
+          links: undefined,
+          optOutText: "I don't want to be considered",
+          description: 'multiselect question description',
+          hideFromListing: false,
+          subText: 'sub text',
+          text: 'multiselect question',
+          options: [{ ordinal: 1, text: 'multiselect question option' }],
+        },
+      });
+
+      expect(res.success).toBe(true);
+      const scriptName = 'data transfer Sample jurisdiction';
+
+      expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
+        where: {
+          scriptName,
+        },
+      });
+      expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
+        data: {
+          scriptName,
+          triggeringUser: userId,
+        },
+      });
+      expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
+        data: {
+          didScriptRun: true,
+          triggeringUser: userId,
+        },
+        where: {
+          scriptName,
+        },
+      });
     });
-    expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
-      data: {
-        didScriptRun: true,
-        triggeringUser: id,
-      },
-      where: {
-        scriptName,
-      },
+  });
+
+  const createAddress = (name: string) => {
+    return {
+      place_name: name,
+      city: `${name} city`,
+      state: `${name} state`,
+      street: `${name} street`,
+      street2: `${name} street2`,
+      zipCode: `12345`,
+    };
+  };
+
+  describe('transferJurisdictionListingData', () => {
+    it('should transfer listings', async () => {
+      prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.unitAccessibilityPriorityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([]);
+      prisma.unitRentTypes.findMany = jest.fn().mockResolvedValue([]);
+
+      const jurisdictionId = randomUUID();
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        name: 'sample jurisdiction',
+        id: jurisdictionId,
+      });
+      externalPrismaClient.$queryRaw.mockResolvedValueOnce([
+        { name: 'sample jurisdiction', id: randomUUID() },
+      ]);
+      const listingId = randomUUID();
+      externalPrismaClient.$queryRawUnsafe
+        .mockResolvedValueOnce([
+          {
+            id: listingId,
+            name: 'sample listing',
+            created_at: new Date(),
+            digital_application: false,
+            common_digital_application: false,
+            paper_application: false,
+            referral_opportunity: false,
+            assets: [],
+            accessibility: 'accessibility',
+            amenities: 'amenities',
+            developer: 'developer',
+            household_size_max: 2,
+            household_size_min: 1,
+            display_waitlist_size: false,
+            status: 'active',
+            building_address_id: randomUUID(),
+            leasing_agent_address_id: randomUUID(),
+            application_pick_up_address_id: randomUUID(),
+            application_drop_off_address_id: randomUUID(),
+          },
+        ])
+        .mockResolvedValueOnce([createAddress('building')])
+        .mockResolvedValueOnce([createAddress('leasing agent')])
+        .mockResolvedValueOnce([createAddress('application pick up')])
+        .mockResolvedValueOnce([createAddress('application drop up')]);
+      const createdListingId = randomUUID();
+      const mockListingSave = jest
+        .fn()
+        .mockResolvedValueOnce({ id: createdListingId });
+      prisma.listings.create = mockListingSave;
+
+      const id = randomUUID();
+      const scriptName = 'data transfer listings Sample jurisdiction';
+
+      const res = await service.transferJurisdictionListingData(
+        {
+          user: {
+            id,
+          } as unknown as User,
+        } as unknown as ExpressRequest,
+        {
+          connectionString: 'Sample',
+          jurisdiction: 'Sample jurisdiction',
+        },
+        externalPrismaClient,
+      );
+
+      expect(prisma.listings.create).toBeCalledTimes(1);
+      expect(mockListingSave).toBeCalledWith({
+        data: {
+          id: listingId,
+          accessibility: 'accessibility',
+          additionalApplicationSubmissionNotes: undefined,
+          afsLastRunAt: undefined,
+          amenities: 'amenities',
+          amiPercentageMax: undefined,
+          amiPercentageMin: undefined,
+          applicationDropOffAddressOfficeHours: undefined,
+          applicationDropOffAddressType: undefined,
+          applicationDueDate: undefined,
+          applicationFee: undefined,
+          applicationMailingAddressType: undefined,
+          applicationOpenDate: undefined,
+          applicationOrganization: undefined,
+          applicationPickUpAddressOfficeHours: undefined,
+          applicationPickUpAddressType: undefined,
+          assets: [],
+          buildingSelectionCriteria: undefined,
+          buildingTotalUnits: undefined,
+          closedAt: undefined,
+          commonDigitalApplication: false,
+          contentUpdatedAt: undefined,
+          costsNotIncluded: undefined,
+          createdAt: expect.anything(),
+          creditHistory: undefined,
+          criminalBackground: undefined,
+          customMapPin: undefined,
+          depositHelperText: undefined,
+          depositMax: undefined,
+          depositMin: undefined,
+          developer: 'developer',
+          digitalApplication: false,
+          disableUnitsAccordion: undefined,
+          displayWaitlistSize: false,
+          homeType: undefined,
+          householdSizeMax: 2,
+          householdSizeMin: 1,
+          hrdId: undefined,
+          isVerified: undefined,
+          isWaitlistOpen: undefined,
+          jurisdictions: {
+            connect: {
+              id: jurisdictionId,
+            },
+          },
+          lastApplicationUpdateAt: undefined,
+          leasingAgentEmail: undefined,
+          leasingAgentName: undefined,
+          leasingAgentOfficeHours: undefined,
+          leasingAgentPhone: undefined,
+          leasingAgentTitle: undefined,
+          listingsApplicationDropOffAddress: {
+            create: {
+              city: 'application drop up city',
+              county: undefined,
+              createdAt: undefined,
+              latitude: undefined,
+              longitude: undefined,
+              placeName: 'application drop up',
+              state: 'application drop up state',
+              street: 'application drop up street',
+              street2: 'application drop up street2',
+              zipCode: undefined,
+            },
+          },
+          listingsApplicationMailingAddress: undefined,
+          listingsApplicationPickUpAddress: {
+            create: {
+              city: 'application pick up city',
+              county: undefined,
+              createdAt: undefined,
+              latitude: undefined,
+              longitude: undefined,
+              placeName: 'application pick up',
+              state: 'application pick up state',
+              street: 'application pick up street',
+              street2: 'application pick up street2',
+              zipCode: undefined,
+            },
+          },
+          listingsBuildingAddress: {
+            create: {
+              city: 'building city',
+              county: 'Sample jurisdiction',
+              createdAt: undefined,
+              latitude: undefined,
+              longitude: undefined,
+              placeName: 'building',
+              state: 'building state',
+              street: 'building street',
+              street2: 'building street2',
+              zipCode: undefined,
+            },
+          },
+          listingsLeasingAgentAddress: {
+            create: {
+              city: 'leasing agent city',
+              county: undefined,
+              createdAt: undefined,
+              latitude: undefined,
+              longitude: undefined,
+              placeName: 'leasing agent',
+              state: 'leasing agent state',
+              street: 'leasing agent street',
+              street2: 'leasing agent street2',
+              zipCode: undefined,
+            },
+          },
+          managementCompany: undefined,
+          managementWebsite: undefined,
+          marketingType: undefined,
+          name: 'sample listing',
+          neighborhood: undefined,
+          ownerCompany: undefined,
+          paperApplication: false,
+          petPolicy: undefined,
+          phoneNumber: undefined,
+          postmarkedApplicationsReceivedByDate: undefined,
+          programRules: undefined,
+          publishedAt: undefined,
+          referralOpportunity: false,
+          rentalAssistance: undefined,
+          rentalHistory: undefined,
+          requestedChanges: undefined,
+          requestedChangesDate: undefined,
+          requiredDocuments: undefined,
+          reservedCommunityDescription: undefined,
+          reservedCommunityMinAge: undefined,
+          reservedCommunityTypes: undefined,
+          resultLink: undefined,
+          reviewOrderType: undefined,
+          servicesOffered: undefined,
+          smokingPolicy: undefined,
+          specialNotes: undefined,
+          status: 'active',
+          unitAmenities: undefined,
+          unitsAvailable: undefined,
+          waitlistCurrentSize: undefined,
+          waitlistMaxSize: undefined,
+          waitlistOpenSpots: undefined,
+          whatToExpect: undefined,
+          yearBuilt: undefined,
+        },
+      });
+
+      expect(res.success).toBe(true);
+
+      expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
+        where: {
+          scriptName,
+        },
+      });
+      expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
+        data: {
+          scriptName,
+          triggeringUser: id,
+        },
+      });
+      expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
+        data: {
+          didScriptRun: true,
+          triggeringUser: id,
+        },
+        where: {
+          scriptName,
+        },
+      });
+    });
+
+    it('should transfer listings with RCD', async () => {
+      prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.unitAccessibilityPriorityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([]);
+      prisma.unitRentTypes.findMany = jest.fn().mockResolvedValue([]);
+
+      const jurisdictionId = randomUUID();
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        name: 'sample jurisdiction',
+        id: jurisdictionId,
+      });
+      externalPrismaClient.$queryRaw.mockResolvedValueOnce([
+        { name: 'sample jurisdiction', id: randomUUID() },
+      ]);
+      const doorwayReservedCommunityTypeID = randomUUID();
+      const listingId = randomUUID();
+      externalPrismaClient.$queryRawUnsafe
+        .mockResolvedValueOnce([
+          {
+            id: listingId,
+            name: 'sample listing',
+            created_at: new Date(),
+            digital_application: false,
+            common_digital_application: false,
+            paper_application: false,
+            referral_opportunity: false,
+            assets: [],
+            household_size_max: 2,
+            household_size_min: 1,
+            display_waitlist_size: false,
+            status: 'closed',
+            reserved_community_type_id: randomUUID(),
+          },
+        ])
+        .mockResolvedValueOnce([{ name: 'senior' }]);
+      prisma.reservedCommunityTypes.findMany = jest.fn().mockResolvedValueOnce([
+        { name: 'sample reserved type', id: randomUUID() },
+        { name: 'senior55', id: doorwayReservedCommunityTypeID },
+      ]);
+
+      const createdListingId = randomUUID();
+      const mockListingSave = jest
+        .fn()
+        .mockResolvedValueOnce({ id: createdListingId });
+      prisma.listings.create = mockListingSave;
+
+      const id = randomUUID();
+
+      await service.transferJurisdictionListingData(
+        {
+          user: {
+            id,
+          } as unknown as User,
+        } as unknown as ExpressRequest,
+        {
+          connectionString: 'Sample',
+          jurisdiction: 'Sample jurisdiction',
+        },
+        externalPrismaClient,
+      );
+
+      expect(mockListingSave).toBeCalledWith({
+        data: {
+          id: listingId,
+          accessibility: undefined,
+          additionalApplicationSubmissionNotes: undefined,
+          afsLastRunAt: undefined,
+          amenities: undefined,
+          amiPercentageMax: undefined,
+          amiPercentageMin: undefined,
+          applicationDropOffAddressOfficeHours: undefined,
+          applicationDropOffAddressType: undefined,
+          applicationDueDate: undefined,
+          applicationFee: undefined,
+          applicationMailingAddressType: undefined,
+          applicationOpenDate: undefined,
+          applicationOrganization: undefined,
+          applicationPickUpAddressOfficeHours: undefined,
+          applicationPickUpAddressType: undefined,
+          assets: [],
+          buildingSelectionCriteria: undefined,
+          buildingTotalUnits: undefined,
+          closedAt: undefined,
+          commonDigitalApplication: false,
+          contentUpdatedAt: undefined,
+          costsNotIncluded: undefined,
+          createdAt: expect.anything(),
+          creditHistory: undefined,
+          criminalBackground: undefined,
+          customMapPin: undefined,
+          depositHelperText: undefined,
+          depositMax: undefined,
+          depositMin: undefined,
+          developer: undefined,
+          digitalApplication: false,
+          disableUnitsAccordion: undefined,
+          displayWaitlistSize: false,
+          homeType: undefined,
+          householdSizeMax: 2,
+          householdSizeMin: 1,
+          hrdId: undefined,
+          isVerified: undefined,
+          isWaitlistOpen: undefined,
+          jurisdictions: {
+            connect: {
+              id: jurisdictionId,
+            },
+          },
+          lastApplicationUpdateAt: undefined,
+          leasingAgentEmail: undefined,
+          leasingAgentName: undefined,
+          leasingAgentOfficeHours: undefined,
+          leasingAgentPhone: undefined,
+          leasingAgentTitle: undefined,
+          listingsApplicationDropOffAddress: undefined,
+          listingsApplicationMailingAddress: undefined,
+          listingsApplicationPickUpAddress: undefined,
+          listingsBuildingAddress: undefined,
+          listingsLeasingAgentAddress: undefined,
+          managementCompany: undefined,
+          managementWebsite: undefined,
+          marketingType: undefined,
+          name: 'sample listing',
+          neighborhood: undefined,
+          ownerCompany: undefined,
+          paperApplication: false,
+          petPolicy: undefined,
+          phoneNumber: undefined,
+          postmarkedApplicationsReceivedByDate: undefined,
+          programRules: undefined,
+          publishedAt: undefined,
+          referralOpportunity: false,
+          rentalAssistance: undefined,
+          rentalHistory: undefined,
+          requestedChanges: undefined,
+          requestedChangesDate: undefined,
+          requiredDocuments: undefined,
+          reservedCommunityDescription: undefined,
+          reservedCommunityMinAge: undefined,
+          reservedCommunityTypes: {
+            connectOrCreate: {
+              create: {
+                description: undefined,
+                jurisdictions: {
+                  connect: {
+                    id: jurisdictionId,
+                  },
+                },
+                name: 'senior55',
+              },
+              where: {
+                id: doorwayReservedCommunityTypeID,
+              },
+            },
+          },
+          resultLink: undefined,
+          reviewOrderType: undefined,
+          servicesOffered: undefined,
+          smokingPolicy: undefined,
+          specialNotes: undefined,
+          status: 'closed',
+          unitAmenities: undefined,
+          unitsAvailable: undefined,
+          waitlistCurrentSize: undefined,
+          waitlistMaxSize: undefined,
+          waitlistOpenSpots: undefined,
+          whatToExpect: undefined,
+          yearBuilt: undefined,
+        },
+      });
+    });
+
+    it('should transfer units for listings', async () => {
+      console.log = jest.fn();
+      prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      const doorwayPriorityTypeId = randomUUID();
+      const priorityTypeId = randomUUID();
+      prisma.unitAccessibilityPriorityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([
+          { name: 'sample priority type', id: doorwayPriorityTypeId },
+        ]);
+      const doorwayRentTypeId = randomUUID();
+      const rentTypeId = randomUUID();
+      prisma.unitRentTypes.findMany = jest.fn().mockResolvedValue([
+        { name: 'fixed', id: doorwayRentTypeId },
+        { name: 'percentageOfIncome', id: randomUUID() },
+      ]);
+
+      const jurisdictionId = randomUUID();
+      const amiChartId = randomUUID();
+      const anotherAmiChartId = randomUUID();
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        name: 'sample jurisdiction',
+        id: jurisdictionId,
+      });
+      externalPrismaClient.$queryRaw
+        .mockResolvedValueOnce([
+          { name: 'sample jurisdiction', id: randomUUID() },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'sample priority type', id: priorityTypeId },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'fixed', id: rentTypeId },
+          { name: 'percentageOfIncome', id: randomUUID() },
+        ]);
+      externalPrismaClient.$queryRawUnsafe
+        .mockResolvedValueOnce([
+          {
+            id: randomUUID(),
+            name: 'sample listing',
+            created_at: new Date(),
+            digital_application: false,
+            common_digital_application: false,
+            paper_application: false,
+            referral_opportunity: false,
+            assets: [],
+            accessibility: 'accessibility',
+            amenities: 'amenities',
+            developer: 'developer',
+            household_size_max: 2,
+            household_size_min: 1,
+            display_waitlist_size: false,
+            status: 'active',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            name: 'oneBdr',
+            floor: 1,
+            ami_percentage: '30',
+            annual_income_min: '1000',
+            annual_income_max: '10000',
+            max_occupancy: 5,
+            min_occupancy: 2,
+            num_bathrooms: 1,
+            num_bedrooms: 2,
+            number: '200',
+            sq_feet: '600',
+            ami_chart_id: amiChartId,
+            priority_type_id: priorityTypeId,
+            unit_rent_type_id: rentTypeId,
+          },
+          {
+            name: 'studio',
+            floor: 1,
+            ami_percentage: '30',
+            annual_income_min: '1000',
+            annual_income_max: '10000',
+            max_occupancy: 5,
+            min_occupancy: 2,
+            num_bathrooms: 1,
+            num_bedrooms: 2,
+            number: '200',
+            sq_feet: '600',
+            ami_chart_id: anotherAmiChartId, //This ami chart should not be found
+          },
+        ]);
+      const unitTypeId = randomUUID();
+      prisma.unitTypes.findFirst = jest
+        .fn()
+        .mockResolvedValueOnce({ id: unitTypeId });
+      prisma.amiChart.findFirst = jest
+        .fn()
+        .mockResolvedValueOnce({ id: amiChartId })
+        .mockResolvedValueOnce(null);
+      const createdListingId = randomUUID();
+      const mockListingSave = jest
+        .fn()
+        .mockResolvedValueOnce({ id: createdListingId });
+      prisma.listings.create = mockListingSave;
+      const mockUnitsSave = jest.fn().mockResolvedValueOnce(null);
+      prisma.units.create = mockUnitsSave;
+
+      const id = randomUUID();
+      const scriptName = 'data transfer listings Sample jurisdiction';
+
+      const res = await service.transferJurisdictionListingData(
+        {
+          user: {
+            id,
+          } as unknown as User,
+        } as unknown as ExpressRequest,
+        {
+          connectionString: 'Sample',
+          jurisdiction: 'Sample jurisdiction',
+        },
+        externalPrismaClient,
+      );
+
+      expect(console.log).toBeCalledWith(
+        `Ami chart not found in Doorway: ${anotherAmiChartId} for listing sample listing`,
+      );
+
+      expect(prisma.listings.create).toBeCalledTimes(1);
+      expect(prisma.units.create).toBeCalledTimes(2);
+      expect(prisma.units.create).toBeCalledWith({
+        data: {
+          amiChart: {
+            connect: {
+              id: amiChartId,
+            },
+          },
+          amiPercentage: '30',
+          annualIncomeMax: '10000',
+          annualIncomeMin: '1000',
+          bmrProgramChart: undefined,
+          floor: 1,
+          listings: {
+            connect: {
+              id: createdListingId,
+            },
+          },
+          maxOccupancy: 5,
+          minOccupancy: 2,
+          monthlyIncomeMin: undefined,
+          monthlyRent: undefined,
+          monthlyRentAsPercentOfIncome: undefined,
+          numBathrooms: 1,
+          numBedrooms: 2,
+          number: '200',
+          sqFeet: '600',
+          status: undefined,
+          unitAccessibilityPriorityTypes: {
+            connect: {
+              id: doorwayPriorityTypeId,
+            },
+          },
+          unitRentTypes: {
+            connect: {
+              id: doorwayRentTypeId,
+            },
+          },
+          unitTypes: {
+            connect: {
+              id: unitTypeId,
+            },
+          },
+        },
+      });
+
+      expect(res.success).toBe(true);
+
+      expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
+        where: {
+          scriptName,
+        },
+      });
+      expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
+        data: {
+          scriptName,
+          triggeringUser: id,
+        },
+      });
+      expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
+        data: {
+          didScriptRun: true,
+          triggeringUser: id,
+        },
+        where: {
+          scriptName,
+        },
+      });
+    });
+
+    it('should transfer listing multiselect questions', async () => {
+      console.log = jest.fn();
+      prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.unitAccessibilityPriorityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([]);
+      prisma.unitRentTypes.findMany = jest.fn().mockResolvedValue([]);
+      const jurisdictionId = randomUUID();
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        name: 'sample jurisdiction',
+        id: jurisdictionId,
+      });
+      externalPrismaClient.$queryRaw.mockResolvedValueOnce([
+        { name: 'sample jurisdiction', id: randomUUID() },
+      ]);
+      const createdListingId = randomUUID();
+      const mockListingSave = jest
+        .fn()
+        .mockResolvedValueOnce({ id: createdListingId });
+      prisma.listings.create = mockListingSave;
+
+      const externalListingId = randomUUID();
+      const multiselectQuestionId = randomUUID();
+      const differentMultiselectQuestionId = randomUUID();
+      externalPrismaClient.$queryRawUnsafe
+        .mockResolvedValueOnce([
+          {
+            id: externalListingId,
+            name: 'sample listing',
+            created_at: new Date(),
+            digital_application: false,
+            common_digital_application: false,
+            paper_application: false,
+            referral_opportunity: false,
+            assets: [],
+            accessibility: 'accessibility',
+            amenities: 'amenities',
+            developer: 'developer',
+            household_size_max: 2,
+            household_size_min: 1,
+            display_waitlist_size: false,
+            status: 'active',
+          },
+        ])
+        .mockResolvedValueOnce(null) // no units for this test
+        .mockResolvedValueOnce([
+          {
+            ordinal: 1,
+            listingId: externalListingId,
+            multiselect_question_id: multiselectQuestionId,
+          },
+          {
+            ordinal: 2,
+            listingId: externalListingId,
+            multiselect_question_id: differentMultiselectQuestionId, // multiselect question not in doorway
+          },
+        ]);
+
+      const mockListingMultiselectQuestionCreate = jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockRejectedValueOnce('ERROR!');
+      prisma.listingMultiselectQuestions.create =
+        mockListingMultiselectQuestionCreate;
+
+      const id = randomUUID();
+
+      await service.transferJurisdictionListingData(
+        {
+          user: {
+            id,
+          } as unknown as User,
+        } as unknown as ExpressRequest,
+        {
+          connectionString: 'Sample',
+          jurisdiction: 'Sample jurisdiction',
+        },
+        externalPrismaClient,
+      );
+
+      expect(prisma.listingMultiselectQuestions.create).toBeCalledTimes(2);
+      expect(prisma.listingMultiselectQuestions.create).toBeCalledWith({
+        data: {
+          listingId: createdListingId,
+          multiselectQuestionId: multiselectQuestionId,
+          ordinal: 1,
+        },
+      });
+
+      expect(console.log).toBeCalledWith(
+        `unable to migrate listing multiselect question ${differentMultiselectQuestionId} to listing ${createdListingId}`,
+      );
+    });
+
+    it('should transfer listing events', async () => {
+      prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+      prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.unitAccessibilityPriorityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([]);
+      prisma.unitRentTypes.findMany = jest.fn().mockResolvedValue([]);
+      const jurisdictionId = randomUUID();
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        name: 'sample jurisdiction',
+        id: jurisdictionId,
+      });
+      externalPrismaClient.$queryRaw.mockResolvedValueOnce([
+        { name: 'sample jurisdiction', id: randomUUID() },
+      ]);
+      const createdListingId = randomUUID();
+      const mockListingSave = jest
+        .fn()
+        .mockResolvedValueOnce({ id: createdListingId });
+      prisma.listings.create = mockListingSave;
+
+      const externalListingId = randomUUID();
+      externalPrismaClient.$queryRawUnsafe
+        .mockResolvedValueOnce([
+          {
+            id: externalListingId,
+            name: 'sample listing',
+            created_at: new Date(),
+            digital_application: false,
+            common_digital_application: false,
+            paper_application: false,
+            referral_opportunity: false,
+            assets: [],
+            accessibility: 'accessibility',
+            amenities: 'amenities',
+            developer: 'developer',
+            household_size_max: 2,
+            household_size_min: 1,
+            display_waitlist_size: false,
+            status: 'active',
+          },
+        ])
+        .mockResolvedValueOnce([]) // no units for this test
+        .mockResolvedValueOnce([]) // no multiselect questions
+        .mockResolvedValueOnce([
+          {
+            type: 'publicLottery',
+            url: 'http://example.com',
+            note: 'note',
+            label: 'label',
+            start_time: new Date(),
+            end_time: new Date(),
+            start_date: new Date(),
+          },
+        ]);
+
+      prisma.listingEvents.createMany = jest.fn();
+
+      const id = randomUUID();
+
+      await service.transferJurisdictionListingData(
+        {
+          user: {
+            id,
+          } as unknown as User,
+        } as unknown as ExpressRequest,
+        {
+          connectionString: 'Sample',
+          jurisdiction: 'Sample jurisdiction',
+        },
+        externalPrismaClient,
+      );
+
+      expect(prisma.listingEvents.createMany).toBeCalledTimes(1);
+      expect(prisma.listingEvents.createMany).toBeCalledWith({
+        data: [
+          {
+            endTime: expect.anything(),
+            label: 'label',
+            note: 'note',
+            startDate: expect.anything(),
+            startTime: expect.anything(),
+            type: 'publicLottery',
+            url: 'http://example.com',
+            listingId: createdListingId,
+          },
+        ],
+      });
     });
   });
 

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -7214,6 +7214,13 @@ jest-message-util@^29.6.3:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock-extended@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-2.0.4.tgz#2bb430ba0adb9e10ea6a68d08731f2129330c8fe"
+  integrity sha512-MgL3B3GjURQFjjPGqbCANydA5BFNPygv0mYp4Tjfxohh9MWwxxX8Eq2p6ncCt/Vt+RAnaLlDaI7gwrDRD7Pt9A==
+  dependencies:
+    ts-essentials "^7.0.3"
+
 jest-mock@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.6.3.tgz#433f3fd528c8ec5a76860177484940628bdf5e0a"
@@ -9628,6 +9635,11 @@ triple-beam@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
   integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
+
+ts-essentials@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
 ts-jest@~29.1.1:
   version "29.1.1"

--- a/shared-helpers/src/utilities/formKeys.ts
+++ b/shared-helpers/src/utilities/formKeys.ts
@@ -64,7 +64,7 @@ export const countyKeys = [
   "Marin",
   "Napa",
   // "San Francisco",
-  // "San Mateo",
+  "San Mateo",
   "Santa Clara",
   "Solano",
   "Sonoma",

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
@@ -152,7 +152,6 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
         ? getValues().applicationMethods
         : listing?.applicationMethods
 
-    console.log("applicationMethods", applicationMethods)
     applicationMethods?.forEach((method) => {
       switch (method.type) {
         case ApplicationMethodsTypeEnum.Internal:
@@ -188,7 +187,6 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
   // register applicationMethods so we can set a value for it
   register("applicationMethods")
 
-  console.log("methods", methods)
   return (
     <>
       <hr className="spacer-section-above spacer-section" />

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
@@ -152,6 +152,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
         ? getValues().applicationMethods
         : listing?.applicationMethods
 
+    console.log("applicationMethods", applicationMethods)
     applicationMethods?.forEach((method) => {
       switch (method.type) {
         case ApplicationMethodsTypeEnum.Internal:
@@ -186,6 +187,8 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
   }, [methods, setValue])
   // register applicationMethods so we can set a value for it
   register("applicationMethods")
+
+  console.log("methods", methods)
   return (
     <>
       <hr className="spacer-section-above spacer-section" />


### PR DESCRIPTION
This PR addresses [#715](https://github.com/housingbayarea/bloom/issues/715)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Initial script for moving over data from SMC. This adds two scripts, one for copying over the base jurisdiction data such as AMI charts and preferences and the other is for copying over listings/units.

Notes:
- Images and lottery results will be manually ported over by product. That way the images will be moved to s3.
- Requested approver field is not going to get ported over since this doesn't port over the users at this point. Talked with product and that is ok with them.

## How Can This Be Tested/Reviewed?

This is how I've been testing it:
- Do a reseed locally
- Start up the app locally and go to the swagger api `http://localhost:3100/api`.
- Login via the api to the admin account `http://localhost:3100/api#/auth/login`.
- Go to Heroku and get the DB credentials for the HBA staging environment `https://data.heroku.com/datastores/fd968c98-f208-4066-b8cf-7d3a6bf8ff03#administration`
- Use the credentials from above to run the first script `http://localhost:3100/api#/scriptRunner/transferJurisdictionData`. I've been using "San Mateo" as the jurisdiction but any of the three jurisdictions would work
- Verify that AMI charts and multiselect questions are in the database. You can also verify that they show up in the partner site (This will only work for San Mateo)
- Run the script for `http://localhost:3100/api#/scriptRunner/transferJurisdictionListingsData` using the same db credentials and jurisdiction used in the previous script
- Verify that the new Listings look identical in partners between HBA staging vs local partners


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
