### PR TITLE
fix: filter ami charts by jurisdition (#4177)

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -149,6 +149,10 @@ export const stagingSeed = async (
   const amiChart = await prismaClient.amiChart.create({
     data: amiChartFactory(10, jurisdiction.id),
   });
+  await prismaClient.amiChart.create({
+    data: amiChartFactory(8, additionalJurisdiction.id),
+  });
+  // Create map layers
   await prismaClient.mapLayers.create({
     data: mapLayerFactory(jurisdiction.id, 'Redlined Districts', redlinedMap),
   });

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -36,7 +36,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
   const formMethods = useFormContext()
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { watch } = formMethods
-  const jurisdiction: string = watch("jurisdiction.id")
+  const jurisdiction: string = watch("jurisdictions.id")
   /**
    * fetch form options
    */


### PR DESCRIPTION
Pulls over the following commit from core:
- [fix: filter ami charts by jurisdition (](https://github.com/metrotranscom/doorway/commit/7c9b7955d3915a80729386a0d575bdc217c8bc92)https://github.com/bloom-housing/bloom/pull/4177[)](https://github.com/metrotranscom/doorway/commit/7c9b7955d3915a80729386a0d575bdc217c8bc92)

This is for ticket [#4174](https://github.com/bloom-housing/bloom/issues/4174)