### PR TITLE
fix: lottery export terms checkbox

### DIFF
--- a/sites/partners/src/components/shared/ExportTermsDialog.tsx
+++ b/sites/partners/src/components/shared/ExportTermsDialog.tsx
@@ -7,25 +7,39 @@ import styles from "./ExportTermsDialog.module.scss"
 export interface ExportTermsDialogProps {
   children: React.ReactNode
   dialogHeader: string
+  id: string
   isOpen: boolean
   onClose: () => void
   onSubmit: () => void
+  loadingState?: boolean
 }
 
 export const ExportTermsDialog = ({
   children,
   dialogHeader,
   isOpen,
+  id,
   onClose,
   onSubmit,
+  loadingState,
 }: ExportTermsDialogProps) => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, handleSubmit, errors } = useForm()
 
   return (
-    <Dialog isOpen={isOpen} onClose={onClose}>
-      <Dialog.Header className={styles["export-terms-header"]}>{dialogHeader}</Dialog.Header>
-      <Dialog.Content>
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabelledBy={`export-terms-modal-header-${id}`}
+      ariaDescribedBy={`export-terms-modal-content-${id}`}
+    >
+      <Dialog.Header
+        className={styles["export-terms-header"]}
+        id={`export-terms-modal-header-${id}`}
+      >
+        {dialogHeader}
+      </Dialog.Header>
+      <Dialog.Content id={`export-terms-modal-content-${id}`}>
         <>{children}</>
       </Dialog.Content>
       <Form id="terms" onSubmit={handleSubmit(onSubmit)}>
@@ -45,7 +59,12 @@ export const ExportTermsDialog = ({
           <Button type="submit" variant="primary" id="terms" size="sm">
             {t("t.export")}
           </Button>
-          <Button variant="secondary-outlined" size="sm" onClick={onClose}>
+          <Button
+            variant="secondary-outlined"
+            size="sm"
+            onClick={onClose}
+            loadingMessage={loadingState ? t("t.loading") : undefined}
+          >
             {t("t.cancel")}
           </Button>
         </Dialog.Footer>

--- a/sites/partners/src/pages/listings/[id]/applications/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/index.tsx
@@ -284,6 +284,7 @@ const ApplicationsList = () => {
 
                 <ExportTermsDialog
                   dialogHeader={t("applications.export.dialogHeader")}
+                  id="applications"
                   isOpen={isTermsOpen}
                   onClose={() => setIsTermsOpen(false)}
                   onSubmit={onSubmit}

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -21,6 +21,7 @@ import {
   ReviewOrderTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import Layout from "../../../layouts"
+import { ExportTermsDialog } from "../../../components/shared/ExportTermsDialog"
 import { ListingContext } from "../../../components/listings/ListingContext"
 import { MetaTags } from "../../../components/shared/MetaTags"
 import ListingGuard from "../../../components/shared/ListingGuard"
@@ -718,61 +719,39 @@ const Lottery = (props: { listing: Listing | undefined }) => {
               </Button>
             </Dialog.Footer>
           </Dialog>
-          <Dialog
+          <ExportTermsDialog
+            dialogHeader={t("listings.lottery.export")}
+            id="partner-lottery"
             isOpen={!!termsExportModal}
-            ariaLabelledBy="terms-export-lottery-modal-header"
-            ariaDescribedBy="terms-export-lottery-modal-content"
             onClose={() => setTermsExportModal(false)}
+            onSubmit={async () => {
+              setLoading(true)
+              try {
+                await onExport()
+                setLoading(false)
+                setTermsExportModal(false)
+              } catch {
+                setLoading(false)
+                addToast(t("account.settings.alerts.genericError"), { variant: "alert" })
+              }
+            }}
+            loadingState={loading || exportLoading}
           >
-            <Dialog.Header id="terms-export-lottery-modal-header">
-              {t("listings.lottery.export")}
-            </Dialog.Header>
-            <Dialog.Content id="terms-export-lottery-modal-content">
-              <p>
-                {listing.listingMultiselectQuestions.length
-                  ? t("listings.lottery.exportFile")
-                  : t("listings.lottery.exportFileNoPreferences")}{" "}
-                {t("listings.lottery.exportContentTimestamp", {
-                  date: dayjs(listing.lotteryLastRunAt).format("MM/DD/YYYY"),
-                  time: dayjs(listing.lotteryLastRunAt).format("h:mm a"),
-                })}
-              </p>
-              <p>{t("listings.lottery.termsAccept")}</p>
-              <h2 className={styles["terms-of-use-header"]}>
-                {t("authentication.terms.termsOfUse")}
-              </h2>
-              <Markdown>{t("listings.lottery.terms")}</Markdown>
-            </Dialog.Content>
-            <Dialog.Footer>
-              <Button
-                variant="primary"
-                onClick={async () => {
-                  setLoading(true)
-                  try {
-                    await onExport()
-                    setLoading(false)
-                    setTermsExportModal(false)
-                  } catch {
-                    setLoading(false)
-                    addToast(t("account.settings.alerts.genericError"), { variant: "alert" })
-                  }
-                }}
-                size="sm"
-                loadingMessage={loading || exportLoading ? t("t.loading") : undefined}
-              >
-                {t("t.export")}
-              </Button>
-              <Button
-                variant="primary-outlined"
-                onClick={() => {
-                  setTermsExportModal(false)
-                }}
-                size="sm"
-              >
-                {t("t.cancel")}
-              </Button>
-            </Dialog.Footer>
-          </Dialog>
+            <p>
+              {listing.listingMultiselectQuestions.length
+                ? t("listings.lottery.exportFile")
+                : t("listings.lottery.exportFileNoPreferences")}{" "}
+              {t("listings.lottery.exportContentTimestamp", {
+                date: dayjs(listing.lotteryLastRunAt).format("MM/DD/YYYY"),
+                time: dayjs(listing.lotteryLastRunAt).format("h:mm a"),
+              })}
+            </p>
+            <p>{t("listings.lottery.termsAccept")}</p>
+            <h2 className={styles["terms-of-use-header"]}>
+              {t("authentication.terms.termsOfUse")}
+            </h2>
+            <Markdown>{t("listings.lottery.terms")}</Markdown>
+          </ExportTermsDialog>
           <Dialog
             isOpen={!!publishModal}
             ariaLabelledBy="publish-lottery-modal-header"


### PR DESCRIPTION
This PR addresses #4299

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR forces a partner user to check a box confirming that they understand the terms of downloading a lottery export.

## How Can This Be Tested/Reviewed?

This can be tested by attempting to export a lottery as a partner user and attempting to export without/with the agreed to terms checkbox selected.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
