### PR TITLE
fix: partial date formatting on paper app

### DIFF
--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -1,4 +1,4 @@
-import { TimeFieldPeriod } from "@bloom-housing/ui-components"
+import { DateFieldValues, TimeFieldPeriod, TimeFieldValues } from "@bloom-housing/ui-components"
 import {
   fieldGroupObjectToArray,
   adaFeatureKeys,
@@ -85,42 +85,30 @@ export const mapFormToApi = ({
     ? data.application?.language
     : null
 
-  const submissionDate: Date | null = (() => {
-    // rename default (wrong property names)
-    const {
-      day: submissionDay,
-      month: submissionMonth,
-      year: submissionYear,
-    } = data.dateSubmitted || {}
-    const { hours, minutes = 0, seconds = 0, period } = data?.timeSubmitted || {}
+  const getDateTime = (date: DateFieldValues, time: TimeFieldValues) => {
+    let day = date?.day
+    let month = date?.month
+    const year = date?.year
+    const { hours, minutes = 0, seconds = 0, period } = time || {}
 
-    if (!submissionDay || !submissionMonth || !submissionYear) return null
+    if (!day || !month || !year) return null
+
+    if (month.length === 1) month = `0${month}`
+    if (day.length === 1) day = `0${day}`
 
     const dateString = dayjs(
-      `${submissionMonth}/${submissionDay}/${submissionYear} ${hours}:${minutes}:${seconds} ${period}`,
+      `${month}/${day}/${year} ${hours}:${minutes}:${seconds} ${period}`,
       "MM/DD/YYYY hh:mm:ss a"
     ).format(TIME_24H_FORMAT)
 
     const formattedDate = dayjs(dateString, TIME_24H_FORMAT).toDate()
 
     return formattedDate
-  })()
+  }
 
-  const receivedAt: Date | null = (() => {
-    const { day: receivedDay, month: receivedMonth, year: receivedYear } = data?.dateReceived || {}
-    const { hours, minutes = 0, seconds = 0, period } = data?.timeReceived || {}
+  const submissionDate: Date | null = getDateTime(data?.dateSubmitted, data?.timeSubmitted)
 
-    if (!receivedDay || !receivedMonth || !receivedYear) return null
-
-    const dateString = dayjs(
-      `${receivedMonth}/${receivedDay}/${receivedYear} ${hours}:${minutes}:${seconds} ${period}`,
-      "MM/DD/YYYY hh:mm:ss a"
-    ).format(TIME_24H_FORMAT)
-
-    const formattedDate = dayjs(dateString, TIME_24H_FORMAT).toDate()
-
-    return formattedDate
-  })()
+  const receivedAt: Date | null = getDateTime(data?.dateReceived, data?.timeReceived)
 
   const receivedBy = data.application?.receivedBy || null
 


### PR DESCRIPTION
## Description

Will allow partial date formatting on the two paper application date fields.

## How Can This Be Tested/Reviewed?

Try to update a paper application with a partially formatted date (i.e. with single integers in month and day, like `1/5/2024` vs `01/05/2024` and ensure the data is saved

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
