### PR TITLE
fix: add post lottery button when lottery functionality is turned on

### DIFF
--- a/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
+++ b/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
@@ -769,7 +769,7 @@ describe("<ListingFormActions>", () => {
       })
 
       it("renders correct buttons in a closed edit state", () => {
-        const { getByText } = render(
+        const { getByText, queryAllByText } = render(
           <AuthContext.Provider value={{ profile: adminUser }}>
             <ListingContext.Provider value={{ ...listing, status: ListingsStatusEnum.closed }}>
               <ListingFormActions type={ListingFormActionsType.edit} />
@@ -779,9 +779,23 @@ describe("<ListingFormActions>", () => {
         expect(getByText("Reopen")).toBeTruthy()
         expect(getByText("Save & Exit")).toBeTruthy()
         expect(getByText("Unpublish")).toBeTruthy()
-        // Disabled for Doorway
-        // expect(getByText("Post Results")).toBeTruthy()
+        expect(queryAllByText("Post Results")).toHaveLength(0)
         expect(getByText("Cancel")).toBeTruthy()
+      })
+      it("renders correct buttons in a closed edit state if lottery is turned on", () => {
+        process.env.showLottery = "TRUE"
+        const { getByText } = render(
+          <AuthContext.Provider value={{ profile: adminUser }}>
+            <ListingContext.Provider value={{ ...listing, status: ListingsStatusEnum.closed }}>
+              <ListingFormActions type={ListingFormActionsType.edit} />
+            </ListingContext.Provider>
+          </AuthContext.Provider>
+        )
+        expect(getByText("Reopen")).toBeInTheDocument()
+        expect(getByText("Save & Exit")).toBeInTheDocument()
+        expect(getByText("Unpublish")).toBeInTheDocument()
+        expect(getByText("Post Results")).toBeInTheDocument()
+        expect(getByText("Cancel")).toBeInTheDocument()
       })
     })
     describe("as a jurisdictional admin", () => {

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -168,7 +168,7 @@ const ListingFormActions = ({
     )
 
     // Disabled for Doorway
-    /* const editPostedResultsButton = (lotteryResults) => (
+    const editPostedResultsButton = (lotteryResults) => (
       <Grid.Cell className="flex" key="btn-edit-lottery">
         <Button
           type="button"
@@ -198,7 +198,7 @@ const ListingFormActions = ({
           {t("listings.actions.postResults")}
         </Button>
       </Grid.Cell>
-    ) */
+    )
 
     const previewButton = (
       <Grid.Cell key="btn-preview">
@@ -411,17 +411,19 @@ const ListingFormActions = ({
           elements.push(unpublishButton)
         }
 
-        // Disabled for Doorway
-        /* const lotteryResults = listing?.listingEvents?.find(
-          (event) => event.type === ListingEventsTypeEnum.lotteryResults
-        ) */
+        // Only admins can publish results
+        // and the functionality should only be turned on if the rest of lottery functionality is
+        if (isListingApprover && process.env.showLottery === "TRUE") {
+          const lotteryResults = listing?.listingEvents?.find(
+            (event) => event.type === ListingEventsTypeEnum.lotteryResults
+          )
 
-        // all users can manage lottery results on closed listings
-        /* if (lotteryResults) {
-          elements.push(editPostedResultsButton(lotteryResults))
-        } else if (listing.status === ListingsStatusEnum.closed) {
-          elements.push(postResultsButton)
-        } */
+          if (lotteryResults) {
+            elements.push(editPostedResultsButton(lotteryResults))
+          } else if (listing.status === ListingsStatusEnum.closed) {
+            elements.push(postResultsButton)
+          }
+        }
 
         elements.push(cancelButton)
       }


### PR DESCRIPTION
This PR addresses [#4171](https://github.com/bloom-housing/bloom/issues/4171)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Re-adds the post lottery button if the lottery functionality is turned on

## How Can This Be Tested/Reviewed?

Make sure `SHOW_LOTTERY=TRUE` is set in the env file for partners
- Go to the partner site and in a closed listing see that the "Post results" button is there when editing the listing
- Upload results and check that the "preview results" link appears
- Go to the public site and go to the listings page for the above listing. Check that the "Download Results" button is visible

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
