### PR TITLE
release: map marker endpoint (#4453)

### DIFF
--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -35,6 +35,7 @@ import { ListingCreate } from '../dtos/listings/listing-create.dto';
 import { ListingDuplicate } from '../dtos/listings/listing-duplicate.dto';
 import { ListingCsvQueryParams } from '../dtos/listings/listing-csv-query-params.dto';
 import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
+import { ListingMapMarker } from '../dtos/listings/listing-map-marker.dto';
 import { ListingsQueryParams } from '../dtos/listings/listings-query-params.dto';
 import { ListingsRetrieveParams } from '../dtos/listings/listings-retrieve-params.dto';
 import { ListingUpdate } from '../dtos/listings/listing-update.dto';
@@ -123,6 +124,16 @@ export class ListingController {
     return await this.listingCsvExportService.exportFile(req, res, queryParams);
   }
 
+  @Get('mapMarkers')
+  @ApiOperation({
+    summary: 'Get listing map markers',
+    operationId: 'mapMarkers',
+  })
+  @ApiOkResponse({ type: ListingMapMarker, isArray: true })
+  async mapMarkers() {
+    return await this.listingService.mapMarkers();
+  }
+
   @Get(`external/:id`)
   @ApiOperation({
     summary: 'Get listing for external consumption by id',
@@ -137,23 +148,6 @@ export class ListingController {
     @Query() queryParams: ListingsRetrieveParams,
   ) {
     return await this.listingService.findOneAndExternalize(
-      listingId,
-      language,
-      queryParams.view,
-    );
-  }
-
-  @Get(`:id`)
-  @ApiOperation({ summary: 'Get listing by id', operationId: 'retrieve' })
-  @UseInterceptors(ClassSerializerInterceptor)
-  @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
-  @ApiOkResponse({ type: Listing })
-  async retrieve(
-    @Headers('language') language: LanguagesEnum,
-    @Param('id', new ParseUUIDPipe({ version: '4' })) listingId: string,
-    @Query() queryParams: ListingsRetrieveParams,
-  ) {
-    return await this.listingService.findOne(
       listingId,
       language,
       queryParams.view,
@@ -235,6 +229,24 @@ export class ListingController {
   ) {
     return await this.listingService.findListingsWithMultiSelectQuestion(
       multiselectQuestionId,
+    );
+  }
+
+  // NestJS best practice to have get(':id') at the bottom of the file
+  @Get(`:id`)
+  @ApiOperation({ summary: 'Get listing by id', operationId: 'retrieve' })
+  @UseInterceptors(ClassSerializerInterceptor)
+  @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
+  @ApiOkResponse({ type: Listing })
+  async retrieve(
+    @Headers('language') language: LanguagesEnum,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) listingId: string,
+    @Query() queryParams: ListingsRetrieveParams,
+  ) {
+    return await this.listingService.findOne(
+      listingId,
+      language,
+      queryParams.view,
     );
   }
 }

--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -66,7 +66,7 @@ import { ListingCreateUpdateValidationPipe } from '../validation-pipes/listing-c
   PaginationAllowsAllQueryParams,
   IdDTO,
 )
-@UseGuards(ApiKeyGuard, OptionalAuthGuard)
+@UseGuards(OptionalAuthGuard)
 @PermissionTypeDecorator('listing')
 @ActivityLogMetadata([{ targetPropertyName: 'status', propertyPath: 'status' }])
 @UseInterceptors(ActivityLogInterceptor)
@@ -113,7 +113,7 @@ export class ListingController {
     operationId: 'listAsCsv',
   })
   @Header('Content-Type', 'application/zip')
-  @UseGuards(OptionalAuthGuard, PermissionGuard)
+  @UseGuards(ApiKeyGuard, OptionalAuthGuard, PermissionGuard)
   @UseInterceptors(ExportLogInterceptor)
   async listAsCsv(
     @Request() req: ExpressRequest,
@@ -159,6 +159,7 @@ export class ListingController {
   @UseInterceptors(ClassSerializerInterceptor)
   @UsePipes(new ListingCreateUpdateValidationPipe(defaultValidationPipeOptions))
   @ApiOkResponse({ type: Listing })
+  @UseGuards(ApiKeyGuard)
   async create(
     @Request() req: ExpressRequest,
     @Body() listingDto: ListingCreate,
@@ -185,6 +186,7 @@ export class ListingController {
   @Delete()
   @ApiOperation({ summary: 'Delete listing by id', operationId: 'delete' })
   @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
+  @UseGuards(ApiKeyGuard)
   async delete(
     @Body() dto: IdDTO,
     @Request() req: ExpressRequest,

--- a/api/src/dtos/listings/listing-map-marker.dto.ts
+++ b/api/src/dtos/listings/listing-map-marker.dto.ts
@@ -1,0 +1,22 @@
+import { Expose } from 'class-transformer';
+import { IsNumber, IsString, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class ListingMapMarker {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  id: string;
+
+  @Expose()
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  lat: number;
+
+  @Expose()
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  lng: number;
+}

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -29,6 +29,7 @@ import { AmiChart } from '../dtos/ami-charts/ami-chart.dto';
 import { Listing } from '../dtos/listings/listing.dto';
 import { ListingCreate } from '../dtos/listings/listing-create.dto';
 import { ListingDuplicate } from '../dtos/listings/listing-duplicate.dto';
+import { ListingMapMarker } from '../dtos/listings/listing-map-marker.dto';
 import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
 import { ListingsQueryParams } from '../dtos/listings/listings-query-params.dto';
 import { ListingUpdate } from '../dtos/listings/listing-update.dto';
@@ -2007,5 +2008,27 @@ export class ListingService implements OnModuleInit {
     }
 
     return listing.jurisdictionId;
+  }
+
+  async mapMarkers(): Promise<ListingMapMarker[]> {
+    const listingsRaw = await this.prisma.listings.findMany({
+      select: {
+        id: true,
+        listingsBuildingAddress: true,
+      },
+      where: {
+        status: ListingsStatusEnum.active,
+      },
+    });
+
+    const listings = mapTo(Listing, listingsRaw);
+
+    return listings.map((listing) => {
+      return {
+        id: listing.id,
+        lat: listing.listingsBuildingAddress.latitude,
+        lng: listing.listingsBuildingAddress.longitude,
+      } as ListingMapMarker;
+    });
   }
 }

--- a/api/test/integration/api-key-guard.e2e-spec.ts
+++ b/api/test/integration/api-key-guard.e2e-spec.ts
@@ -1,12 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
+import cookieParser from 'cookie-parser';
 import { AppModule } from '../../src/modules/app.module';
 import { PrismaService } from '../../src/services/prisma.service';
+import { Login } from '../../src/dtos/auth/login.dto';
+import { userFactory } from '../../prisma/seed-helpers/user-factory';
 
 describe('API Key Guard Tests', () => {
   let app: INestApplication;
   let prisma: PrismaService;
+  let cookies = '';
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,7 +19,26 @@ describe('API Key Guard Tests', () => {
 
     app = moduleFixture.createNestApplication();
     prisma = moduleFixture.get<PrismaService>(PrismaService);
+    app.use(cookieParser());
     await app.init();
+
+    const storedUser = await prisma.userAccounts.create({
+      data: await userFactory({
+        roles: { isAdmin: true },
+        mfaEnabled: false,
+        confirmedAt: new Date(),
+      }),
+    });
+    const resLogIn = await request(app.getHttpServer())
+      .post('/auth/login')
+      .set({ passkey: process.env.API_PASS_KEY || '' })
+      .send({
+        email: storedUser.email,
+        password: 'Abcdef12345!',
+      } as Login)
+      .expect(201);
+
+    cookies = resLogIn.headers['set-cookie'];
   });
 
   afterAll(async () => {
@@ -25,21 +48,26 @@ describe('API Key Guard Tests', () => {
 
   it('should succeed when correct header is present', async () => {
     await request(app.getHttpServer())
-      .get('/jurisdictions')
+      .get('/reservedCommunityTypes')
+      .set('Cookie', cookies)
       .set({ passkey: process.env.API_PASS_KEY || '' })
       .expect(200);
   });
 
   it('should error when incorrect header is present', async () => {
     const res = await request(app.getHttpServer())
-      .get('/listings')
+      .get('/reservedCommunityTypes')
       .set({ passkey: 'the wrong key' })
+      .set('Cookie', cookies)
       .expect(401);
     expect(res.body.message).toBe('Traffic not from a known source');
   });
 
   it('should error when no header is present', async () => {
-    const res = await request(app.getHttpServer()).get('/listings').expect(401);
+    const res = await request(app.getHttpServer())
+      .get('/reservedCommunityTypes')
+      .set('Cookie', cookies)
+      .expect(401);
     expect(res.body.message).toBe('Traffic not from a known source');
   });
 });

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -1248,6 +1248,14 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
 
       expect(activityLogResult).not.toBeNull();
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -1212,6 +1212,14 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
 
       expect(activityLogResult).not.toBeNull();
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -1148,6 +1148,14 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
 
       expect(activityLogResult).not.toBeNull();
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-limited-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-limited-juris-admin-correct-juris.e2e-spec.ts
@@ -1188,6 +1188,12 @@ describe('Testing Permissioning of endpoints as Limited Jurisdictional Admin in 
 
       expect(activityLogResult).not.toBeNull();
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-limited-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-limited-juris-admin-wrong-juris.e2e-spec.ts
@@ -1156,6 +1156,12 @@ describe('Testing Permissioning of endpoints as Limited Jurisdictional Admin in 
 
       expect(activityLogResult).not.toBeNull();
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -1060,6 +1060,14 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .set('Cookie', cookies)
         .expect(403);
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
@@ -1140,6 +1140,14 @@ describe('Testing Permissioning of endpoints as partner with correct listing', (
         .set('Cookie', cookies)
         .expect(200);
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -1099,6 +1099,14 @@ describe('Testing Permissioning of endpoints as partner with wrong listing', () 
         .set('Cookie', cookies)
         .expect(200);
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -1131,6 +1131,14 @@ describe('Testing Permissioning of endpoints as public user', () => {
         .set('Cookie', cookies)
         .expect(403);
     });
+
+    it('should succeed for mapMarkers endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/listings/mapMarkers`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
   });
 
   describe('Testing application flagged set endpoints', () => {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -3521,4 +3521,27 @@ describe('Testing listing service', () => {
       expect(prisma.assets.deleteMany).not.toHaveBeenCalled();
     });
   });
+
+  describe('Test mapMarkers endpoint', () => {
+    it('should find all active listings', async () => {
+      prisma.listings.findMany = jest.fn().mockResolvedValue([
+        {
+          id: 'random id',
+          listingsBuildingAddress: exampleAddress,
+        },
+      ]);
+
+      await service.mapMarkers();
+
+      expect(prisma.listings.findMany).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          listingsBuildingAddress: true,
+        },
+        where: {
+          status: ListingsStatusEnum.active,
+        },
+      });
+    });
+  });
 });

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -298,6 +298,20 @@ export class ListingsService {
     })
   }
   /**
+   * Get listing map markers
+   */
+  mapMarkers(options: IRequestOptions = {}): Promise<ListingMapMarker[]> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/mapMarkers"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+
+      /** 适配ios13，get请求不允许带body */
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
    * Get listing for external consumption by id
    */
   externalRetrieve(
@@ -317,55 +331,6 @@ export class ListingsService {
       configs.params = { view: params["view"] }
 
       /** 适配ios13，get请求不允许带body */
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
-   * Get listing by id
-   */
-  retrieve(
-    params: {
-      /**  */
-      id: string
-      /**  */
-      view?: ListingViews
-    } = {} as any,
-    options: IRequestOptions = {}
-  ): Promise<Listing> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/listings/{id}"
-      url = url.replace("{id}", params["id"] + "")
-
-      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-      configs.params = { view: params["view"] }
-
-      /** 适配ios13，get请求不允许带body */
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
-   * Update listing by id
-   */
-  update(
-    params: {
-      /**  */
-      id: string
-      /** requestBody */
-      body?: ListingUpdate
-    } = {} as any,
-    options: IRequestOptions = {}
-  ): Promise<Listing> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/listings/{id}"
-      url = url.replace("{id}", params["id"] + "")
-
-      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = params.body
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -404,6 +369,55 @@ export class ListingsService {
       let data = null
 
       configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Update listing by id
+   */
+  update(
+    params: {
+      /**  */
+      id: string
+      /** requestBody */
+      body?: ListingUpdate
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<Listing> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/{id}"
+      url = url.replace("{id}", params["id"] + "")
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Get listing by id
+   */
+  retrieve(
+    params: {
+      /**  */
+      id: string
+      /**  */
+      view?: ListingViews
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<Listing> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/{id}"
+      url = url.replace("{id}", params["id"] + "")
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+      configs.params = { view: params["view"] }
+
+      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -3654,6 +3668,17 @@ export interface PaginatedListing {
 
   /**  */
   meta: PaginationMeta
+}
+
+export interface ListingMapMarker {
+  /**  */
+  id: string
+
+  /**  */
+  lat: number
+
+  /**  */
+  lng: number
 }
 
 export interface UnitAmiChartOverrideCreate {


### PR DESCRIPTION
This PR addresses [#(889)](https://github.com/metrotranscom/doorway/issues/889)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Creates a public endpoint to return the id, longitude, and latitude of every open listing called `mapMarkers`.

The existing list endpoint will be used with view params to handle the other endpoint case.

## How Can This Be Tested/Reviewed?

Using OpenAPI or by hitting the API directly through another client, call `listings/mapMarkers`
Verify only open listing id's are returned and check the lat and long returned matches what is in the db.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
