### PR TITLE
fix: faq page fix

### DIFF
--- a/doorway-ui-components/src/page_components/help-center/DoorwayLinkableCardGroup.tsx
+++ b/doorway-ui-components/src/page_components/help-center/DoorwayLinkableCardGroup.tsx
@@ -12,6 +12,9 @@ type DoorwayLinkableCardGroupProps = {
 const DoorwayLinkableCardGroup = (props: DoorwayLinkableCardGroupProps) => {
   const getLinks = () => {
     const links = []
+    if (!props.cards?.length) {
+      return []
+    }
     for (const card of props.cards) {
       if (card.props?.jumplinkData) {
         const jumplinkData = card.props.jumplinkData

--- a/sites/public/src/tsx_content/questions-cards.tsx
+++ b/sites/public/src/tsx_content/questions-cards.tsx
@@ -324,6 +324,6 @@ export function questionsLinkableCards(): React.ReactElement<CardProps>[] {
         </Card.Section>
       </Card>
     )
-    return questions
   }
+  return questions
 }


### PR DESCRIPTION
This PR addresses [#(insert-number-here)](https://exygy.slack.com/archives/C02G1S19QA2/p1727724477064559)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When trying to hit the Frequently Asked Questions page an error is getting thrown. https://housingbayarea.mtc.ca.gov/help/questions (Page not found in production but an actual error in local development)

This only happens when the `SHOW_PUBLIC_LOTTERY` env variable is not set or set to false

## How Can This Be Tested/Reviewed?

Either set the `SHOW_PUBLIC_LOTTERY` env for the public site to FALSE or remove it entirely from the file.

go to http://localhost:3000/help/questions and the page should fully load

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
