### PR TITLE
release: remove errant lottery copy

### DIFF
--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -378,7 +378,6 @@ describe("lottery", () => {
     expect(header).toBeInTheDocument()
 
     fireEvent.click(getByText("Run lottery"))
-    expect(getByText("This data will expire on", { exact: false })).toBeInTheDocument()
     expect(await findByText("Confirmation needed")).toBeInTheDocument()
     expect(
       getByText("Make sure to add all paper applications before running the lottery.")
@@ -411,7 +410,6 @@ describe("lottery", () => {
     expect(header).toBeInTheDocument()
 
     fireEvent.click(getByText("Run lottery"))
-    expect(getByText("This data will expire on", { exact: false })).toBeInTheDocument()
     expect(await findByText("Confirmation needed")).toBeInTheDocument()
     expect(getByText("5 unresolved duplicate sets.")).toBeInTheDocument()
     expect(getByText("Run lottery without resolving duplicates")).toBeInTheDocument()

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -336,9 +336,6 @@ const Lottery = (props: { listing: Listing }) => {
               {t("applications.addConfirmModalHeader")}
             </Dialog.Header>
             <Dialog.Content id="run-lottery-modal-content">
-              {process.env.lotteryDaysTillExpiry ? (
-                <p>{t("listings.lottery.dialogAlert", { date: formattedExpiryDate })}</p>
-              ) : undefined}
               {duplicatesExist ? (
                 <p>
                   {t("listings.lottery.duplicateContent")}{" "}


### PR DESCRIPTION
This PR addresses [#(4058)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4058)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Releases https://github.com/bloom-housing/bloom/pull/4239

## How Can This Be Tested/Reviewed?

Sign into Partners as a admin, navigate to a closed listing opted into lottery, go to lottery tab, click Run Lottery. Should match image below.
![Screenshot 2024-08-07 at 2 48 00 PM](https://github.com/user-attachments/assets/e24ef868-3f3a-4e0b-850b-4c763cb024e5)

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
