### PR TITLE
fix: timezone apply to opp email

### DIFF
--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -526,7 +526,9 @@ export class EmailService {
     if (listing.applicationDueDate) {
       tableRows.push({
         label: this.polyglot.t('rentalOpportunity.applicationsDue'),
-        value: dayjs(listing.applicationDueDate).format('MMMM D, YYYY'),
+        value: dayjs(listing.applicationDueDate)
+          .tz(process.env.TIME_ZONE)
+          .format('MMMM D, YYYY'),
       });
     }
     tableRows.push({
@@ -573,7 +575,9 @@ export class EmailService {
       if (lotteryEvent && lotteryEvent.startDate) {
         tableRows.push({
           label: this.polyglot.t('rentalOpportunity.lottery'),
-          value: dayjs(lotteryEvent.startDate).format('MMMM D, YYYY'),
+          value: dayjs(lotteryEvent.startDate)
+            .tz(process.env.TIME_ZONE)
+            .format('MMMM D, YYYY'),
         });
       }
     }


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/980

- [x] Addresses the issue in full

## Description
listing opportunity email now has dates transformed into the correct timezone

## How Can This Be Tested/Reviewed?
locally: after seeding make sure you turn on the listing opportunity jurisdiction setting to get the email


create a listing with an application due date -> publish listing -> you should get an email with the correct date

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
