### PR TITLE
fix: docker symlink

### DIFF
--- a/build/docker/Dockerfile.backend
+++ b/build/docker/Dockerfile.backend
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 node:16.3.0
 # The source stage will contain only the necessary source code
 FROM node:18.20-alpine AS source
 
-RUN apk add --no-cache openssl
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 
 # WORKDIR doesn't need to be fancy, but it needs to be consistent
 WORKDIR /app


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Switching to symlink instead of apk add. Based on https://github.com/nodejs/docker-node/issues/2175#issuecomment-2530130523

## How Can This Be Tested/Reviewed?

Run docker build . -f build/docker/Dockerfile.backend --target run -t api:run-candidate locally and see that the following warning is not present:
`prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
Please manually install OpenSSL and try installing Prisma again.`
To view logs, open link provided after build completes in the browser.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
