### PR TITLE
fix: nonpartner lottery results can now be uploaded

### DIFF
--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -419,17 +419,14 @@ const ListingFormActions = ({
 
         // Only admins can publish results
         // and the functionality should only be turned on if the rest of lottery functionality is
-        if (isListingApprover && process.env.showLottery === "TRUE") {
+        if (isListingApprover && process.env.showLottery) {
           const lotteryResults = listing?.listingEvents?.find(
             (event) => event.type === ListingEventsTypeEnum.lotteryResults
           )
 
           if (lotteryResults) {
             elements.push(editPostedResultsButton(lotteryResults))
-          } else if (
-            listing.status === ListingsStatusEnum.closed &&
-            (!listing?.lotteryOptIn || !process.env.showLottery)
-          ) {
+          } else if (listing.status === ListingsStatusEnum.closed && !listing?.lotteryOptIn) {
             elements.push(postResultsButton)
           }
         }
@@ -480,17 +477,14 @@ const ListingFormActions = ({
           elements.push(unpublishButton)
         }
 
-        if (process.env.showLottery === "TRUE") {
+        if (process.env.showLottery) {
           const lotteryResults = listing?.listingEvents?.find(
             (event) => event.type === ListingEventsTypeEnum.lotteryResults
           )
 
           if (lotteryResults) {
             elements.push(editPostedResultsButton(lotteryResults))
-          } else if (
-            listing.status === ListingsStatusEnum.closed &&
-            (!listing?.lotteryOptIn || !process.env.showLottery)
-          ) {
+          } else if (listing.status === ListingsStatusEnum.closed && !listing?.lotteryOptIn) {
             elements.push(postResultsButton)
           }
         }
@@ -502,6 +496,7 @@ const ListingFormActions = ({
     }
 
     return listingApprovalPermissions?.length > 0 ? getApprovalActions() : getDefaultActions()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isListingApprover,
     listing,


### PR DESCRIPTION
- [x] Addresses the issue in full

## Description
Doorway admin were not able to upload lottery results for listings that opted out of the partner lottery

this changes it so that that option is once again available

## How Can This Be Tested/Reviewed?
- create or edit a listing such that it is a lottery listing, and opt out of the partner lottery
- close the listing
- go back in to edit the listing, you should now be able to upload lottery  results with the "Post Results" option

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
