### PR TITLE
fix: enforce max length

### DIFF
--- a/sites/partners/src/components/settings/PreferenceDrawer.tsx
+++ b/sites/partners/src/components/settings/PreferenceDrawer.tsx
@@ -248,8 +248,12 @@ const PreferenceDrawer = ({
                       type="text"
                       dataTestId={"preference-title"}
                       defaultValue={questionData?.text}
-                      errorMessage={t("errors.requiredFieldError")}
-                      validation={{ required: true }}
+                      errorMessage={
+                        errors.text?.type === "maxLength"
+                          ? t("errors.maxLength", { length: 32 })
+                          : t("errors.requiredFieldError")
+                      }
+                      validation={{ required: true, maxLength: 32 }}
                       error={errors.text}
                       inputProps={{
                         onChange: () => clearErrors("text"),


### PR DESCRIPTION
This PR addresses #941 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the preference drawer to include FE validation that the title is no more than 32 characters.

Note that I intentionally did not include this validation on the BE since the issue indicated enforcing this via the UI and changing the multiselect questions dto would have implications for programs as well. I imagine BE validation will be brought over once we develop a sustainable solution for Core + HBA. As a reminder, those jurisdictions currently have preferences over that character limit so this change is made in Doorway rather than Core.

## How Can This Be Tested/Reviewed?

Add a new preference and try saving a new preference with no title filled out and then a title over 32 characters to observe the dynamic error message.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
