### PR TITLE
fix: ami chart selection bug

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -234,9 +234,6 @@ export const stagingSeed = async (
       data: amiChartFactory(8, additionalJurisdiction.id),
     });
   }
-  await prismaClient.amiChart.create({
-    data: amiChartFactory(8, additionalJurisdiction.id),
-  });
   // Create map layers
   await prismaClient.mapLayers.create({
     data: mapLayerFactory(jurisdiction.id, 'Redlined Districts', redlinedMap),

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -228,6 +228,12 @@ export const stagingSeed = async (
   const amiChart = await prismaClient.amiChart.create({
     data: amiChartFactory(10, jurisdiction.id),
   });
+  const NUM_AMI_CHARTS = 5;
+  for (let index = 0; index < NUM_AMI_CHARTS; index++) {
+    await prismaClient.amiChart.create({
+      data: amiChartFactory(8, additionalJurisdiction.id),
+    });
+  }
   await prismaClient.amiChart.create({
     data: amiChartFactory(8, additionalJurisdiction.id),
   });

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -130,7 +130,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
   useEffect(() => {
     void resetDefaultValues()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [amiCharts])
 
   const fetchAmiChart = async (defaultChartID?: string) => {
     try {


### PR DESCRIPTION
This PR addresses #984

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

There is an intermittent issue where when you go to a listing edit page and open a unit drawer, if the unit has an ami chart selected that is not first in the list - sometimes the unit drawer will load with the first ami chart selected anyway.

## How Can This Be Tested/Reviewed?

The new seed has multiple ami charts. Create a listing with a unit that has an ami chart selected that is not the first chart that appears in the dropdown. Re-open the edit page and open the unit drawer and ensure the proper ami chart is selected.

Will backport the fix to core.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
