### PR TITLE
fix: extend to three hours

### DIFF
--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -37,7 +37,7 @@ export const AUTH_COOKIE_OPTIONS: CookieOptions = {
   httpOnly: true,
   secure,
   sameSite,
-  maxAge: TOKEN_COOKIE_MAXAGE / 24, // access token should last 1 hr
+  maxAge: TOKEN_COOKIE_MAXAGE / 8, // access token should last 1.5 hr
   domain: process.env.COOKIE_DOMAIN ?? undefined,
 };
 export const REFRESH_COOKIE_OPTIONS: CookieOptions = {


### PR DESCRIPTION
This PR addresses #849 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR extends the cookie's max age to 180 minutes as the issue describes.

## How Can This Be Tested/Reviewed?

It's difficult to test this duration but you can change the divisor to 1560 to have it timeout in 1 minute. Then sign in, do something else for a minute, and then refresh the partners portal. You'll be redirected to the sign-in page showing that the correct value is being updated in this PR.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
