### PR TITLE
fix: escape apostrophes in listing name in emails

### DIFF
--- a/api/src/views/confirmation.hbs
+++ b/api/src/views/confirmation.hbs
@@ -1,5 +1,5 @@
 {{#> layout_default }}
-  <h1><span class="intro">{{t "confirmation.gotYourConfirmationNumber"}}</span> <br />{{listing.name}}</h1>
+  <h1><span class="intro">{{t "confirmation.gotYourConfirmationNumber"}}</span> <br />{{{listing.name}}}</h1>
 
   <table class="inset" role="presentation" border="0" cellpadding="0" cellspacing="0">
     <tbody>

--- a/api/src/views/listing-opportunity.hbs
+++ b/api/src/views/listing-opportunity.hbs
@@ -1,6 +1,6 @@
 {{#> layout_default }}
 
-  <h1><span class="intro"> {{t "rentalOpportunity.intro"}}</span> <br />{{listingName}}</h1>
+  <h1><span class="intro"> {{t "rentalOpportunity.intro"}}</span> <br />{{{listingName}}}</h1>
   <table class="inset fit-content" role="presentation" border="0" cellpadding="0" cellspacing="0">
     <tbody>
       <tr>

--- a/backend/core/src/shared/views/listing-opportunity.hbs
+++ b/backend/core/src/shared/views/listing-opportunity.hbs
@@ -1,6 +1,6 @@
 {{#> layout_default }}
 
-  <h1><span class="intro"> {{t "rentalOpportunity.intro"}}</span> <br />{{{listingName}}}</h1>
+  <h1><span class="intro"> {{t "rentalOpportunity.intro"}}</span> <br />{{listingName}}</h1>
   <table class="inset fit-content" role="presentation" border="0" cellpadding="0" cellspacing="0">
     <tbody>
       <tr>

--- a/backend/core/src/shared/views/listing-opportunity.hbs
+++ b/backend/core/src/shared/views/listing-opportunity.hbs
@@ -1,6 +1,6 @@
 {{#> layout_default }}
 
-  <h1><span class="intro"> {{t "rentalOpportunity.intro"}}</span> <br />{{listingName}}</h1>
+  <h1><span class="intro"> {{t "rentalOpportunity.intro"}}</span> <br />{{{listingName}}}</h1>
   <table class="inset fit-content" role="presentation" border="0" cellpadding="0" cellspacing="0">
     <tbody>
       <tr>


### PR DESCRIPTION
This PR addresses #844 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Escapes apostrophes in the listing opportunity email

## How Can This Be Tested/Reviewed?

Related to [this PR](https://github.com/metrotranscom/doorway/pull/814)

Testing this was kind of a pain, I just locally updated the listing opportunity email call to instead send an SES email to me.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
