### PR TITLE
fix: docker uses lockfile

### DIFF
--- a/build/docker/Dockerfile.backend
+++ b/build/docker/Dockerfile.backend
@@ -75,6 +75,7 @@ WORKDIR /app
 COPY --from=source --chown=node:node \
     /app/api/package*.json \
     /app/api/tsconfig*.json \
+    /app/api/yarn*.lock \
     /app/api/prisma ./
 
 # Set the NODE_ENV variable
@@ -101,6 +102,7 @@ WORKDIR /app
 COPY --from=source --chown=node:node \
     /app/api/package*.json \
     /app/api/tsconfig*.json \
+    /app/api/yarn*.lock \
     /app/api/prisma ./
 
 # Add only dependencies required to run the application


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Docker build now always uses yarn.lock file for packages.

## How Can This Be Tested/Reviewed?

Run `docker build . -f build/docker/Dockerfile.backend --target run -t api:run-candidate` locally and see that there is no `info No lockfile found.` in the logs.
To view logs, open link provided after build completes in the browser.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
