### PR TITLE
fix: update node to 18.20

### DIFF
--- a/build/docker/Dockerfile.backend
+++ b/build/docker/Dockerfile.backend
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 node:16.3.0
 
 # The source stage will contain only the necessary source code
-FROM node:18.14-alpine AS source
+FROM node:18.20-alpine AS source
 
 # WORKDIR doesn't need to be fancy, but it needs to be consistent
 WORKDIR /app
@@ -47,7 +47,7 @@ CMD yarn test
 #####################
 
 # The build stage builds the code using the dependencies from the deps stage
-FROM node:18.14-alpine AS build
+FROM node:18.20-alpine AS build
 
 # Start in the root
 WORKDIR /app
@@ -67,7 +67,7 @@ RUN yarn build
 #####################
 
 # The optimize stage contains only dependencies needed to run the service
-FROM node:18.14-alpine AS optimize
+FROM node:18.20-alpine AS optimize
 
 # No need to keep nested dirs since shared-helpers is only needed for testing
 WORKDIR /app
@@ -93,7 +93,7 @@ RUN yarn prisma generate
 #####################
 
 # The run stage contains an optimized image for running the application
-FROM node:18.14-alpine AS run
+FROM node:18.20-alpine AS run
 
 # No need to keep nested dirs since shared-helpers is only needed for testing
 WORKDIR /app


### PR DESCRIPTION
The doorway pipeline failed because of a dependency mismatch. Specifically the package 'cheerio' (brought in via 'juice') needs at least node version 18.17 and we are on 18.14.

This PR updates it to the latest 18 version. We could upgrade to 22, but that would be a bigger change so for now just updating the minor version.

To test:
- Have docker desktop installed and running on your machine
- update your .env file for the api to have `DATABASE_URL=postgres://morganludtke@docker.for.mac.host.internal:5432/bloom` with `morganludtke` replaced with your machine's name
- build the docker image with this command `docker build . -f build/docker/Dockerfile.backend --target run -t api:run-candidate`
  - This is the step that is currently failing. So having this PR locally should successfully build
- Run the docker image with this command `docker run  --env-file ./api/.env -p 3100:3100 api:run-candidate`. All should work as expected