### PR TITLE
feat: lottery status (released to partners / retracted) (bloom-housing#4167)

### DIFF
--- a/api/prisma/migrations/14_add_lottery_status_enums/migration.sql
+++ b/api/prisma/migrations/14_add_lottery_status_enums/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "lottery_status_enum" AS ENUM ('errored', 'ran', 'approved', 'releasedToPartners', 'publishedToPublic', 'expired');
+
+-- AlterTable
+ALTER TABLE "listings" ADD COLUMN     "lottery_status" "lottery_status_enum";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -516,6 +516,7 @@ model Listings {
   afsLastRunAt                          DateTime?                     @default(dbgenerated("'1970-01-01 00:00:00-07'::timestamp with time zone")) @map("afs_last_run_at") @db.Timestamptz(6)
   lastApplicationUpdateAt               DateTime?                     @default(dbgenerated("'1970-01-01 00:00:00-07'::timestamp with time zone")) @map("last_application_update_at") @db.Timestamptz(6)
   lotteryLastRunAt                      DateTime?                     @map("lottery_last_run_at") @db.Timestamptz(6)
+  lotteryStatus                         LotteryStatusEnum?            @map("lottery_status")
   buildingAddressId                     String?                       @map("building_address_id") @db.Uuid
   applicationPickUpAddressId            String?                       @map("application_pick_up_address_id") @db.Uuid
   applicationDropOffAddressId           String?                       @map("application_drop_off_address_id") @db.Uuid
@@ -1016,6 +1017,17 @@ enum ListingsStatusEnum {
   changesRequested
 
   @@map("listings_status_enum")
+}
+
+enum LotteryStatusEnum {
+  errored
+  ran
+  approved
+  releasedToPartners
+  publishedToPublic
+  expired
+
+  @@map("lottery_status_enum")
 }
 
 enum MultiselectQuestionsApplicationSectionEnum {

--- a/api/prisma/seed-helpers/listing-factory.ts
+++ b/api/prisma/seed-helpers/listing-factory.ts
@@ -5,6 +5,7 @@ import {
   PrismaClient,
   ListingsStatusEnum,
   ApplicationMethodsTypeEnum,
+  LotteryStatusEnum,
 } from '@prisma/client';
 import { randomInt } from 'crypto';
 import { randomName } from './word-generator';
@@ -41,6 +42,7 @@ export const listingFactory = async (
     reservedCommunityType?: string;
     digitalApp?: boolean;
     noImage?: boolean;
+    lotteryStatus?: LotteryStatusEnum;
   },
 ): Promise<Prisma.ListingsCreateInput> => {
   const previousListing = optionalParams?.listing || {};
@@ -66,6 +68,7 @@ export const listingFactory = async (
     assets: [],
     name: randomName(),
     status: optionalParams?.status || ListingsStatusEnum.active,
+    lotteryStatus: optionalParams?.lotteryStatus || undefined,
     displayWaitlistSize: Math.random() < 0.5,
     listingsBuildingAddress: {
       create: addressFactory(),

--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -26,34 +26,35 @@ import {
   ApiOkResponse,
 } from '@nestjs/swagger';
 import { Request as ExpressRequest, Response } from 'express';
-import { ListingService } from '../services/listing.service';
-import { defaultValidationPipeOptions } from '../utilities/default-validation-pipe-options';
-import { ListingsQueryParams } from '../dtos/listings/listings-query-params.dto';
 import { LanguagesEnum } from '@prisma/client';
-import { ListingsRetrieveParams } from '../dtos/listings/listings-retrieve-params.dto';
-import { PaginationAllowsAllQueryParams } from '../dtos/shared/pagination.dto';
-import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
-import { PaginatedListingDto } from '../dtos/listings/paginated-listing.dto';
-import Listing from '../dtos/listings/listing.dto';
-import { IdDTO } from '../dtos/shared/id.dto';
-import { ListingCreate } from '../dtos/listings/listing-create.dto';
-import { SuccessDTO } from '../dtos/shared/success.dto';
-import { ListingUpdate } from '../dtos/listings/listing-update.dto';
-import { ListingCreateUpdateValidationPipe } from '../validation-pipes/listing-create-update-pipe';
-import { mapTo } from '../utilities/mapTo';
-import { User } from '../dtos/users/user.dto';
-import { OptionalAuthGuard } from '../guards/optional.guard';
-import { ActivityLogInterceptor } from '../interceptors/activity-log.interceptor';
 import { ActivityLogMetadata } from '../decorators/activity-log-metadata.decorator';
-import { PermissionTypeDecorator } from '../decorators/permission-type.decorator';
 import { PermissionAction } from '../decorators/permission-action.decorator';
+import { PermissionTypeDecorator } from '../decorators/permission-type.decorator';
+import Listing from '../dtos/listings/listing.dto';
+import { ListingCreate } from '../dtos/listings/listing-create.dto';
+import { ListingCsvQueryParams } from '../dtos/listings/listing-csv-query-params.dto';
+import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
+import { ListingLotteryStatus } from '../dtos/listings/listing-lottery-status.dto';
+import { ListingsQueryParams } from '../dtos/listings/listings-query-params.dto';
+import { ListingsRetrieveParams } from '../dtos/listings/listings-retrieve-params.dto';
+import { ListingUpdate } from '../dtos/listings/listing-update.dto';
+import { PaginatedListingDto } from '../dtos/listings/paginated-listing.dto';
+import { IdDTO } from '../dtos/shared/id.dto';
+import { PaginationAllowsAllQueryParams } from '../dtos/shared/pagination.dto';
+import { SuccessDTO } from '../dtos/shared/success.dto';
+import { User } from '../dtos/users/user.dto';
 import { permissionActions } from '../enums/permissions/permission-actions-enum';
 import { AdminOrJurisdictionalAdminGuard } from '../guards/admin-or-jurisdiction-admin.guard';
-import { ListingCsvExporterService } from '../services/listing-csv-export.service';
-import { ListingCsvQueryParams } from '../dtos/listings/listing-csv-query-params.dto';
-import { PermissionGuard } from '../guards/permission.guard';
-import { ExportLogInterceptor } from '../interceptors/export-log.interceptor';
 import { ApiKeyGuard } from '../guards/api-key.guard';
+import { OptionalAuthGuard } from '../guards/optional.guard';
+import { PermissionGuard } from '../guards/permission.guard';
+import { ActivityLogInterceptor } from '../interceptors/activity-log.interceptor';
+import { ExportLogInterceptor } from '../interceptors/export-log.interceptor';
+import { ListingService } from '../services/listing.service';
+import { ListingCsvExporterService } from '../services/listing-csv-export.service';
+import { defaultValidationPipeOptions } from '../utilities/default-validation-pipe-options';
+import { mapTo } from '../utilities/mapTo';
+import { ListingCreateUpdateValidationPipe } from '../validation-pipes/listing-create-update-pipe';
 
 @Controller('listings')
 @ApiTags('listings')
@@ -197,9 +198,28 @@ export class ListingController {
     return await this.listingService.process();
   }
 
+  @Put('lotteryStatus')
+  @ApiOperation({
+    summary: 'Change the listing lottery status',
+    operationId: 'lotteryStatus',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  @UseGuards(ApiKeyGuard)
+  async lotteryStatus(
+    @Request() req: ExpressRequest,
+    @Body() dto: ListingLotteryStatus,
+  ): Promise<SuccessDTO> {
+    return await this.listingService.lotteryStatus(
+      dto,
+      mapTo(User, req['user']),
+    );
+  }
+
   @Put(':id')
   @ApiOperation({ summary: 'Update listing by id', operationId: 'update' })
   @UsePipes(new ListingCreateUpdateValidationPipe(defaultValidationPipeOptions))
+  @ApiOkResponse({ type: Listing })
+  @UseGuards(ApiKeyGuard)
   async update(
     @Request() req: ExpressRequest,
     @Param('id') listingId: string,

--- a/api/src/dtos/listings/listing-lottery-status.dto.ts
+++ b/api/src/dtos/listings/listing-lottery-status.dto.ts
@@ -1,0 +1,22 @@
+import { Expose } from 'class-transformer';
+import { IsDefined, IsEnum, IsString, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { LotteryStatusEnum } from '@prisma/client';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class ListingLotteryStatus {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  listingId: string;
+
+  @Expose()
+  @IsEnum(LotteryStatusEnum, { groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty({
+    enum: LotteryStatusEnum,
+    enumName: 'LotteryStatusEnum',
+  })
+  lotteryStatus: LotteryStatusEnum;
+}

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -18,6 +18,7 @@ import {
   ApplicationAddressTypeEnum,
   ApplicationMethodsTypeEnum,
   ListingsStatusEnum,
+  LotteryStatusEnum,
   ReviewOrderTypeEnum,
 } from '@prisma/client';
 import { EnforceLowerCase } from '../../decorators/enforce-lower-case.decorator';
@@ -411,6 +412,14 @@ class Listing extends AbstractDTO {
   @Type(() => Date)
   @ApiPropertyOptional()
   lotteryLastRunAt?: Date;
+
+  @Expose()
+  @IsEnum(LotteryStatusEnum, { groups: [ValidationsGroupsEnum.default] })
+  @ApiPropertyOptional({
+    enum: LotteryStatusEnum,
+    enumName: 'LotteryStatusEnum',
+  })
+  lotteryStatus?: LotteryStatusEnum;
 
   @Expose()
   @IsDate({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -1,10 +1,12 @@
 import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
   Inject,
   Injectable,
   Logger,
   NotFoundException,
   OnModuleInit,
-  HttpException,
 } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
@@ -12,42 +14,44 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   LanguagesEnum,
   ListingsStatusEnum,
+  LotteryStatusEnum,
   Prisma,
   ReviewOrderTypeEnum,
   UserRoleEnum,
 } from '@prisma/client';
 import { firstValueFrom } from 'rxjs';
+import { ApplicationFlaggedSetService } from './application-flagged-set.service';
+import { EmailService } from './email.service';
+import { PermissionService } from './permission.service';
 import { PrismaService } from './prisma.service';
+import { TranslationService } from './translation.service';
+import { AmiChart } from '../dtos/ami-charts/ami-chart.dto';
+import { Listing } from '../dtos/listings/listing.dto';
+import { ListingCreate } from '../dtos/listings/listing-create.dto';
+import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
+import { ListingLotteryStatus } from '../dtos/listings/listing-lottery-status.dto';
 import { ListingsQueryParams } from '../dtos/listings/listings-query-params.dto';
+import { ListingUpdate } from '../dtos/listings/listing-update.dto';
+import { IdDTO } from '../dtos/shared/id.dto';
+import { SuccessDTO } from '../dtos/shared/success.dto';
+import { User } from '../dtos/users/user.dto';
+import Unit from '../dtos/units/unit.dto';
+import { ListingViews } from '../enums/listings/view-enum';
+import { ListingFilterKeys } from '../enums/listings/filter-key-enum';
+import { permissionActions } from '../enums/permissions/permission-actions-enum';
+import { buildFilter } from '../utilities/build-filter';
+import { buildOrderByForListings } from '../utilities/build-order-by';
+import { startCronJob } from '../utilities/cron-job-starter';
+import { mapTo } from '../utilities/mapTo';
 import {
   buildPaginationMetaInfo,
   calculateSkip,
   calculateTake,
 } from '../utilities/pagination-helpers';
-import { buildOrderByForListings } from '../utilities/build-order-by';
-import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
-import { ListingFilterKeys } from '../enums/listings/filter-key-enum';
-import { buildFilter } from '../utilities/build-filter';
-import { Listing } from '../dtos/listings/listing.dto';
-import { mapTo } from '../utilities/mapTo';
 import {
   summarizeUnitsByTypeAndRent,
   summarizeUnits,
 } from '../utilities/unit-utilities';
-import { AmiChart } from '../dtos/ami-charts/ami-chart.dto';
-import { ListingViews } from '../enums/listings/view-enum';
-import { TranslationService } from './translation.service';
-import { ListingCreate } from '../dtos/listings/listing-create.dto';
-import { SuccessDTO } from '../dtos/shared/success.dto';
-import { ListingUpdate } from '../dtos/listings/listing-update.dto';
-import { ApplicationFlaggedSetService } from './application-flagged-set.service';
-import { User } from '../dtos/users/user.dto';
-import { EmailService } from './email.service';
-import { IdDTO } from '../dtos/shared/id.dto';
-import { startCronJob } from '../utilities/cron-job-starter';
-import { PermissionService } from './permission.service';
-import { permissionActions } from '../enums/permissions/permission-actions-enum';
-import Unit from '../dtos/units/unit.dto';
 
 export type getListingsArgs = {
   skip: number;
@@ -1776,5 +1780,121 @@ export class ListingService implements OnModuleInit {
     }
 
     return listing.jurisdictionId;
+  }
+
+  async lotteryStatus(
+    dto: ListingLotteryStatus,
+    requestingUser: User,
+  ): Promise<SuccessDTO> {
+    const storedListing = await this.findOrThrow(
+      dto.listingId,
+      ListingViews.details,
+    );
+
+    await this.permissionService.canOrThrow(
+      requestingUser,
+      'listing',
+      permissionActions.update,
+      {
+        id: storedListing.id,
+        jurisdictionId: storedListing.jurisdictionId,
+      },
+    );
+
+    if (storedListing.status !== ListingsStatusEnum.closed) {
+      throw new BadRequestException(
+        'Lottery status cannot be changed until listing is closed.',
+      );
+    }
+
+    const isAdmin = requestingUser.userRoles?.isAdmin;
+    const currentStatus = storedListing.lotteryStatus;
+
+    // TODO: remove when all status logic has been implemented
+    let res;
+
+    switch (dto?.lotteryStatus) {
+      case LotteryStatusEnum.ran: {
+        if (!isAdmin) {
+          throw new ForbiddenException();
+        } else if (
+          currentStatus === LotteryStatusEnum.approved ||
+          currentStatus === LotteryStatusEnum.releasedToPartners ||
+          currentStatus === LotteryStatusEnum.publishedToPublic
+        ) {
+          // TODO: add retracted to history
+          // TODO: remove when all status logic has been implemented
+          res = await this.prisma.listings.update({
+            data: {
+              lotteryStatus: dto?.lotteryStatus,
+            },
+            where: {
+              id: dto.listingId,
+            },
+          });
+        } else {
+          // TODO: add ran to history
+        }
+        break;
+      }
+      case LotteryStatusEnum.errored: {
+        // TODO
+        break;
+      }
+      case LotteryStatusEnum.approved: {
+        // TODO
+        break;
+      }
+      case LotteryStatusEnum.releasedToPartners: {
+        if (!isAdmin) {
+          throw new ForbiddenException();
+        } else if (currentStatus !== LotteryStatusEnum.approved) {
+          throw new BadRequestException(
+            'Lottery cannot be released to partners without being in approved state.',
+          );
+        }
+        // TODO: add released to partners to history
+        // TODO: remove when all status logic has been implemented
+        res = await this.prisma.listings.update({
+          data: {
+            lotteryStatus: dto?.lotteryStatus,
+          },
+          where: {
+            id: dto.listingId,
+          },
+        });
+        break;
+      }
+      case LotteryStatusEnum.publishedToPublic: {
+        // TODO
+        break;
+      }
+      case LotteryStatusEnum.expired: {
+        // TODO
+        break;
+      }
+      default: {
+        throw new BadRequestException(
+          `${dto?.lotteryStatus} is not an allowed lottery status.`,
+        );
+      }
+    }
+    // TODO: uncomment when all status logic is implemented
+    // const res = await this.prisma.listings.update({
+    //   data: {
+    //     lotteryStatus: dto?.lotteryStatus,
+    //   },
+    //   where: {
+    //     id: dto.listingId,
+    //   },
+    // });
+
+    if (!res) {
+      throw new HttpException('Listing lottery status failed to save.', 500);
+    }
+
+    return {
+      success: true,
+    };
   }
 }

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -6,6 +6,7 @@ import {
   LanguagesEnum,
   ListingEventsTypeEnum,
   ListingsStatusEnum,
+  LotteryStatusEnum,
   ReviewOrderTypeEnum,
   UnitTypeEnum,
   UserRoleEnum,
@@ -942,6 +943,105 @@ describe('Listing Controller Tests', () => {
         expect.arrayContaining([partnerUser.email]),
         process.env.PARTNERS_PORTAL_URL,
       );
+    });
+  });
+
+  describe('lottery status endpoint', () => {
+    it("should error when trying to update listing that doesn't exist", async () => {
+      const id = randomUUID();
+      const res = await request(app.getHttpServer())
+        .put('/listings/lotteryStatus')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          listingId: id,
+          lotteryStatus: LotteryStatusEnum.ran,
+        })
+        .set('Cookie', adminAccessToken)
+        .expect(404);
+      expect(res.body.message).toEqual(
+        `listingId ${id} was requested but not found`,
+      );
+    });
+
+    it('should error if user is not an admin and tries to update to ran or releasedToPartner', async () => {
+      const jurisdictionA = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdictionA.id, prisma);
+      const listingData = await listingFactory(jurisdictionA.id, prisma, {
+        status: ListingsStatusEnum.closed,
+      });
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .put('/listings/lotteryStatus')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          listingId: listing.id,
+          lotteryStatus: LotteryStatusEnum.ran,
+        })
+        .expect(403);
+
+      const res2 = await request(app.getHttpServer())
+        .put('/listings/lotteryStatus')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          listingId: listing.id,
+          lotteryStatus: LotteryStatusEnum.releasedToPartners,
+        })
+        .expect(403);
+    });
+
+    it('should update listing lottery status to releasedToPartners from approved', async () => {
+      const jurisdictionA = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdictionA.id, prisma);
+      const listingData = await listingFactory(jurisdictionA.id, prisma, {
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.approved,
+      });
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .put('/listings/lotteryStatus')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          listingId: listing.id,
+          lotteryStatus: LotteryStatusEnum.releasedToPartners,
+        })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+      expect(res.body.success).toEqual(true);
+    });
+
+    it('should update listing lottery status to ran from releasedToPartners aka retract', async () => {
+      const jurisdictionA = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdictionA.id, prisma);
+      const listingData = await listingFactory(jurisdictionA.id, prisma, {
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.releasedToPartners,
+      });
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .put('/listings/lotteryStatus')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          listingId: listing.id,
+          lotteryStatus: LotteryStatusEnum.ran,
+        })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+      expect(res.body.success).toEqual(true);
     });
   });
 });

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -5,6 +5,7 @@ import {
   LanguagesEnum,
   ListingEventsTypeEnum,
   ListingsStatusEnum,
+  LotteryStatusEnum,
   ReviewOrderTypeEnum,
   UnitTypeEnum,
   UserRoleEnum,
@@ -30,6 +31,7 @@ import { ListingViews } from '../../../src/enums/listings/view-enum';
 import { TranslationService } from '../../../src/services/translation.service';
 import { GoogleTranslateService } from '../../../src/services/google-translate.service';
 import { ListingCreate } from '../../../src/dtos/listings/listing-create.dto';
+import { ListingLotteryStatus } from 'src/dtos/listings/listing-lottery-status.dto';
 import { ListingUpdate } from '../../../src/dtos/listings/listing-update.dto';
 import { ListingPublishedCreate } from '../../../src/dtos/listings/listing-published-create.dto';
 import { ListingPublishedUpdate } from '../../../src/dtos/listings/listing-published-update.dto';
@@ -38,7 +40,6 @@ import { User } from '../../../src/dtos/users/user.dto';
 import { EmailService } from '../../../src/services/email.service';
 import { PermissionService } from '../../../src/services/permission.service';
 import { permissionActions } from '../../../src/enums/permissions/permission-actions-enum';
-import { disconnect } from 'process';
 
 /*
   generates a super simple mock listing for us to test logic with
@@ -2953,5 +2954,260 @@ describe('Testing listing service', () => {
         },
       });
     });
+  });
+
+  describe('Test lotteryStatus endpoint', () => {
+    const adminUser = {
+      id: 'admin id',
+      userRoles: {
+        isAdmin: true,
+      },
+    } as User;
+
+    const partnerUser = {
+      id: 'partner id',
+      userRoles: {
+        isAdmin: false,
+        isPartner: true,
+      },
+    } as User;
+
+    it('should error when listing is not closed', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.active,
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () =>
+          await service.lotteryStatus(
+            {
+              listingId: randomUUID(),
+              lotteryStatus: LotteryStatusEnum.ran,
+            } as ListingLotteryStatus,
+            user,
+          ),
+      ).rejects.toThrowError(
+        'Lottery status cannot be changed until listing is closed.',
+      );
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        user,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
+
+      expect(prisma.listings.update).not.toHaveBeenCalled();
+    });
+
+    it.todo(
+      'should not update status if requested status does not match enums',
+    );
+
+    it.todo('should update status to ran from null/errored');
+
+    it('should not update status to ran if user is not an admin', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.closed,
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () =>
+          await service.lotteryStatus(
+            {
+              listingId: randomUUID(),
+              lotteryStatus: LotteryStatusEnum.ran,
+            } as ListingLotteryStatus,
+            partnerUser,
+          ),
+      ).rejects.toThrowError();
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        partnerUser,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
+
+      expect(prisma.listings.update).not.toHaveBeenCalled();
+    });
+
+    it.todo('should update status to errored');
+
+    it.todo('should update status to approved from ran');
+
+    it.todo('should not update status to approved when status is not ran');
+
+    it.todo('should not update status to approved if user is not an admin');
+
+    it('should update status to releasedToPartners from approved', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.approved,
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.releasedToPartners,
+      });
+
+      await service.lotteryStatus(
+        {
+          listingId: randomUUID(),
+          lotteryStatus: LotteryStatusEnum.releasedToPartners,
+        } as ListingLotteryStatus,
+        adminUser,
+      );
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        adminUser,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
+      expect(prisma.listings.update).toHaveBeenCalledWith({
+        data: {
+          lotteryStatus: LotteryStatusEnum.releasedToPartners,
+        },
+        where: {
+          id: expect.anything(),
+        },
+      });
+    });
+
+    it('should not update status to releasedToPartners when status is not approved', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.ran,
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () =>
+          await service.lotteryStatus(
+            {
+              listingId: randomUUID(),
+              lotteryStatus: LotteryStatusEnum.releasedToPartners,
+            } as ListingLotteryStatus,
+            adminUser,
+          ),
+      ).rejects.toThrowError(
+        'Lottery cannot be released to partners without being in approved state.',
+      );
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        adminUser,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
+
+      expect(prisma.listings.update).not.toHaveBeenCalled();
+    });
+
+    it('should not update status to releasedToPartners if user is not an admin', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.ran,
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () =>
+          await service.lotteryStatus(
+            {
+              listingId: randomUUID(),
+              lotteryStatus: LotteryStatusEnum.releasedToPartners,
+            } as ListingLotteryStatus,
+            partnerUser,
+          ),
+      ).rejects.toThrowError();
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        partnerUser,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
+
+      expect(prisma.listings.update).not.toHaveBeenCalled();
+    });
+
+    it.todo(
+      'should update status to publishedToPublic from releasedToPartners',
+    );
+
+    it.todo(
+      'should not update status to publishedToPublic when status is not releasedToPartners',
+    );
+
+    it.todo(
+      'should not update status to publishedToPublic if user is not an admin or partner',
+    );
+
+    it('should update status to ran from approved/releasedToPartners/publishedToPublic aka retracted', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.releasedToPartners,
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+        status: ListingsStatusEnum.closed,
+        lotteryStatus: LotteryStatusEnum.ran,
+      });
+
+      await service.lotteryStatus(
+        {
+          listingId: randomUUID(),
+          lotteryStatus: LotteryStatusEnum.ran,
+        } as ListingLotteryStatus,
+        adminUser,
+      );
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        adminUser,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
+      expect(prisma.listings.update).toHaveBeenCalledWith({
+        data: {
+          lotteryStatus: LotteryStatusEnum.ran,
+        },
+        where: {
+          id: expect.anything(),
+        },
+      });
+    });
+
+    it.todo('should update status to expired');
   });
 });

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -356,7 +356,7 @@ export class ListingsService {
       body?: ListingUpdate
     } = {} as any,
     options: IRequestOptions = {}
-  ): Promise<any> {
+  ): Promise<Listing> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/listings/{id}"
       url = url.replace("{id}", params["id"] + "")
@@ -380,6 +380,28 @@ export class ListingsService {
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
       let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Change the listing lottery status
+   */
+  lotteryStatus(
+    params: {
+      /** requestBody */
+      body?: ListingLotteryStatus
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<Listing> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/lotteryStatus"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
 
       configs.data = data
 
@@ -3099,6 +3121,9 @@ export interface Listing {
   lotteryLastRunAt?: Date
 
   /**  */
+  lotteryStatus?: LotteryStatusEnum
+
+  /**  */
   lastApplicationUpdateAt?: Date
 
   /**  */
@@ -3603,6 +3628,9 @@ export interface ListingCreate {
   lotteryLastRunAt?: Date
 
   /**  */
+  lotteryStatus?: LotteryStatusEnum
+
+  /**  */
   lastApplicationUpdateAt?: Date
 
   /**  */
@@ -3670,6 +3698,14 @@ export interface ListingCreate {
 
   /**  */
   requestedChangesUser?: IdDTO
+}
+
+export interface ListingLotteryStatus {
+  /**  */
+  listingId: string
+
+  /**  */
+  lotteryStatus: LotteryStatusEnum
 }
 
 export interface ListingUpdate {
@@ -3858,6 +3894,9 @@ export interface ListingUpdate {
 
   /**  */
   lotteryLastRunAt?: Date
+
+  /**  */
+  lotteryStatus?: LotteryStatusEnum
 
   /**  */
   lastApplicationUpdateAt?: Date
@@ -5488,6 +5527,15 @@ export enum ReviewOrderTypeEnum {
   "lottery" = "lottery",
   "firstComeFirstServe" = "firstComeFirstServe",
   "waitlist" = "waitlist",
+}
+
+export enum LotteryStatusEnum {
+  "errored" = "errored",
+  "ran" = "ran",
+  "approved" = "approved",
+  "releasedToPartners" = "releasedToPartners",
+  "publishedToPublic" = "publishedToPublic",
+  "expired" = "expired",
 }
 
 export enum ValidationMethodEnum {


### PR DESCRIPTION
This PR addresses [#(4057)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4057)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Pulls over commit from core:
https://github.com/bloom-housing/bloom/pull/4167

## How Can This Be Tested/Reviewed?

Run migration and run backend in the terminal. Use the swagger open api for the following flows.
Flow 1: Login as an admin, attempt to change the status of a active listing to releasedToPartners, you should receive an error since listing is not closed.
Flow 2: Login as an admin, attempt to change the status of a closed listing to releasedToPartners, you should receive an error since it must be in approved.
Flow 3: Change the status manually in the db to approved, login as an admin, attempt to change the status of a closed listing to releasedToPartners, confirm change was successful, attempt to change status to ran (this is retracting the lottery), confirm success.
Flow 4: Attempt flow 3 as a partner or juris admin, confirm you receive permission errors.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
