### PR TITLE
feat: doorway infra release - banner

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -52,6 +52,7 @@
   "account.viewApplications": "Ver solicitudes",
   "alert.applicationMessage": "¡Las solicitudes ya están disponibles para más listados! Es posible que deba crear una cuenta. Revise los <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-terms-use' target='_blank'>Términos de uso</a> y la <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-privacy-policy' target='_blank'>Política de privacidad</a>, los cuales han cambiado.",
   "alert.maintenance": "Este sitio está en mantenimiento programado. Nos disculpamos por cualquier inconveniente.",
+  "alert.infraMaintenance": "El portal Doorway Housing se someterá a un breve mantenimiento el 8 de agosto de 7:00 a 8:00 a. m., hora del Pacífico. Si tiene problemas para acceder al portal, vuelva a intentarlo más tarde. Gracias por su comprensión.",
   "application.ada.hearing": "Para deficiencias auditivas",
   "application.ada.label": "Viviendas accesibles de conformidad con ADA",
   "application.ada.mobility": "Para problemas de movilidad",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -52,6 +52,7 @@
   "account.settings.update": "Update",
   "alert.applicationMessage": "Applications are now available for more listings! You may be required to create an account. Please review the <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-terms-use' target='_blank'>Terms of Use</a> and <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-privacy-policy' target='_blank'>Privacy Policy</a>, both of which have changed.",
   "alert.maintenance": "This site is undergoing scheduled maintenance. We apologize for any inconvenience.",
+  "alert.infraMaintenance": "The Doorway Housing Portal will be undergoing brief maintenance on 8/8 from 7:00 - 8:00 am Pacific time. If you have trouble reaching the portal, please try back later. Thank you for your understanding.",
   "application.ada.hearing": "For Hearing Impairments",
   "application.ada.label": "ADA Accessible Units",
   "application.ada.mobility": "For Mobility Impairments",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -52,6 +52,7 @@
   "account.viewApplications": "Tingnan ang mga aplikasyon",
   "alert.applicationMessage": "Ang mga aplikasyon ay magagamit na ngayon para sa higit pang mga listahan! Maaaring kailanganin kang gumawa ng account. Pakisuri ang <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-terms-use' target='_blank'>Mga Tuntunin ng Paggamit</a> at <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-privacy-policy' target='_blank'>Patakaran sa Privacy</a>, na parehong nagbago.",
   "alert.maintenance": "Ang site na ito ay sumasailalim sa naka-iskedyul na pagpapanatili. Humihingi kami ng paumanhin para sa anumang abala.",
+  "alert.infraMaintenance": "Cổng thông tin Nhà ở Doorway sẽ được bảo trì ngắn hạn vào ngày 8/8 từ 7:00 - 8:00 sáng theo giờ Thái Bình Dương. Nếu bạn gặp khó khăn khi truy cập cổng, vui lòng thử lại sau. Cảm ơn bạn đã hiểu biết của bạn.",
   "application.ada.hearing": "Para sa mga Kapansanan sa Pandinig",
   "application.ada.label": "Mga Accessible Unit ng ADA",
   "application.ada.mobility": "Para sa mga Kapansanan sa Pagkilos",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -52,6 +52,7 @@
   "account.viewApplications": "Xem hồ sơ",
   "alert.applicationMessage": "Các ứng dụng hiện có sẵn cho nhiều danh sách hơn! Bạn có thể được yêu cầu tạo một tài khoản. Vui lòng xem lại <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-terms-use' target='_blank'>Điều khoản sử dụng</a> và <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-privacy-policy' target='_blank'>Chính sách quyền riêng tư</a>, cả hai đều đã thay đổi.",
   "alert.maintenance": "Trang web này đang được bảo trì theo lịch trình. Chúng tôi xin lỗi vì bất cứ sự bất tiện nào.",
+  "alert.infraMaintenance": "Ang Doorway Housing Portal ay sasailalim sa maikling maintenance sa 8/8 mula 7:00 - 8:00 am Pacific time. Kung nahihirapan kang maabot ang portal, pakisubukang muli sa ibang pagkakataon. Salamat sa iyong pag-unawa.",
   "application.ada.hearing": "Đối với người khiếm thính",
   "application.ada.label": "Các Căn nhà Dễ tiếp cập của ADA",
   "application.ada.mobility": "Đối với người suy giảm khả năng vận động",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -52,6 +52,7 @@
   "account.viewApplications": "查看申請",
   "alert.applicationMessage": "現在可以申請更多清單！您可能需要建立一個帳戶。請查看<a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-terms-use' target='_blank'>使用條款</a>和<a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-privacy-policy' target='_blank'>隱私權政策</a>，兩者均已變更。",
   "alert.maintenance": "该网站正在进行定期维护。很抱歉给您带来不便。",
+  "alert.infraMaintenance": "Doorway Housing Portal 將於太平洋時間 8 月 8 日上午 7:00 - 8:00 進行短暫維護。 如果您在訪問入口網站時遇到問題，請稍後再試。 感謝您的體諒。",
   "application.ada.hearing": "針對聽力障礙",
   "application.ada.label": "《美國殘疾人法案》(ADA) 規定的無障礙單位",
   "application.ada.mobility": "針對行動不便",

--- a/shared-helpers/src/views/layout/AlertBanner.tsx
+++ b/shared-helpers/src/views/layout/AlertBanner.tsx
@@ -23,7 +23,7 @@ const AlertBanner = ({ children, maintenanceWindow, variant }: AlertBannerProps)
     }
     return inMaintenance
   }
-
+  console.log(getInMaintenance())
   return (
     getInMaintenance() && (
       <div className={styles["site-alert-banner-container"]} data-variant={variant}>

--- a/shared-helpers/src/views/layout/AlertBanner.tsx
+++ b/shared-helpers/src/views/layout/AlertBanner.tsx
@@ -23,7 +23,7 @@ const AlertBanner = ({ children, maintenanceWindow, variant }: AlertBannerProps)
     }
     return inMaintenance
   }
-  console.log(getInMaintenance())
+
   return (
     getInMaintenance() && (
       <div className={styles["site-alert-banner-container"]} data-variant={variant}>

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -106,16 +106,16 @@ const Layout = (props) => {
       })
     }
   }
-
+  console.log(process.env.maintenanceWindow)
   return (
     <div className="site-wrapper">
       <div className="site-content">
         <Head>
           <title>{t("nav.siteTitle")}</title>
         </Head>
-        {/* temporary change to support email issue, should return to alert.maintenance after window */}
+        {/* temporary change to infra maintenance, should return to alert.maintenance after window */}
         <AlertBanner maintenanceWindow={process.env.maintenanceWindow} variant={"primary"}>
-          <Markdown>{t("alert.applicationMessage")}</Markdown>
+          <Markdown>{t("alert.infraMaintenance")}</Markdown>
         </AlertBanner>
         <SiteHeader
           logoSrc="/images/doorway-logo.png"

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -106,7 +106,7 @@ const Layout = (props) => {
       })
     }
   }
-  console.log(process.env.maintenanceWindow)
+
   return (
     <div className="site-wrapper">
       <div className="site-content">


### PR DESCRIPTION
This PR addresses [#(779)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/779)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Doorway needs an alert banner for tomorrow's maintenance.

## How Can This Be Tested/Reviewed?

Add `MAINTENANCE_WINDOW=2024-08-07 10:00 -07:00,2024-08-08 8:00 -07:00` to public env file. View public sight and confirm banner is present in all languages.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
