### PR TITLE
fix: escape symbol on listing opportunity email

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -19,9 +19,13 @@ import { instance } from './logger/winston.logger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
-    logger: WinstonModule.createLogger({
-      instance: instance,
-    }),
+    // In local development use the built in logger for better readability
+    logger:
+      process.env.NODE_ENV === 'development'
+        ? ['error', 'warn', 'log', 'debug']
+        : WinstonModule.createLogger({
+            instance: instance,
+          }),
   });
   const allowList = process.env.CORS_ORIGINS || [];
   const allowListRegex = process.env.CORS_REGEX

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -521,9 +521,9 @@ export class EmailService {
     }
     tableRows.push({
       label: this.polyglot.t('rentalOpportunity.address'),
-      value: `${listing.listingsBuildingAddress.street}, ${listing.listingsBuildingAddress.city} ${listing.listingsBuildingAddress.state} ${listing.listingsBuildingAddress.zipCode}`,
+      value: `${listing.listingsBuildingAddress?.street}, ${listing.listingsBuildingAddress?.city} ${listing.listingsBuildingAddress?.state} ${listing.listingsBuildingAddress?.zipCode}`,
     });
-    Object.entries(units.bedrooms).forEach(([key, bedroom]) => {
+    Object.entries(units?.bedrooms || {})?.forEach(([key, bedroom]) => {
       const sqFtString = this.formatUnitDetails(bedroom, 'sqFeet', 'sqft');
       const bathroomstring = this.formatUnitDetails(
         bedroom,
@@ -533,24 +533,24 @@ export class EmailService {
       );
       tableRows.push({
         label: this.polyglot.t(`rentalOpportunity.${key}`),
-        value: `${bedroom.length} unit${
+        value: `${bedroom?.length} unit${
           bedroom.length > 1 ? 's' : ''
         }${bathroomstring}${sqFtString}`,
       });
     });
-    if (units.rent?.length) {
+    if (units?.rent?.length) {
       tableRows.push({
         label: this.polyglot.t('rentalOpportunity.rent'),
         value: this.formatPricing(units.rent),
       });
     }
-    if (units.minIncome?.length) {
+    if (units?.minIncome?.length) {
       tableRows.push({
         label: this.polyglot.t('rentalOpportunity.minIncome'),
         value: this.formatPricing(units.minIncome),
       });
     }
-    if (units.maxIncome?.length) {
+    if (units?.maxIncome?.length) {
       tableRows.push({
         label: this.polyglot.t('rentalOpportunity.maxIncome'),
         value: this.formatPricing(units.maxIncome),
@@ -612,9 +612,6 @@ export class EmailService {
     emails: string[],
     appUrl: string,
   ) {
-    const jurisdiction = await this.getJurisdiction([
-      { id: listingInfo.juris },
-    ]);
     await this.sendSES({
       to: emails,
       subject: this.polyglot.t('lotteryReleased.header', {

--- a/api/src/views/listing-opportunity.hbs
+++ b/api/src/views/listing-opportunity.hbs
@@ -29,7 +29,7 @@
       {{#each languageUrls}}
         <tr>
           <td align="center">
-            <a href="{{this.url}}" class="btn btn-primary btn-submit" target="_blank" style="color:white">{{this.name}}</a>
+            <a href="{{this.url}}" class="btn btn-primary btn-submit" target="_blank" style="color:white">{{{this.name}}}</a>
           </td>
         </tr>
       {{/each}}

--- a/api/src/views/partials/footer.hbs
+++ b/api/src/views/partials/footer.hbs
@@ -24,6 +24,5 @@
         <!-- END FOOTER -->
       </div>
     </td>
-    <td>&nbsp;</td>
   </tr>
 </table>


### PR DESCRIPTION
This PR addresses https://exygy.slack.com/archives/C02G1S19QA2/p1725663205708509

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When using the `&` symbol in a handlebar template it outputs it as `&amp;`. This change escapes it by adding the `{{{` instead of `{{` as described [here](https://handlebarsjs.com/guide/expressions.html#html-escaping)

Also, the footer has an extra row of `&nbsp;` that was appearing on the upper right of the email

## How Can This Be Tested/Reviewed?

This is hard to test if you don't have access to the govdelivery staging environment. These are the possibilities to test it:
- In email.service.ts on line 607 you can switch the call from this.govDelivery to this.sendSES with your email in the To field.
  - You will need to set `enableListingOpportunity` to TRUE on the seeded jurisdiction
- You could take my word that it looks correct on the govDelivery email: 
![image](https://github.com/user-attachments/assets/4b368705-2ea5-4cff-b372-2defefee1fae)

The removal of the extra row in the footer does impact most emails, that is something that could be tested


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
