### PR TITLE
fix: update google analytics to use ga4 syntax

### DIFF
--- a/sites/public/src/lib/customScripts.ts
+++ b/sites/public/src/lib/customScripts.ts
@@ -1,27 +1,24 @@
-export const headScript = () => {
-  const gtmKey = process.env.gtmKey
-  if (gtmKey) {
-    return `
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','${gtmKey}')
-    `
-  } else {
-    return ""
-  }
+export const gaLoadScript = () => {
+  const gaKey = process.env.gtmKey
+  if (gaKey) {
+    const script = document.createElement("script")
+    script.async = true
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${gaKey}`
+    return script
+  } else return null
 }
 
-export const bodyTopTag = () => {
-  const gtmKey = process.env.gtmKey
-  if (gtmKey) {
-    return `
-    <noscript><iframe height="0" src="//www.googletagmanager.com/ns.html?id=${gtmKey}" style="display:none;visibility:hidden" width="0"></iframe></noscript>
-  `
-  } else {
-    return ""
-  }
+export const gaCaptureScript = () => {
+  const gaKey = process.env.gtmKey
+  if (gaKey) {
+    const script = document.createElement("script")
+    script.innerHTML = `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '${gaKey}');`
+    return script
+  } else return null
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/sites/public/src/pages/_app.tsx
+++ b/sites/public/src/pages/_app.tsx
@@ -14,7 +14,7 @@ import {
   AuthProvider,
   MessageProvider,
 } from "@bloom-housing/shared-helpers"
-import { headScript, bodyTopTag, pageChangeHandler } from "../lib/customScripts"
+import { pageChangeHandler, gaLoadScript, gaCaptureScript } from "../lib/customScripts"
 import { AppSubmissionContext } from "../lib/applications/AppSubmissionContext"
 import ApplicationConductor, {
   loadApplicationFromAutosave,
@@ -60,16 +60,12 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
     if (!document.body.dataset.customScriptsLoaded) {
       router.events.on("routeChangeComplete", pageChangeHandler)
 
-      const headScriptTag = document.createElement("script")
-      headScriptTag.textContent = headScript()
-      if (headScriptTag.textContent !== "") {
-        document.head.append(headScriptTag)
-      }
-
-      const bodyTopTagTmpl = document.createElement("template")
-      bodyTopTagTmpl.innerHTML = bodyTopTag()
-      if (bodyTopTagTmpl.innerHTML !== "") {
-        document.body.prepend(bodyTopTagTmpl.content.cloneNode(true))
+      // GA 4 Tracking
+      const gaLoadNode = gaLoadScript()
+      const gaCaptureNode = gaCaptureScript()
+      if (gaLoadNode && gaCaptureNode) {
+        document.head.append(gaLoadNode)
+        document.head.append(gaCaptureNode)
       }
 
       document.body.dataset.customScriptsLoaded = "true"


### PR DESCRIPTION
## Description

Google Analytics stopped working for Doorway at the end of May/early June. https://exygy.slack.com/archives/C02G1S19QA2/p1719945449278659. I am not sure how we were able to get data before then as I know google turned off UA integration. Maybe it was a slow roll out and it finally got to us. But this PR uses the styling of HBA to add the google analytics script tags to the site.

## How Can This Be Tested/Reviewed?

When running this locally make sure you have a google analytic tag set for the public site `GTM_KEY=G-XXXXXXXXXX`

Load the public site and go to a few pages, make sure that there is a network call to `https://www.google-analytics.com/g/collect` with the above google tag

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
