### PR TITLE
fix: match pref on id (#4372)

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -374,7 +374,7 @@ const SelectAndOrder = ({
                               register={register}
                               inputProps={{
                                 defaultChecked: draftListingData.some(
-                                  (existingItem) => existingItem.text === item.text
+                                  (existingItem) => existingItem.id === item.id
                                 ),
                               }}
                             />


### PR DESCRIPTION
This PR addresses #4360 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the defaultSelected Logic within the "Select Preference" drawer to match on id rather than text to handle multiple preferences with the same name.

## How Can This Be Tested/Reviewed?

Run locally, Log in to partners as an admin, Add preferences with the same name or make multiple copies of existing preferences, Add only some of the preferences with the same name to the listing, Save, Go back to Edit and view the preferences, and only the ones you selected will show as checked. Previously, all with the same name would show as selected.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
