### PR TITLE
fix: network error for password login

### DIFF
--- a/sites/public/src/pages/sign-in.tsx
+++ b/sites/public/src/pages/sign-in.tsx
@@ -157,13 +157,11 @@ const SignIn = () => {
       } catch (error) {
         setLoading(false)
         if (sendToReCaptchaFlow(error.response.data.name)) {
-          {
-            await singleUseCodeFlow(email, true)
-          }
-          const { status } = error.response || {}
-          determineNetworkError(status, error)
-          setRefreshReCaptcha(!refreshReCaptcha)
+          await singleUseCodeFlow(email, true)
         }
+        const { status } = error.response || {}
+        determineNetworkError(status, error)
+        setRefreshReCaptcha(!refreshReCaptcha)
       }
     }
   }


### PR DESCRIPTION
This PR addresses #727 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

With the addition of recaptcha, the determine network error check was accidentally moved to be only under the recaptcha check. This just pulls it outside of that if statement

## How Can This Be Tested/Reviewed?

Make sure you have `SHOW_PWDLESS=TRUE` set in your .env file for public
- When on the public site login page click "use your password instead"
- Enter an email that is not in the system and anything into the password field
- On submit make sure that an error message shows

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
