### PR TITLE
fix: add lottery help center links to lottery results

### DIFF
--- a/sites/public/src/pages/account/application/[id]/lottery-results.tsx
+++ b/sites/public/src/pages/account/application/[id]/lottery-results.tsx
@@ -142,8 +142,7 @@ export default () => {
                     <div>
                       <Button
                         className={styles["section-button"]}
-                        href={"https://www.exygy.com"} // NOTE: Update per jurisdiction
-                        hideExternalLinkIcon={true}
+                        href={"/help/questions#how-do-lottery-results-work-section"}
                         size={"sm"}
                       >
                         {t("account.application.lottery.rawRankButton")}
@@ -160,8 +159,7 @@ export default () => {
                     <div>
                       <Button
                         className={styles["section-button"]}
-                        href={"https://www.exygy.com"} // NOTE: Update per jurisdiction
-                        hideExternalLinkIcon={true}
+                        href={"/help/questions#how-do-lottery-results-work-section"}
                         size={"sm"}
                       >
                         {t("account.application.lottery.preferencesButton")}


### PR DESCRIPTION
This PR addresses [#4347](https://github.com/bloom-housing/bloom/issues/4347)

- [x] Addresses the issue in full

## Description

Adds links to the help center content on the lottery results page.

## How Can This Be Tested/Reviewed?

Ensure the links go to the help center lottery section. Per [accessibility guidelines](https://www.w3.org/TR/WCAG20-TECHS/G200.html), they don't open in a new tab.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
