### PR TITLE
fix: split out scripts and fix public transfer script

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -69,18 +69,35 @@ export class ScirptRunnerController {
     );
   }
 
-  @Put('transferJurisdictionUserApplicationData')
+  @Put('transferJurisdictionPartnerUserData')
   @ApiOperation({
     summary:
-      'A script that pulls user and application data from one source into the current db',
-    operationId: 'transferJurisdictionUserApplicationData',
+      'A script that pulls partner user data from one source into the current db',
+    operationId: 'transferJurisdictionPartnerUserData',
   })
   @ApiOkResponse({ type: SuccessDTO })
-  async transferJurisdictionUserApplicationData(
+  async transferJurisdictionPartnerUserData(
     @Body() dataTransferDTO: DataTransferDTO,
     @Request() req: ExpressRequest,
   ): Promise<SuccessDTO> {
-    return await this.scriptRunnerService.transferJurisdictionUserApplicationData(
+    return await this.scriptRunnerService.transferJurisdictionPartnerUserData(
+      req,
+      dataTransferDTO,
+    );
+  }
+
+  @Put('transferJurisdictionPublicUserApplicationData')
+  @ApiOperation({
+    summary:
+      'A script that pulls public user and application data from one source into the current db',
+    operationId: 'transferJurisdictionPublicUserApplicationData',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async transferJurisdictionPublicUserApplicationData(
+    @Body() dataTransferDTO: DataTransferDTO,
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.transferJurisdictionPublicUserAndApplicationData(
       req,
       dataTransferDTO,
     );

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -77,6 +77,7 @@ describe('Testing script runner service', () => {
     });
 
     it('should transfer ami and multiselect questions', async () => {
+      console.log = jest.fn();
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
@@ -282,6 +283,7 @@ describe('Testing script runner service', () => {
 
   describe('transferJurisdictionListingData', () => {
     it('should transfer listings', async () => {
+      console.log = jest.fn();
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
@@ -536,6 +538,7 @@ describe('Testing script runner service', () => {
     });
 
     it('should transfer listings with RCD', async () => {
+      console.log = jest.fn();
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
@@ -996,6 +999,7 @@ describe('Testing script runner service', () => {
     });
 
     it('should transfer listing events', async () => {
+      console.log = jest.fn();
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
@@ -1088,7 +1092,7 @@ describe('Testing script runner service', () => {
     });
   });
 
-  describe('transferJurisdictionUserApplicationData', () => {
+  describe('transferJurisdictionPartnerUserData', () => {
     it('should transfer partner users', async () => {
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
@@ -1141,12 +1145,12 @@ describe('Testing script runner service', () => {
         activeAccessToken: null,
         activeRefreshToken: null,
       };
-      externalPrismaClient.userAccounts.findMany
-        .mockResolvedValueOnce([partnerOne])
-        .mockResolvedValueOnce([]);
+      externalPrismaClient.userAccounts.findMany.mockResolvedValueOnce([
+        partnerOne,
+      ]);
       prisma.userAccounts.create = jest.fn();
       const id = randomUUID();
-      await service.transferJurisdictionUserApplicationData(
+      await service.transferJurisdictionPartnerUserData(
         {
           user: {
             id,
@@ -1208,8 +1212,11 @@ describe('Testing script runner service', () => {
         },
       });
     });
+  });
 
+  describe('transferJurisdictionPublicUserApplicationData', () => {
     it('should transfer public users', async () => {
+      console.log = jest.fn();
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
@@ -1274,20 +1281,41 @@ describe('Testing script runner service', () => {
         confirmationCode: 'confirmationCode',
         reviewStatus: ApplicationReviewStatusEnum.valid,
       };
-      externalPrismaClient.userAccounts.findMany
-        .mockResolvedValueOnce([]) // No partner users
-        .mockResolvedValueOnce([
-          { ...publicUser, applications: [application] } as any,
-        ]);
+      // application tied to a different jurisdiction
+      const differentApplication = {
+        ...application,
+        id: randomUUID(),
+        listings: { id: randomUUID(), jurisdictionId: randomUUID() },
+      };
+      const additionalPublicUsers = [...Array(25).keys()].map((user) => {
+        return {
+          ...publicUser,
+          id: randomUUID(),
+          email: `email-${user}@email.com`,
+          applications: [{ ...application, id: randomUUID() }],
+        };
+      });
+      externalPrismaClient.userAccounts.findMany.mockResolvedValueOnce([
+        {
+          ...publicUser,
+          applications: [
+            application,
+            differentApplication,
+            { ...application, id: randomUUID() },
+          ],
+        } as any,
+        ...additionalPublicUsers,
+      ]);
       const createdUserId = randomUUID();
       prisma.userAccounts.findFirst = jest.fn().mockResolvedValueOnce(null);
       prisma.userAccounts.create = jest
         .fn()
-        .mockResolvedValueOnce({ id: createdUserId });
+        .mockResolvedValueOnce({ id: createdUserId })
+        .mockResolvedValue({ id: randomUUID() });
       prisma.applications.create = jest.fn();
       prisma.address.createMany = jest.fn();
       const id = randomUUID();
-      await service.transferJurisdictionUserApplicationData(
+      await service.transferJurisdictionPublicUserAndApplicationData(
         {
           user: {
             id,
@@ -1300,7 +1328,7 @@ describe('Testing script runner service', () => {
         externalPrismaClient,
       );
 
-      expect(prisma.userAccounts.create).toBeCalledTimes(1);
+      expect(prisma.userAccounts.create).toBeCalledTimes(26);
       expect(prisma.userAccounts.create).toBeCalledWith({
         data: {
           activeAccessToken: null,
@@ -1338,7 +1366,7 @@ describe('Testing script runner service', () => {
         },
       });
 
-      expect(prisma.applications.create).toBeCalledTimes(1);
+      expect(prisma.applications.create).toBeCalledTimes(27);
       expect(prisma.applications.create).toBeCalledWith({
         data: {
           appUrl: 'appUrl',
@@ -1368,6 +1396,11 @@ describe('Testing script runner service', () => {
           },
         },
       });
+      expect(console.log).toBeCalledWith('migrating 26 public users');
+      expect(console.log).toBeCalledWith(
+        'Progress: 20 users and 21 applications',
+      );
+      expect(console.log).toBeCalledWith('migrated 27 applications');
     });
   });
 

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2247,7 +2247,7 @@ export class ScriptRunnerService {
     })
   }
   /**
-   * A script that pulls data from one source into the current db
+   * A script that pulls jurisdiction data from one source into the current db
    */
   transferJurisdictionData(
     params: {
@@ -2269,7 +2269,7 @@ export class ScriptRunnerService {
     })
   }
   /**
-   * A script that pulls data from one source into the current db
+   * A script that pulls listing data from one source into the current db
    */
   transferJurisdictionListingsData(
     params: {
@@ -2280,6 +2280,50 @@ export class ScriptRunnerService {
   ): Promise<SuccessDTO> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/scriptRunner/transferJurisdictionListingsData"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * A script that pulls partner user data from one source into the current db
+   */
+  transferJurisdictionPartnerUserData(
+    params: {
+      /** requestBody */
+      body?: DataTransferDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/transferJurisdictionPartnerUserData"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * A script that pulls public user and application data from one source into the current db
+   */
+  transferJurisdictionPublicUserApplicationData(
+    params: {
+      /** requestBody */
+      body?: DataTransferDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/transferJurisdictionPublicUserApplicationData"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
@@ -2350,6 +2394,44 @@ export class ScriptRunnerService {
   optOutExistingLotteries(options: IRequestOptions = {}): Promise<SuccessDTO> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/scriptRunner/optOutExistingLotteries"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * A script that creates a new reserved community type
+   */
+  createNewReservedCommunityType(
+    params: {
+      /** requestBody */
+      body?: CommunityTypeDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/createNewReservedCommunityType"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * A script that updates single use code translations to show extended expiration time
+   */
+  updateCodeExpirationTranslations(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/updateCodeExpirationTranslations"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
@@ -6030,6 +6112,17 @@ export interface AmiChartImportDTO {
 
   /**  */
   jurisdictionId: string
+}
+
+export interface CommunityTypeDTO {
+  /**  */
+  id: string
+
+  /**  */
+  name: string
+
+  /**  */
+  description?: string
 }
 
 export interface ApplicationCsvQueryParams {


### PR DESCRIPTION
This PR addresses #4193

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When running the last SMC transfer script of user migration it stopped after only migrating 2 public users without any errors. This happened because for the second user there was an application that wasn't for SMC. The previous code had a "return" statement to avoid adding that application but it accidentally returned out of the whole function.

This PR does the following to remediate the problem:
- splits the existing transfer script into two separate scripts so that we can run just the public user portion
- Changes the code that had the problem so that it just skips the application create but continues on with the rest of the script
- Update unit test to cover that scenario
- Add additional logging so that we can see the progress as the script runs. Tests also cover this

Note: scripts are only intended to be run once, but these will want to be used again for Alameda and San Jose so having them split out is good for long term. That is why I updated the existing already run script as well

## How Can This Be Tested/Reviewed?

Unit tests were added, but this can also manually be tested via these steps:

- Do a reseed locally
- Start up the app locally and go to the swagger api http://localhost:3100/api.
- Login via the api to the admin account http://localhost:3100/api#/auth/login.
- Go to Heroku and get the DB credentials for the HBA staging environment https://data.heroku.com/datastores/fd968c98-f208-4066-b8cf-7d3a6bf8ff03#administration
- Use the credentials from above to run the first script http://localhost:3100/api#/scriptRunner/transferJurisdictionData.
- Run the script for http://localhost:3100/api#/scriptRunner/transferJurisdictionListingsData using the same db credentials and jurisdiction used in the previous script
- Run the latest script to migrate users and applications http://localhost:3100/api#/scriptRunner/transferJurisdictionPublicUserApplicationData.
Verify public users have been transferred over. The easiest way is to compare the user_accounts and associated tables in the database
Verify that applications have properly been carried over. You can do this by looking at the properties in the partner site and clicking on the applications tab and then the specific application you want to look at.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
