### PR TITLE
fix: availability filter

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -282,7 +282,7 @@ export class ListingService implements OnModuleInit {
           filter[ListingFilterKeys.availability] ===
           FilterAvailabilityEnum.waitlistOpen
         ) {
-          whereClauseArray.push(`combined.is_waitlist_open = true`);
+          whereClauseArray.push(`combined.review_order_type = 'waitlist'`);
         } else if (
           filter[ListingFilterKeys.availability] ===
           FilterAvailabilityEnum.unitsAvailable


### PR DESCRIPTION
This PR addresses #720

## Description

A bug fix for the availability type filter. Previously, a listing would only show for open waitlist if it also specified a number of available spots on the waitlist. With this change, if a listing selects the waitlist review order type, it will show.

## How Can This Be Tested/Reviewed?

Add or update a listing to have the waitlist review order and ensure it shows on the frontend when the open waitlist filter is selected.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
