### PR TITLE
fix: hide other recipients

### DIFF
--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -416,7 +416,7 @@ export class EmailService {
     void (await this.loadTranslations(jurisdiction));
 
     await this.sendSES({
-      to: emails,
+      bcc: emails,
       subject: this.polyglot.t('requestApproval.header'),
       html: this.template('request-approval')({
         appOptions: { listingName: listingInfo.name },
@@ -438,7 +438,7 @@ export class EmailService {
     void (await this.loadTranslations(jurisdiction));
 
     await this.sendSES({
-      to: emails,
+      bcc: emails,
       subject: this.polyglot.t('changesRequested.header'),
       html: this.template('changes-requested')({
         appOptions: { listingName: listingInfo.name },
@@ -458,7 +458,7 @@ export class EmailService {
     void (await this.loadTranslations(jurisdiction));
 
     await this.sendSES({
-      to: emails,
+      bcc: emails,
       subject: this.polyglot.t('listingApproved.header'),
       html: this.template('listing-approved')({
         appOptions: { listingName: listingInfo.name },
@@ -617,7 +617,7 @@ export class EmailService {
     appUrl: string,
   ) {
     await this.sendSES({
-      to: emails,
+      bcc: emails,
       subject: this.polyglot.t('lotteryReleased.header', {
         listingName: listingInfo.name,
       }),
@@ -639,7 +639,7 @@ export class EmailService {
     ]);
     void (await this.loadTranslations(jurisdiction));
     await this.sendSES({
-      to: emails,
+      bcc: emails,
       subject: this.polyglot.t('lotteryPublished.header', {
         listingName: listingInfo.name,
       }),

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -664,8 +664,7 @@ export class EmailService {
     for (const language in emails) {
       void (await this.loadTranslations(null, language as LanguagesEnum));
       await this.sendSES({
-        to: emails[language],
-
+        bcc: emails[language],
         subject: this.polyglot.t('lotteryAvailable.header', {
           listingName: listingInfo.name,
         }),

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -411,11 +411,13 @@ export class EmailService {
     listingInfo: IdDTO,
     emails: string[],
     appUrl: string,
+    jurisEmail: string,
   ) {
     const jurisdiction = await this.getJurisdiction([jurisdictionId]);
     void (await this.loadTranslations(jurisdiction));
 
     await this.sendSES({
+      to: jurisEmail,
       bcc: emails,
       subject: this.polyglot.t('requestApproval.header'),
       html: this.template('request-approval')({
@@ -431,6 +433,7 @@ export class EmailService {
     listingInfo: listingInfo,
     emails: string[],
     appUrl: string,
+    jurisEmail: string,
   ) {
     const jurisdiction = listingInfo.juris
       ? await this.getJurisdiction([{ id: listingInfo.juris }])
@@ -438,6 +441,7 @@ export class EmailService {
     void (await this.loadTranslations(jurisdiction));
 
     await this.sendSES({
+      to: jurisEmail,
       bcc: emails,
       subject: this.polyglot.t('changesRequested.header'),
       html: this.template('changes-requested')({
@@ -453,11 +457,13 @@ export class EmailService {
     listingInfo: IdDTO,
     emails: string[],
     publicUrl: string,
+    jurisEmail: string,
   ) {
     const jurisdiction = await this.getJurisdiction([jurisdictionId]);
     void (await this.loadTranslations(jurisdiction));
 
     await this.sendSES({
+      to: jurisEmail,
       bcc: emails,
       subject: this.polyglot.t('listingApproved.header'),
       html: this.template('listing-approved')({
@@ -615,8 +621,10 @@ export class EmailService {
     listingInfo: listingInfo,
     emails: string[],
     appUrl: string,
+    jurisEmail: string,
   ) {
     await this.sendSES({
+      to: jurisEmail,
       bcc: emails,
       subject: this.polyglot.t('lotteryReleased.header', {
         listingName: listingInfo.name,
@@ -633,12 +641,14 @@ export class EmailService {
     listingInfo: listingInfo,
     emails: string[],
     appUrl: string,
+    jurisEmail: string,
   ) {
     const jurisdiction = await this.getJurisdiction([
       { id: listingInfo.juris },
     ]);
     void (await this.loadTranslations(jurisdiction));
     await this.sendSES({
+      to: jurisEmail,
       bcc: emails,
       subject: this.polyglot.t('lotteryPublished.header', {
         listingName: listingInfo.name,
@@ -664,6 +674,7 @@ export class EmailService {
     for (const language in emails) {
       void (await this.loadTranslations(null, language as LanguagesEnum));
       await this.sendSES({
+        to: jurisdiction.emailFromAddress,
         bcc: emails[language],
         subject: this.polyglot.t('lotteryAvailable.header', {
           listingName: listingInfo.name,

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -400,10 +400,12 @@ export class ListingService implements OnModuleInit {
         OR: userRolesWhere,
       },
     });
+
     // account for users having access to multiple jurisdictions
-    const userWithJuris = userResults?.find(
-      (user) => user.jurisdictions.length,
+    const userWithJuris = userResults?.find((user) =>
+      user.jurisdictions.some((juris) => juris.id === jurisId),
     );
+
     const matchingJurisInfo = userWithJuris?.jurisdictions?.find(
       (juris) => juris.id === jurisId,
     );

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -411,8 +411,11 @@ export class ListingService implements OnModuleInit {
     const emailFromAddress = getEmailFromAddress
       ? rawJuris?.emailFromAddress
       : null;
-    const userEmails: string[] = [];
-    rawUsers?.forEach((user) => user?.email && userEmails.push(user.email));
+
+    const userEmails: string[] = rawUsers?.reduce((userEmails, user) => {
+      if (user?.email) userEmails.push(user.email);
+      return userEmails;
+    }, []);
     return { emails: userEmails, publicUrl, emailFromAddress };
   }
 

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -400,14 +400,16 @@ export class ListingService implements OnModuleInit {
         OR: userRolesWhere,
       },
     });
-
     // account for users having access to multiple jurisdictions
-    const jurisInfo = userResults[0]?.jurisdictions?.find(
+    const userWithJuris = userResults?.find(
+      (user) => user.jurisdictions.length,
+    );
+    const matchingJurisInfo = userWithJuris?.jurisdictions?.find(
       (juris) => juris.id === jurisId,
     );
-    const publicUrl = getPublicUrl ? jurisInfo?.publicUrl : null;
+    const publicUrl = getPublicUrl ? matchingJurisInfo?.publicUrl : null;
     const emailFromAddress = getEmailFromAddress
-      ? jurisInfo?.emailFromAddress
+      ? matchingJurisInfo?.emailFromAddress
       : null;
     const userEmails: string[] = [];
     userResults?.forEach((user) => user?.email && userEmails.push(user.email));

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -406,6 +406,8 @@ export class LotteryService {
       ],
       listing.id,
       listing.jurisdictions?.id,
+      false,
+      true,
     );
 
     const publicUserEmailInfo = await this.getPublicUserEmailInfo(listing.id);
@@ -423,6 +425,7 @@ export class LotteryService {
       },
       partnerUserEmailInfo.emails,
       this.configService.get('PARTNERS_PORTAL_URL'),
+      partnerUserEmailInfo.emailFromAddress,
     );
 
     await this.emailService.lotteryPublishedApplicant(
@@ -508,6 +511,8 @@ export class LotteryService {
           ],
           storedListing.id,
           storedListing.jurisdictionId,
+          false,
+          true,
         );
 
         await this.emailService.lotteryReleased(
@@ -518,6 +523,7 @@ export class LotteryService {
           },
           partnerUserEmailInfo.emails,
           this.configService.get('PARTNERS_PORTAL_URL'),
+          partnerUserEmailInfo.emailFromAddress,
         );
         break;
       }

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -51,6 +51,7 @@ describe('Listing Controller Tests', () => {
   let app: INestApplication;
   let prisma: PrismaService;
   let jurisdictionAId: string;
+  let jurisdictionAEmail: string;
   let adminAccessToken: string;
 
   const testEmailService = {
@@ -87,6 +88,7 @@ describe('Listing Controller Tests', () => {
       data: jurisdictionFactory(),
     });
     jurisdictionAId = jurisdiction.id;
+    jurisdictionAEmail = jurisdiction.emailFromAddress;
     await reservedCommunityTypeFactoryAll(jurisdictionAId, prisma);
     await unitAccessibilityPriorityTypeFactoryAll(prisma);
     const adminUser = await prisma.userAccounts.create({
@@ -906,7 +908,7 @@ describe('Listing Controller Tests', () => {
       );
     });
 
-    it('update status to pending approval and notify appropriate users', async () => {
+    it.only('update status to pending approval and notify appropriate users', async () => {
       const res = await request(app.getHttpServer())
         .post('/auth/login')
         .set({ passkey: process.env.API_PASS_KEY || '' })
@@ -940,6 +942,7 @@ describe('Listing Controller Tests', () => {
         { id: listing.id, name: val.name },
         expect.arrayContaining([adminUser.email, jurisAdmin.email]),
         process.env.PARTNERS_PORTAL_URL,
+        jurisdictionAEmail,
       );
       //ensure juris admin is not included since don't have approver permissions in alameda seed
       expect(mockRequestApproval.mock.calls[0]['emails']).toEqual(
@@ -980,6 +983,7 @@ describe('Listing Controller Tests', () => {
         { id: listing.id, name: val.name },
         expect.arrayContaining([partnerUser.email]),
         jurisdictionA.publicUrl,
+        jurisdictionA.emailFromAddress,
       );
       expect(mockListingOpportunity).toBeCalledWith(
         expect.objectContaining({
@@ -1022,6 +1026,7 @@ describe('Listing Controller Tests', () => {
         { id: listing.id, name: val.name, juris: expect.anything() },
         expect.arrayContaining([partnerUser.email]),
         process.env.PARTNERS_PORTAL_URL,
+        jurisdictionAEmail,
       );
     });
   });

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -908,7 +908,7 @@ describe('Listing Controller Tests', () => {
       );
     });
 
-    it.only('update status to pending approval and notify appropriate users', async () => {
+    it('update status to pending approval and notify appropriate users', async () => {
       const res = await request(app.getHttpServer())
         .post('/auth/login')
         .set({ passkey: process.env.API_PASS_KEY || '' })

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -44,6 +44,7 @@ describe('Lottery Controller Tests', () => {
   let cookies = '';
   let adminAccessToken: string;
   let jurisdictionAId: string;
+  let jurisdictionAEmail: string;
   let unitTypeA: UnitTypes;
 
   const testEmailService = {
@@ -101,6 +102,7 @@ describe('Lottery Controller Tests', () => {
       data: jurisdictionFactory(),
     });
     jurisdictionAId = jurisdiction.id;
+    jurisdictionAEmail = jurisdiction.emailFromAddress;
     await reservedCommunityTypeFactoryAll(jurisdictionAId, prisma);
     await unitTypeFactoryAll(prisma);
     unitTypeA = await unitTypeFactorySingle(prisma, UnitTypeEnum.oneBdrm);
@@ -895,6 +897,7 @@ describe('Lottery Controller Tests', () => {
         },
         expect.arrayContaining([partnerUser.email, adminUser.email]),
         process.env.PARTNERS_PORTAL_URL,
+        jurisdictionAEmail,
       );
 
       const activityLogResult = await prisma.activityLog.findFirst({
@@ -1077,7 +1080,7 @@ describe('Lottery Controller Tests', () => {
           juris: expect.stringMatching(jurisdictionAId),
         },
         expect.arrayContaining([partnerUser.email, adminUser.email]),
-        process.env.PARTNERS_PORTAL_URL,
+        jurisdictionAEmail,
       );
 
       expect(mockLotteryPublishedApplicant).toBeCalledWith(

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -1080,6 +1080,7 @@ describe('Lottery Controller Tests', () => {
           juris: expect.stringMatching(jurisdictionAId),
         },
         expect.arrayContaining([partnerUser.email, adminUser.email]),
+        process.env.PARTNERS_PORTAL_URL,
         jurisdictionAEmail,
       );
 

--- a/api/test/unit/services/email.service.spec.ts
+++ b/api/test/unit/services/email.service.spec.ts
@@ -336,7 +336,7 @@ describe('Testing email service', () => {
 
       expect(sendMock).toHaveBeenCalled();
       const emailMock = sendMock.mock.calls[0][0];
-      expect(emailMock.to).toEqual(emailArr);
+      expect(emailMock.bcc).toEqual(emailArr);
       expect(emailMock.subject).toEqual('Listing approval requested');
       expect(emailMock.html).toMatch(
         `<img src="https://housingbayarea.mtc.ca.gov/images/doorway-logo.png" alt="Bloom Housing Portal" width="300" height="65" class="header-image"/>`,
@@ -378,7 +378,7 @@ describe('Testing email service', () => {
 
       expect(sendMock).toHaveBeenCalled();
       const emailMock = sendMock.mock.calls[0][0];
-      expect(emailMock.to).toEqual(emailArr);
+      expect(emailMock.bcc).toEqual(emailArr);
       expect(emailMock.subject).toEqual('Listing changes requested');
       expect(emailMock.html).toMatch(
         `<img src="https://housingbayarea.mtc.ca.gov/images/doorway-logo.png" alt="Bloom Housing Portal" width="300" height="65" class="header-image"/>`,
@@ -423,7 +423,7 @@ describe('Testing email service', () => {
 
       expect(sendMock).toHaveBeenCalled();
       const emailMock = sendMock.mock.calls[0][0];
-      expect(emailMock.to).toEqual(emailArr);
+      expect(emailMock.bcc).toEqual(emailArr);
       expect(emailMock.subject).toEqual('New published listing');
       expect(emailMock.html).toMatch(
         `<img src="https://housingbayarea.mtc.ca.gov/images/doorway-logo.png" alt="Bloom Housing Portal" width="300" height="65" class="header-image"/>`,

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -3131,9 +3131,10 @@ describe('Testing listing service', () => {
 
   describe('Test listingApprovalNotify endpoint', () => {
     it('listingApprovalNotify request approval email', async () => {
-      jest
-        .spyOn(service, 'getUserEmailInfo')
-        .mockResolvedValueOnce({ emails: ['admin@email.com'] });
+      jest.spyOn(service, 'getUserEmailInfo').mockResolvedValueOnce({
+        emails: ['admin@email.com'],
+        emailFromAddress: 'no-reply@housingbayarea.org',
+      });
       await service.listingApprovalNotify({
         user,
         listingInfo: { id: 'id', name: 'name' },
@@ -3146,18 +3147,22 @@ describe('Testing listing service', () => {
         ['admin'],
         'id',
         'jurisId',
+        false,
+        true,
       );
       expect(requestApprovalMock).toBeCalledWith(
         { id: 'jurisId' },
         { id: 'id', name: 'name' },
         ['admin@email.com'],
         config.get('PARTNERS_PORTAL_URL'),
+        'no-reply@housingbayarea.org',
       );
     });
 
     it('listingApprovalNotify changes requested email', async () => {
       jest.spyOn(service, 'getUserEmailInfo').mockResolvedValueOnce({
         emails: ['jurisAdmin@email.com', 'partner@email.com'],
+        emailFromAddress: 'no-reply@housingbayarea.org',
       });
       await service.listingApprovalNotify({
         user,
@@ -3171,12 +3176,15 @@ describe('Testing listing service', () => {
         ['partner', 'jurisdictionAdmin'],
         'id',
         'jurisId',
+        false,
+        true,
       );
       expect(changesRequestedMock).toBeCalledWith(
         user,
         { id: 'id', name: 'name', juris: 'jurisId' },
         ['jurisAdmin@email.com', 'partner@email.com'],
         config.get('PARTNERS_PORTAL_URL'),
+        'no-reply@housingbayarea.org',
       );
     });
 
@@ -3184,6 +3192,7 @@ describe('Testing listing service', () => {
       jest.spyOn(service, 'getUserEmailInfo').mockResolvedValueOnce({
         emails: ['jurisAdmin@email.com', 'partner@email.com'],
         publicUrl: 'public.housing.gov',
+        emailFromAddress: 'no-reply@housingbayarea.org',
       });
       await service.listingApprovalNotify({
         user,
@@ -3199,12 +3208,14 @@ describe('Testing listing service', () => {
         'id',
         'jurisId',
         true,
+        true,
       );
       expect(listingApprovedMock).toBeCalledWith(
         expect.objectContaining({ id: 'jurisId' }),
         { id: 'id', name: 'name' },
         ['jurisAdmin@email.com', 'partner@email.com'],
         'public.housing.gov',
+        'no-reply@housingbayarea.org',
       );
     });
 

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -87,14 +87,6 @@ describe('Testing lottery service', () => {
     prisma = module.get<PrismaService>(PrismaService);
     listingService = module.get<ListingService>(ListingService);
     config = module.get<ConfigService>(ConfigService);
-
-    jest.spyOn(listingService, 'getUserEmailInfo').mockResolvedValueOnce({
-      emails: ['admin@email.com', 'partner@email.com'],
-    });
-
-    jest.spyOn(service, 'getPublicUserEmailInfo').mockResolvedValueOnce({
-      en: ['applicant@email.com'],
-    });
   });
 
   describe('Testing lotteryRandomizerHelper()', () => {
@@ -685,6 +677,7 @@ describe('Testing lottery service', () => {
 
       jest.spyOn(listingService, 'getUserEmailInfo').mockResolvedValueOnce({
         emails: ['admin@email.com', 'partner@email.com'],
+        emailFromAddress: 'no-reply@housingbayarea.org',
       });
 
       jest.spyOn(service, 'getPublicUserEmailInfo').mockResolvedValueOnce({
@@ -721,12 +714,15 @@ describe('Testing lottery service', () => {
         ['admin', 'jurisdictionAdmin', 'partner'],
         'example id',
         'jurisId',
+        false,
+        true,
       );
 
       expect(lotteryReleasedMock).toBeCalledWith(
         { id: 'example id', juris: 'jurisId', name: 'example name' },
         ['admin@email.com', 'partner@email.com'],
         config.get('PARTNERS_PORTAL_URL'),
+        'no-reply@housingbayarea.org',
       );
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14631,17 +14631,17 @@ rfdc@^1.3.0:
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
This PR addresses #873 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR sends emails via 'bcc' rather than the 'to' field in order to hide the other recipients of the email. My research showed that the options are simple: use the bcc field to send in bulk or loop through each email and send individually. I've included some resources below mentioning the use of the bcc field. Both implementations are straightforward but I worried that sending emails individually could lead to serious performance issues. I also heard mentions of this approach requiring queuing systems which seemed out of scope. The risk of the bcc approach is that the empty "to" field is more likely to be flagged as suspicious so a dummy email like "doorway-applicant@example.com" could be used to help address that concern... though seemingly not entirely.

Nodemailer discussion: https://github.com/nodemailer/nodemailer/issues/385

SES advocating for the altenative of sending individually: https://aws.amazon.com/blogs/messaging-and-targeting/how-to-send-messages-to-multiple-recipients-with-amazon-simple-email-service-ses/

Stackoverflow supporting bcc: https://stackoverflow.com/questions/66627529/send-email-to-undisclosed-recipients-nodemailer

Mentions of potential flagging with empty "to" field: https://security.stackexchange.com/questions/177713/how-did-i-get-this-email-without-a-to-field

https://stackoverflow.com/a/27855503

**UPDATE**: After discussing with product and Morgan, we're going to utilize bcc to send the bulk emails but use the jurisdiction's from address to avoid the spam flagging issue mentioned above.

**UPDATE PART 2**: The public side will have to be tested with totally separate emails not just modified with a plus symbol since two bcc emails to the same inbox will only show as one email.


## How Can This Be Tested/Reviewed?

This can be tested most easily with the lottery flow. Create an admin and partner user connected to your email. Find a listing with lottery enabled and fill out two applications with two separate accounts **on the public side**. Then, go through the lottery flow with the two partners portal users and notice that emails sent to admins don't show admin@example.com in the recipient list. Then, publish the results to the public and you're two applicant emails should send separately and not have visibility to one another in the email information.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
