### PR TITLE
fix: z-index issues related to the filter bar

### DIFF
--- a/sites/public/src/components/listings/search/ListingsSearch.module.scss
+++ b/sites/public/src/components/listings/search/ListingsSearch.module.scss
@@ -13,13 +13,12 @@
 
 .search-filter-bar {
   width: calc(var(--listings-list-width) - var(--seeds-s6));
-  
   display: flex;
   justify-content: space-between;
   align-items: center;
   position: absolute;
   right: 0px;
-  z-index: 1;
+  z-index: calc(var(--seeds-z-index-overlay) - 1);
   background: white;
   padding-inline-end: var(--seeds-s4);
   padding-block: var(--seeds-s2);

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -211,4 +211,8 @@
       margin-left: 0.6rem;
     }
   }
+
+  .image-card-tag__wrapper {
+    z-index: calc(var(--seeds-z-index-overlay) - 2);
+  }
 }


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/756#issuecomment-2302924630

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

There was a z-index ordering issue between the filter bar and tags in the listings list. This fixes those orderings.

## How Can This Be Tested/Reviewed?

Verify you can scroll up and down the listing list and all the content disappears under the filter bar.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
