### PR TITLE
fix: add required field for applications in script

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -788,7 +788,6 @@ export class ScriptRunnerService {
             return;
           }
           try {
-            console.log('application', application);
             await this.prisma.applications.create({
               data: {
                 id: application.id,
@@ -800,6 +799,7 @@ export class ScriptRunnerService {
                 submissionDate: application.submissionDate,
                 preferences: [],
                 programs: [],
+                contactPreferences: [],
                 status: application.status,
                 householdSize: application.householdSize,
                 appUrl: application.appUrl,

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1355,6 +1355,7 @@ describe('Testing script runner service', () => {
           markedAsDuplicate: false,
           preferences: [],
           programs: [],
+          contactPreferences: [],
           reviewStatus: 'valid',
           status: 'submitted',
           submissionDate: expect.anything(),


### PR DESCRIPTION
This PR addresses #4193

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When testing the latest user and application import script for SMC a bug was found. The staging and production database has slightly different null constraints on the table "applications" so when trying to insert an application the field `contact_preferences` is required whereas it isn't locally.

Also a log of each application was accidentally kept in the code

## How Can This Be Tested/Reviewed?

The same steps as the previous PR still apply here:

- Do a reseed locally
- Start up the app locally and go to the swagger api http://localhost:3100/api.
- Login via the api to the admin account http://localhost:3100/api#/auth/login.
- Go to Heroku and get the DB credentials for the HBA staging environment https://data.heroku.com/datastores/fd968c98-f208-4066-b8cf-7d3a6bf8ff03#administration
- Use the credentials from above to run the first script http://localhost:3100/api#/scriptRunner/transferJurisdictionData.
- Run the script for http://localhost:3100/api#/scriptRunner/transferJurisdictionListingsData using the same db credentials and jurisdiction used in the previous script
- Run the latest script to migrate users and applications http://localhost:3100/api#/scriptRunner/transferJurisdictionUserApplicationData.
- Verify that the expected partner users from HBA staging have been carried over. You can verify partner users by logging into the partner site and going to the /users tab. Note: you need to be logged in as an admin to see those users.
- Verify public users have been transferred over. The easiest way is to compare the user_accounts and associated tables in the database
- Verify that applications have properly been carried over. You can do this by looking at the properties in the partner site and clicking on the applications tab and then the specific application you want to look at.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
