### PR TITLE
fix: remove opt in logic

### DIFF
--- a/api/src/utilities/lottery-date-validator.ts
+++ b/api/src/utilities/lottery-date-validator.ts
@@ -15,11 +15,10 @@ export class LotteryDateParamValidator implements ValidatorConstraintInterface {
     listingEvents: ListingEvent[] | undefined,
     args: ValidationArguments,
   ) {
-    const { reviewOrderType, lotteryOptIn } = args.object as {
+    const { reviewOrderType } = args.object as {
       reviewOrderType: string;
-      lotteryOptIn: boolean;
     };
-    if (reviewOrderType === ReviewOrderTypeEnum.lottery && lotteryOptIn) {
+    if (reviewOrderType === ReviewOrderTypeEnum.lottery) {
       return !!listingEvents.find(
         (event: ListingEvent) =>
           event.type === ListingEventsTypeEnum.publicLottery &&

--- a/api/test/unit/utilities/lottery-date-validator.spec.ts
+++ b/api/test/unit/utilities/lottery-date-validator.spec.ts
@@ -2,14 +2,13 @@ import { ListingEventsTypeEnum, ReviewOrderTypeEnum } from '@prisma/client';
 import { LotteryDateParamValidator } from '../../../src/utilities/lottery-date-validator';
 
 describe('Testing OrderQueryParamValidator', () => {
-  it('should return true if reviewOrderType is not lottery and lotteryOptIn is null', () => {
+  it('should return true if reviewOrderType is not lottery', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate([], {
         property: 'listingEvents',
         object: {
           reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
-          lotteryOptIn: null,
         },
         value: undefined,
         constraints: [],
@@ -18,14 +17,13 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeTruthy();
   });
 
-  it('should return false if reviewOrderType is lottery and lotteryOptIn is no', () => {
+  it('should return false if reviewOrderType is lottery and listingEvents is empty', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate([], {
         property: 'listingEvents',
         object: {
           reviewOrderType: ReviewOrderTypeEnum.lottery,
-          lotteryOptIn: false,
         },
         value: undefined,
         constraints: [],
@@ -34,23 +32,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents is empty', () => {
-    const lotteryDateParamValidator = new LotteryDateParamValidator();
-    expect(
-      lotteryDateParamValidator.validate([], {
-        property: 'listingEvents',
-        object: {
-          reviewOrderType: ReviewOrderTypeEnum.lottery,
-          lotteryOptIn: true,
-        },
-        value: undefined,
-        constraints: [],
-        targetName: '',
-      }),
-    ).toBeFalsy();
-  });
-
-  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startDate', () => {
+  it('should return false if reviewOrderType is lottery and listingEvents has publicLottery without startDate', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -69,7 +51,6 @@ describe('Testing OrderQueryParamValidator', () => {
           property: 'listingEvents',
           object: {
             reviewOrderType: ReviewOrderTypeEnum.lottery,
-            lotteryOptIn: true,
           },
           value: undefined,
           constraints: [],
@@ -79,7 +60,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startTime', () => {
+  it('should return false if reviewOrderType is lottery and listingEvents has publicLottery without startTime', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -98,7 +79,6 @@ describe('Testing OrderQueryParamValidator', () => {
           property: 'listingEvents',
           object: {
             reviewOrderType: ReviewOrderTypeEnum.lottery,
-            lotteryOptIn: true,
           },
           value: undefined,
           constraints: [],
@@ -108,7 +88,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without endTime', () => {
+  it('should return false if reviewOrderType is lottery and listingEvents has publicLottery without endTime', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -127,7 +107,6 @@ describe('Testing OrderQueryParamValidator', () => {
           property: 'listingEvents',
           object: {
             reviewOrderType: ReviewOrderTypeEnum.lottery,
-            lotteryOptIn: true,
           },
           value: undefined,
           constraints: [],
@@ -137,7 +116,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has full publicLottery event', () => {
+  it('should return true if reviewOrderType is lottery and listingEvents has full publicLottery event', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -156,7 +135,6 @@ describe('Testing OrderQueryParamValidator', () => {
           property: 'listingEvents',
           object: {
             reviewOrderType: ReviewOrderTypeEnum.lottery,
-            lotteryOptIn: true,
           },
           value: undefined,
           constraints: [],
@@ -166,7 +144,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeTruthy();
   });
 
-  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has full publicLottery event and other events', () => {
+  it('should return true if reviewOrderType is lottery and listingEvents has full publicLottery event and other events', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -194,7 +172,6 @@ describe('Testing OrderQueryParamValidator', () => {
           property: 'listingEvents',
           object: {
             reviewOrderType: ReviewOrderTypeEnum.lottery,
-            lotteryOptIn: true,
           },
           value: undefined,
           constraints: [],

--- a/api/test/unit/utilities/lottery-date-validator.spec.ts
+++ b/api/test/unit/utilities/lottery-date-validator.spec.ts
@@ -18,7 +18,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeTruthy();
   });
 
-  it('should return true if reviewOrderType is lottery and lotteryOptIn is no', () => {
+  it('should return false if reviewOrderType is lottery and lotteryOptIn is no', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate([], {
@@ -31,7 +31,7 @@ describe('Testing OrderQueryParamValidator', () => {
         constraints: [],
         targetName: '',
       }),
-    ).toBeTruthy();
+    ).toBeFalsy();
   });
 
   it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents is empty', () => {


### PR DESCRIPTION
This PR addresses #936 
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the lottery date validation process to require the lottery date whether the user has opted in or not.

## How Can This Be Tested/Reviewed?

This can be tested by attempting to save a lottery listing that opted out of using the system lottery with missing lottery date information. 

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
