### PR TITLE
fix: batch deletion for remove work address script

### DIFF
--- a/api/src/services/application.service.ts
+++ b/api/src/services/application.service.ts
@@ -641,6 +641,7 @@ export class ApplicationService {
       data: {
         ...dto,
         confirmationCode: this.generateConfirmationCode(),
+        contactPreferences: [],
         applicant: dto.applicant
           ? {
               create: {

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -1285,65 +1285,95 @@ export class ScriptRunnerService {
     const requestingUser = mapTo(User, req['user']);
     await this.markScriptAsRunStart('remove work addresses', requestingUser);
 
-    const applicants = await this.prisma.applicant.findMany({
-      select: {
-        id: true,
-        workAddressId: true,
-      },
-      where: {
-        workAddressId: {
-          not: null,
+    let applicantLoop = true;
+
+    while (applicantLoop) {
+      const rawApplicants = await this.prisma.applicant.findMany({
+        select: {
+          id: true,
+          workAddressId: true,
         },
-      },
-    });
-
-    const householdMembers = await this.prisma.householdMember.findMany({
-      select: {
-        id: true,
-        workAddressId: true,
-      },
-      where: {
-        workAddressId: {
-          not: null,
-        },
-      },
-    });
-
-    await this.prisma.applicant.updateMany({
-      data: {
-        workAddressId: null,
-      },
-      where: {
-        workAddressId: {
-          not: null,
-        },
-      },
-    });
-
-    await this.prisma.householdMember.updateMany({
-      data: {
-        workAddressId: null,
-      },
-      where: {
-        workAddressId: {
-          not: null,
-        },
-      },
-    });
-
-    const workAddressesIds = applicants
-      .concat(householdMembers)
-      .map((address) => address.workAddressId);
-
-    for (let i = 0; i < workAddressesIds.length; i += 10000) {
-      await this.prisma.address.deleteMany({
         where: {
-          id: {
-            in: workAddressesIds.slice(i, i + 10000),
+          workAddressId: {
+            not: null,
           },
         },
+        take: 10000,
       });
+
+      if (!rawApplicants?.length) {
+        applicantLoop = false;
+      } else {
+        console.log(
+          `${rawApplicants.length} applicant work addresses to remove`,
+        );
+
+        await this.prisma.applicant.updateMany({
+          data: {
+            workAddressId: null,
+          },
+          where: {
+            id: {
+              in: rawApplicants.map((applicant) => applicant.id),
+            },
+          },
+        });
+
+        await this.prisma.address.deleteMany({
+          where: {
+            id: {
+              in: rawApplicants.map((applicant) => applicant.workAddressId),
+            },
+          },
+        });
+      }
     }
+    console.log(`All applicant work addresses have been removed`);
+
+    let householdLoop = true;
+
+    while (householdLoop) {
+      const rawHouseholdMembers = await this.prisma.householdMember.findMany({
+        select: {
+          id: true,
+          workAddressId: true,
+        },
+        where: {
+          workAddressId: {
+            not: null,
+          },
+        },
+        take: 10000,
+      });
+
+      if (!rawHouseholdMembers?.length) {
+        householdLoop = false;
+      } else {
+        console.log(
+          `${rawHouseholdMembers.length} household member work addresses to remove`,
+        );
+
+        await this.prisma.householdMember.updateMany({
+          data: {
+            workAddressId: null,
+          },
+          where: {
+            id: {
+              in: rawHouseholdMembers.map((member) => member.id),
+            },
+          },
+        });
+
+        await this.prisma.address.deleteMany({
+          where: {
+            id: {
+              in: rawHouseholdMembers.map((member) => member.workAddressId),
+            },
+          },
+        });
+      }
+    }
+    console.log(`All household member work addresses have been removed`);
 
     await this.markScriptAsComplete('remove work addresses', requestingUser);
     return { success: true };

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -1314,8 +1314,8 @@ export class ScriptRunnerService {
         workAddressId: null,
       },
       where: {
-        id: {
-          in: applicants.map((applicant) => applicant.id),
+        workAddressId: {
+          not: null,
         },
       },
     });
@@ -1325,8 +1325,8 @@ export class ScriptRunnerService {
         workAddressId: null,
       },
       where: {
-        id: {
-          in: householdMembers.map((householdMember) => householdMember.id),
+        workAddressId: {
+          not: null,
         },
       },
     });
@@ -1335,13 +1335,15 @@ export class ScriptRunnerService {
       .concat(householdMembers)
       .map((address) => address.workAddressId);
 
-    await this.prisma.address.deleteMany({
-      where: {
-        id: {
-          in: workAddressesIds,
+    for (let i = 0; i < workAddressesIds.length; i += 10000) {
+      await this.prisma.address.deleteMany({
+        where: {
+          id: {
+            in: workAddressesIds.slice(i, i + 10000),
+          },
         },
-      },
-    });
+      });
+    }
 
     await this.markScriptAsComplete('remove work addresses', requestingUser);
     return { success: true };

--- a/api/test/unit/services/application.service.spec.ts
+++ b/api/test/unit/services/application.service.spec.ts
@@ -152,7 +152,7 @@ export const mockCreateApplicationData = (
   submissionDate: Date,
 ): ApplicationCreate => {
   return {
-    contactPreferences: ['example contact preference'],
+    contactPreferences: [],
     preferences: [
       {
         key: 'example key',
@@ -1493,7 +1493,7 @@ describe('Testing application service', () => {
     expect(prisma.applications.create).toHaveBeenCalledWith({
       include: { ...detailView },
       data: {
-        contactPreferences: ['example contact preference'],
+        contactPreferences: [],
         status: ApplicationStatusEnum.submitted,
         submissionType: ApplicationSubmissionTypeEnum.electronical,
         appUrl: 'http://www.example.com',
@@ -1719,7 +1719,7 @@ describe('Testing application service', () => {
     expect(prisma.applications.create).toHaveBeenCalledWith({
       include: { ...detailView },
       data: {
-        contactPreferences: ['example contact preference'],
+        contactPreferences: [],
         status: ApplicationStatusEnum.submitted,
         submissionType: ApplicationSubmissionTypeEnum.electronical,
         appUrl: 'http://www.example.com',
@@ -2073,7 +2073,7 @@ describe('Testing application service', () => {
         ...detailView,
       },
       data: {
-        contactPreferences: ['example contact preference'],
+        contactPreferences: [],
         status: ApplicationStatusEnum.submitted,
         submissionType: ApplicationSubmissionTypeEnum.electronical,
         appUrl: 'http://www.example.com',
@@ -2310,7 +2310,7 @@ describe('Testing application service', () => {
         ...detailView,
       },
       data: {
-        contactPreferences: ['example contact preference'],
+        contactPreferences: [],
         status: ApplicationStatusEnum.submitted,
         submissionType: ApplicationSubmissionTypeEnum.electronical,
         appUrl: 'http://www.example.com',

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1888,11 +1888,11 @@ describe('Testing script runner service', () => {
     prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
     prisma.applicant.findMany = jest
       .fn()
-      .mockResolvedValue([{ id: id, workAddressId: id }]);
+      .mockResolvedValueOnce([{ id: id, workAddressId: id }]);
     prisma.applicant.updateMany = jest.fn().mockResolvedValue(null);
     prisma.householdMember.findMany = jest
       .fn()
-      .mockResolvedValue([{ id: id, workAddressId: id }]);
+      .mockResolvedValueOnce([{ id: id, workAddressId: id }]);
     prisma.householdMember.updateMany = jest.fn().mockResolvedValue(null);
     prisma.address.deleteMany = jest.fn().mockResolvedValue(null);
 
@@ -1933,6 +1933,17 @@ describe('Testing script runner service', () => {
           not: null,
         },
       },
+      take: 10000,
+    });
+    expect(prisma.applicant.updateMany).toHaveBeenCalledWith({
+      data: {
+        workAddressId: null,
+      },
+      where: {
+        id: {
+          in: [id],
+        },
+      },
     });
     expect(prisma.householdMember.findMany).toHaveBeenCalledWith({
       select: {
@@ -1944,34 +1955,27 @@ describe('Testing script runner service', () => {
           not: null,
         },
       },
+      take: 10000,
     });
-    expect(prisma.applicant.updateMany).toHaveBeenCalledWith({
-      data: {
-        workAddressId: null,
-      },
-      where: {
-        workAddressId: {
-          not: null,
-        },
-      },
-    });
+
     expect(prisma.householdMember.updateMany).toHaveBeenCalledWith({
       data: {
         workAddressId: null,
       },
       where: {
-        workAddressId: {
-          not: null,
+        id: {
+          in: [id],
         },
       },
     });
     expect(prisma.address.deleteMany).toHaveBeenCalledWith({
       where: {
         id: {
-          in: [id, id],
+          in: [id],
         },
       },
     });
+    expect(prisma.address.deleteMany).toHaveBeenCalledTimes;
   });
 
   // | ---------- HELPER TESTS BELOW ---------- | //

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1950,8 +1950,8 @@ describe('Testing script runner service', () => {
         workAddressId: null,
       },
       where: {
-        id: {
-          in: [id],
+        workAddressId: {
+          not: null,
         },
       },
     });
@@ -1960,8 +1960,8 @@ describe('Testing script runner service', () => {
         workAddressId: null,
       },
       where: {
-        id: {
-          in: [id],
+        workAddressId: {
+          not: null,
         },
       },
     });

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1975,7 +1975,7 @@ describe('Testing script runner service', () => {
         },
       },
     });
-    expect(prisma.address.deleteMany).toHaveBeenCalledTimes;
+    expect(prisma.address.deleteMany).toHaveBeenCalledTimes(2);
   });
 
   // | ---------- HELPER TESTS BELOW ---------- | //


### PR DESCRIPTION
This PR addresses [#(977)](https://github.com/metrotranscom/doorway/issues/977)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Due to SQL limit of 32767 for items in the where clause, the updateMany and deleteMany calls failed on staging data.
To account for this, updateMany for applicants and householdMembers is switch to checking which record have a workAddressId and the deleteMany for address uses batching on the addressIds.

Additionally, a bug was found in staging that paper and electronic applications were not saving because the contactPreferences were not being sent. Corrected by always setting it to `[]`

## How Can This Be Tested/Reviewed?

Run yarn setup
View db tables `applicant`, `household_member` and `address`. Seed data adds work addresses to a number of applicants and household members.
Run the script /scriptRunner/removeWorkAddresses
Check the tables again and compare the differences.

Add a paper and a electronic application and confirm that the contactPreferences were set to `[]` in the db.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
