### PR TITLE
fix: add missing env var

### DIFF
--- a/ci/buildspec/build_partners.yml
+++ b/ci/buildspec/build_partners.yml
@@ -37,6 +37,7 @@ phases:
         --build-arg "MAINTENANCE_WINDOW=${MAINTENANCE_WINDOW}"
         --build-arg "API_PASS_KEY=${API_PASS_KEY}"
         --build-arg "SHOW_LOTTERY=${SHOW_LOTTERY}"
+        --build-arg "LOTTERY_DAYS_TILL_EXPIRY=${LOTTERY_DAYS_TILL_EXPIRY}"
         -t sites/partners:test
 
       # Run tests
@@ -58,6 +59,7 @@ phases:
         --build-arg "MAINTENANCE_WINDOW=${MAINTENANCE_WINDOW}"
         --build-arg "API_PASS_KEY=${API_PASS_KEY}"
         --build-arg "SHOW_LOTTERY=${SHOW_LOTTERY}"
+        --build-arg "LOTTERY_DAYS_TILL_EXPIRY=${LOTTERY_DAYS_TILL_EXPIRY}"
         -t sites/partners:run-candidate
 
       # Tag the run image


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Forgot to include LOTTERY_DAYS_TILL_EXPIRY env var in partners docker file when releasing to Doorway.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
