### PR TITLE
fix: check for limited juris role

### DIFF
--- a/sites/partners/src/pages/listings/[id]/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/index.tsx
@@ -73,7 +73,8 @@ export default function ListingDetail(props: ListingProps) {
                 lotteryLabel:
                   listing.status === ListingsStatusEnum.closed &&
                   listing?.lotteryOptIn &&
-                  listing?.reviewOrderType === ReviewOrderTypeEnum.lottery
+                  listing?.reviewOrderType === ReviewOrderTypeEnum.lottery &&
+                  !profile?.userRoles?.isLimitedJurisdictionalAdmin
                     ? t("listings.lotteryTitle")
                     : undefined,
               }}


### PR DESCRIPTION
This PR addresses #943 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the lottery tab logic to not show if the user is a limited juris no PII user.

## How Can This Be Tested/Reviewed?

This can be tested by signing in to a limited juris user and viewing a closed lottery listing. There should be no lottery tab visible. Now check out that same listing with other roles and it should still be visible.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
