### PR TITLE
fix: use working link for Contra Costa in Immediate Housing Assistance

### DIFF
--- a/sites/public/src/tsx_content/housing-help-cards.tsx
+++ b/sites/public/src/tsx_content/housing-help-cards.tsx
@@ -39,7 +39,7 @@ export function housingHelpLinkableCards(): React.ReactElement<CardProps>[] {
           {t("help.housingHelp.immediate.alamedaODinfo")}
         </DoorwayCollapsibleSection>
         <DoorwayCollapsibleSection title={t("counties.fullname.ContraCosta")}>
-          <a href="https://cchealth.org/h3/coc/help.php" target="_blank">
+          <a href="https://www.cchealth.org/services-and-programs/homeless-services" target="_blank">
             {t("help.housingHelp.immediate.contraCostaCHS")}
           </a>
           {t("help.housingHelp.immediate.contraCostaCHSinfo")}

--- a/sites/public/src/tsx_content/housing-help-cards.tsx
+++ b/sites/public/src/tsx_content/housing-help-cards.tsx
@@ -39,7 +39,10 @@ export function housingHelpLinkableCards(): React.ReactElement<CardProps>[] {
           {t("help.housingHelp.immediate.alamedaODinfo")}
         </DoorwayCollapsibleSection>
         <DoorwayCollapsibleSection title={t("counties.fullname.ContraCosta")}>
-          <a href="https://www.cchealth.org/services-and-programs/homeless-services" target="_blank">
+          <a
+            href="https://www.cchealth.org/services-and-programs/homeless-services"
+            target="_blank"
+          >
             {t("help.housingHelp.immediate.contraCostaCHS")}
           </a>
           {t("help.housingHelp.immediate.contraCostaCHSinfo")}


### PR DESCRIPTION
This PR addresses #746 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Fixes the link for Contra Costa.

## How Can This Be Tested/Reviewed?

Visit the Help Center > Housing Help page and verify the link works under Immediate Housing Assistance > Contra Costa County.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
