### PR TITLE
release: opt out existing lotteries

### DIFF
--- a/api/prisma/seed-helpers/listing-factory.ts
+++ b/api/prisma/seed-helpers/listing-factory.ts
@@ -46,6 +46,8 @@ export const listingFactory = async (
     lotteryStatus?: LotteryStatusEnum;
     closedAt?: Date;
     reviewOrderType?: ReviewOrderTypeEnum;
+    listingEvents?: Prisma.ListingEventsCreateWithoutListingsInput[];
+    lotteryOptIn?: boolean;
   },
 ): Promise<Prisma.ListingsCreateInput> => {
   const previousListing = optionalParams?.listing || {};
@@ -75,6 +77,7 @@ export const listingFactory = async (
       ? new Date()
       : null,
     lotteryStatus: optionalParams?.lotteryStatus || undefined,
+    lotteryOptIn: optionalParams?.lotteryOptIn || undefined,
     displayWaitlistSize: Math.random() < 0.5,
     listingsBuildingAddress: {
       create: addressFactory(),
@@ -181,6 +184,11 @@ export const listingFactory = async (
           },
         }
       : {},
+    listingEvents: optionalParams?.listingEvents
+      ? {
+          create: optionalParams.listingEvents,
+        }
+      : undefined,
     ...previousListing,
   };
 };

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -3,6 +3,7 @@ import {
   ApplicationMethodsTypeEnum,
   ApplicationSubmissionTypeEnum,
   LanguagesEnum,
+  ListingEventsTypeEnum,
   ListingsStatusEnum,
   MultiselectQuestions,
   MultiselectQuestionsApplicationSectionEnum,
@@ -461,6 +462,7 @@ export const stagingSeed = async (
           'Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents.',
         status: ListingsStatusEnum.active,
         reviewOrderType: ReviewOrderTypeEnum.lottery,
+        lotteryOptIn: true,
         displayWaitlistSize: false,
         reservedCommunityDescription: null,
         reservedCommunityMinAge: null,
@@ -474,6 +476,16 @@ export const stagingSeed = async (
         listingsApplicationDropOffAddress: undefined,
         listingsApplicationMailingAddress: undefined,
         reservedCommunityTypes: undefined,
+        listingEvents: {
+          create: [
+            {
+              type: ListingEventsTypeEnum.publicLottery,
+              startDate: new Date(),
+              startTime: new Date(),
+              endTime: new Date(),
+            },
+          ],
+        },
       },
       units: [
         {
@@ -921,6 +933,7 @@ export const stagingSeed = async (
           'Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents.',
         status: ListingsStatusEnum.active,
         reviewOrderType: ReviewOrderTypeEnum.lottery,
+        lotteryOptIn: false,
         displayWaitlistSize: false,
         reservedCommunityDescription: null,
         reservedCommunityMinAge: null,

--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -94,4 +94,16 @@ export class ScirptRunnerController {
   ): Promise<SuccessDTO> {
     return await this.scriptRunnerService.addLotteryTranslations(req);
   }
+
+  @Put('optOutExistingLotteries')
+  @ApiOperation({
+    summary: 'A script that opts out existing lottery listings',
+    operationId: 'optOutExistingLotteries',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async optOutExistingLotteries(
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.optOutExistingLotteries(req);
+  }
 }

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -5,6 +5,7 @@ import {
   Prisma,
   PrismaClient,
   LanguagesEnum,
+  ReviewOrderTypeEnum,
 } from '@prisma/client';
 import { Request as ExpressRequest } from 'express';
 import { PrismaService } from './prisma.service';
@@ -790,6 +791,38 @@ export class ScriptRunnerService {
 
     await this.markScriptAsComplete('add lottery translations', requestingUser);
 
+    return { success: true };
+  }
+
+  /**
+   *
+   * @param req incoming request object
+   * @returns successDTO
+   * @description opts out existing lottery listings
+   */
+  async optOutExistingLotteries(req: ExpressRequest): Promise<SuccessDTO> {
+    const requestingUser = mapTo(User, req['user']);
+    await this.markScriptAsRunStart(
+      'opt out existing lotteries',
+      requestingUser,
+    );
+
+    const { count } = await this.prisma.listings.updateMany({
+      data: {
+        lotteryOptIn: false,
+      },
+      where: {
+        reviewOrderType: ReviewOrderTypeEnum.lottery,
+        lotteryOptIn: null,
+      },
+    });
+
+    console.log(`updated lottery opt in for ${count} listings`);
+
+    await this.markScriptAsComplete(
+      'opt out existing lotteries',
+      requestingUser,
+    );
     return { success: true };
   }
 

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2223,6 +2223,22 @@ export class ScriptRunnerService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * A script that opts out existing lottery listings
+   */
+  optOutExistingLotteries(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/optOutExistingLotteries"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export class LotteryService {


### PR DESCRIPTION
This PR addresses [#(4258)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4258)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Releases: https://github.com/bloom-housing/bloom/pull/4267

## How Can This Be Tested/Reviewed?

Reseed local database. By default, there should be 2 lottery listings. If you check the db, they will have lotteryOptIn set to `null`. Login as an admin and go to the API UI. Call the `optOutExistingLotteries` script endpoint. You should see 2 printed in the console. Check the database to verify the correct listings have been updated.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
