### PR TITLE
fix: monthly rent seed data

### DIFF
--- a/api/prisma/seed-helpers/unit-factory.ts
+++ b/api/prisma/seed-helpers/unit-factory.ts
@@ -39,9 +39,7 @@ export const unitFactorySingle = (
     minOccupancy: bedrooms,
     maxOccupancy: bedrooms + 2,
     monthlyIncomeMin: randomInt(3500).toString(),
-    monthlyRent: ((Math.random() * 100 + 2500) * (bedrooms || 1)).toPrecision(
-      2,
-    ),
+    monthlyRent: ((Math.random() * 100 + 2500) * (bedrooms || 1)).toFixed(2),
     unitRentTypes: optionalParams?.unitRentTypeId
       ? { connect: { id: optionalParams?.unitRentTypeId } }
       : {


### PR DESCRIPTION
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Seed data bug was introduced in https://github.com/metrotranscom/doorway/pull/760. toPercision makes a string with `e+` which causes a problem in the partners portal. Switching to toFixed instead to limit decimals but not introducing other string characters.

## How Can This Be Tested/Reviewed?

Run `yarn setup`. Check `units` table in the db or run partners portal and check the seeded listing units.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
