### PR TITLE
fix: ensure mutually-exclusive "none" option for Vouchers question

### DIFF
--- a/sites/public/src/components/shared/FormSummaryDetails.tsx
+++ b/sites/public/src/components/shared/FormSummaryDetails.tsx
@@ -481,7 +481,7 @@ const FormSummaryDetails = ({
             label={t("application.review.voucherOrSubsidy")}
             className={styles["summary-value"]}
           >
-            {application.incomeVouchers ? t("t.yes") : t("t.no")}
+            {application.incomeVouchers?.some((item) => item === "none") ? t("t.no") : t("t.yes")}
           </FieldValue>
 
           {application.incomePeriod && (

--- a/sites/public/src/pages/applications/financial/vouchers.tsx
+++ b/sites/public/src/pages/applications/financial/vouchers.tsx
@@ -29,8 +29,14 @@ const ApplicationVouchers = () => {
     : 3
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, errors, trigger } = useForm({
-    defaultValues: { incomeVouchers: application.incomeVouchers?.toString() },
+  const { register, handleSubmit, errors, trigger, getValues, setValue, clearErrors } = useForm({
+    defaultValues: {
+      incomeVouchers: Object.fromEntries(
+        application.incomeVouchers
+          ? application.incomeVouchers.map((item) => [`incomeVouchers-${item}`, true])
+          : []
+      ),
+    },
     shouldFocusError: false,
   })
 
@@ -38,7 +44,9 @@ const ApplicationVouchers = () => {
     const validation = await trigger()
     if (!validation) return
 
-    const { incomeVouchers } = data
+    const incomeVouchers = Object.entries(data)
+      .map(([key, value]) => (!!value ? key.replace("incomeVouchers-", "") : null))
+      .filter((item) => item)
     const toSave = { incomeVouchers }
 
     conductor.currentStep.save(toSave)
@@ -50,8 +58,23 @@ const ApplicationVouchers = () => {
 
   const incomeVouchersOptions = vouchersOrRentalAssistanceKeys.map((item) => ({
     id: item,
+    value: item,
     label: t(`application.financial.vouchers.options.${item}`),
     defaultChecked: application?.incomeVouchers?.includes(item) || false,
+    uniqueName: true,
+    inputProps: {
+      onChange: (e) => {
+        if (e.target.checked) {
+          if (item === "none") {
+            setValue("incomeVouchers-issuedVouchers", false)
+            setValue("incomeVouchers-rentalAssistance", false)
+          } else {
+            setValue("incomeVouchers-none", false)
+          }
+          clearErrors()
+        }
+      },
+    },
   }))
 
   useEffect(() => {
@@ -101,8 +124,15 @@ const ApplicationVouchers = () => {
                 name="incomeVouchers"
                 fields={incomeVouchersOptions}
                 type="checkbox"
-                validation={{ required: true }}
-                error={errors?.incomeVouchers}
+                validation={{
+                  validate: () => {
+                    return !!Object.values(getValues()).filter((value) => value).length
+                  },
+                }}
+                error={
+                  Object.keys(errors).length === Object.keys(getValues()).length &&
+                  Object.keys(getValues()).length > 0
+                }
                 errorMessage={t("errors.selectAtLeastOne")}
                 register={register}
                 dataTestId={"app-income-vouchers"}

--- a/sites/public/src/pages/applications/financial/vouchers.tsx
+++ b/sites/public/src/pages/applications/financial/vouchers.tsx
@@ -45,7 +45,7 @@ const ApplicationVouchers = () => {
     if (!validation) return
 
     const incomeVouchers = Object.entries(data)
-      .map(([key, value]) => (!!value ? key.replace("incomeVouchers-", "") : null))
+      .map(([key, value]) => (value ? key.replace("incomeVouchers-", "") : null))
       .filter((item) => item)
     const toSave = { incomeVouchers }
 


### PR DESCRIPTION
This PR addresses #751 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When you get to the Common App question about Section 8 vouchers, etc., you'll see that if you select None of the above, it deselects the other options—and when you select one of those, None is deselected.

## How Can This Be Tested/Reviewed?

Fill out Common App, verify the option selection

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
