### PR TITLE
fix: paper application saving issue

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -235,4 +235,17 @@ export class ScirptRunnerController {
   ): Promise<SuccessDTO> {
     return await this.scriptRunnerService.hideProgramsFromListings(req);
   }
+
+  @Put('removeWorkAddresses')
+  @ApiOperation({
+    summary:
+      'A script that deletes work addresses from applicants and household members',
+    operationId: 'removeWorkAddresses',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async removeWorkAddresses(
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.removeWorkAddresses(req);
+  }
 }

--- a/api/src/services/application.service.ts
+++ b/api/src/services/application.service.ts
@@ -839,11 +839,13 @@ export class ApplicationService {
                     ...dto.applicant.applicantAddress,
                   },
                 },
-                applicantWorkAddress: {
-                  create: {
-                    ...dto.applicant.applicantWorkAddress,
-                  },
-                },
+                applicantWorkAddress: dto.applicant.applicantAddress?.street
+                  ? {
+                      create: {
+                        ...dto.applicant.applicantAddress,
+                      },
+                    }
+                  : undefined,
                 firstName: dto.applicant.firstName?.trim(),
                 lastName: dto.applicant.lastName?.trim(),
                 birthDay: dto.applicant.birthDay
@@ -922,11 +924,14 @@ export class ApplicationService {
                     ...member.householdMemberAddress,
                   },
                 },
-                householdMemberWorkAddress: {
-                  create: {
-                    ...member.householdMemberWorkAddress,
-                  },
-                },
+                householdMemberWorkAddress: member.householdMemberWorkAddress
+                  ?.street
+                  ? {
+                      create: {
+                        ...member.householdMemberWorkAddress,
+                      },
+                    }
+                  : undefined,
                 firstName: member.firstName?.trim(),
                 lastName: member.lastName?.trim(),
                 birthDay: member.birthDay ? Number(member.birthDay) : undefined,

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -1309,10 +1309,6 @@ export class ScriptRunnerService {
       },
     });
 
-    const workAddressesIds = applicants
-      .concat(householdMembers)
-      .map((address) => address.workAddressId);
-
     await this.prisma.applicant.updateMany({
       data: {
         workAddressId: null,
@@ -1335,15 +1331,17 @@ export class ScriptRunnerService {
       },
     });
 
-    const result = await this.prisma.address.deleteMany({
+    const workAddressesIds = applicants
+      .concat(householdMembers)
+      .map((address) => address.workAddressId);
+
+    await this.prisma.address.deleteMany({
       where: {
         id: {
           in: workAddressesIds,
         },
       },
     });
-
-    console.log(result);
 
     await this.markScriptAsComplete('remove work addresses', requestingUser);
     return { success: true };

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -1281,6 +1281,74 @@ export class ScriptRunnerService {
     return { success: true };
   }
 
+  async removeWorkAddresses(req: ExpressRequest): Promise<SuccessDTO> {
+    const requestingUser = mapTo(User, req['user']);
+    await this.markScriptAsRunStart('remove work addresses', requestingUser);
+
+    const applicants = await this.prisma.applicant.findMany({
+      select: {
+        id: true,
+        workAddressId: true,
+      },
+      where: {
+        workAddressId: {
+          not: null,
+        },
+      },
+    });
+
+    const householdMembers = await this.prisma.householdMember.findMany({
+      select: {
+        id: true,
+        workAddressId: true,
+      },
+      where: {
+        workAddressId: {
+          not: null,
+        },
+      },
+    });
+
+    const workAddressesIds = applicants
+      .concat(householdMembers)
+      .map((address) => address.workAddressId);
+
+    await this.prisma.applicant.updateMany({
+      data: {
+        workAddressId: null,
+      },
+      where: {
+        id: {
+          in: applicants.map((applicant) => applicant.id),
+        },
+      },
+    });
+
+    await this.prisma.householdMember.updateMany({
+      data: {
+        workAddressId: null,
+      },
+      where: {
+        id: {
+          in: householdMembers.map((householdMember) => householdMember.id),
+        },
+      },
+    });
+
+    const result = await this.prisma.address.deleteMany({
+      where: {
+        id: {
+          in: workAddressesIds,
+        },
+      },
+    });
+
+    console.log(result);
+
+    await this.markScriptAsComplete('remove work addresses', requestingUser);
+    return { success: true };
+  }
+
   /**
     this is simply an example
   */

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2541,6 +2541,22 @@ export class ScriptRunnerService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * A script that deletes work addresses from applicants and household members
+   */
+  removeWorkAddresses(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/removeWorkAddresses"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export class LotteryService {

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -187,6 +187,8 @@ export const mapFormToApi = ({
 
   householdMembers.forEach((member) => {
     member.relationship = member.relationship || null
+    delete member.householdMemberWorkAddress
+    delete member.workInRegion
   })
 
   const incomePeriod: IncomePeriodEnum | null = data.application?.incomePeriod || null


### PR DESCRIPTION
This PR addresses [#(977)](https://github.com/metrotranscom/doorway/issues/977) [#(975)](https://github.com/metrotranscom/doorway/issues/975#event-15551490203)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Due to removal of the `Work in city` question from all applications, an unintended bug was created when updating paper applications.

To correct this, the application update function will no longer automatically create a work address for the household members and the applicant.

The existing applications that are affected by this issue need to have the `work_address_id` field cleared from the applicant and householdMembers tables. This is handled by the new script that collects the applicants and householdMembers that have work_address_id's, nulls these fields, and then deletes the empty addresses from the address table.

## How Can This Be Tested/Reviewed?

On the main branch:
- Run `yarn setup`
- Run the backend and partner site
- Create a paper app with a household member
- Edit the application
- Edit again to see the error

Switch to the pr branch:
- Run the script `/scriptRunner/removeWorkAddresses`
- Go back and edit the application, should save successfully
- Create a new application with a household member, should be able to edit infinitely

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
