### PR TITLE
fix: partners seeing all listings in list

### DIFF
--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -76,15 +76,16 @@ export class ListingController {
     private readonly listingCsvExportService: ListingCsvExporterService,
   ) {}
 
-  @Get()
+  @Post('list')
   @ApiOperation({
     summary: 'Get a paginated set of listings',
     operationId: 'list',
   })
+  @PermissionAction(permissionActions.read)
   @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
   @UseInterceptors(ClassSerializerInterceptor)
   @ApiOkResponse({ type: PaginatedListingDto })
-  public async getPaginatedSet(@Query() queryParams: ListingsQueryParams) {
+  public async getPaginatedSet(@Body() queryParams: ListingsQueryParams) {
     return await this.listingService.list(queryParams);
   }
 

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -427,9 +427,10 @@ describe('Listing Controller Tests', () => {
       const query = stringify(queryParams as any);
 
       const res = await request(app.getHttpServer())
-        .get(`/listings?${query}`)
+        .post(`/listings/list`)
+        .send(query)
         .set({ passkey: process.env.API_PASS_KEY || '' })
-        .expect(200);
+        .expect(201);
 
       expect(res.body).toEqual({
         items: [],
@@ -478,9 +479,10 @@ describe('Listing Controller Tests', () => {
       let query = stringify(queryParams as any);
 
       let res = await request(app.getHttpServer())
-        .get(`/listings?${query}`)
+        .post(`/listings/list`)
+        .send(query)
         .set({ passkey: process.env.API_PASS_KEY || '' })
-        .expect(200);
+        .expect(201);
 
       expect(res.body.meta).toEqual({
         currentPage: 1,
@@ -509,9 +511,10 @@ describe('Listing Controller Tests', () => {
       query = stringify(queryParams as any);
 
       res = await request(app.getHttpServer())
-        .get(`/listings?${query}`)
+        .post(`/listings/list`)
+        .send(query)
         .set({ passkey: process.env.API_PASS_KEY || '' })
-        .expect(200);
+        .expect(201);
 
       expect(res.body.meta).toEqual({
         currentPage: 2,

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -1069,10 +1069,10 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -1044,10 +1044,10 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -1014,10 +1014,10 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-limited-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-limited-juris-admin-correct-juris.e2e-spec.ts
@@ -987,10 +987,10 @@ describe('Testing Permissioning of endpoints as Limited Jurisdictional Admin in 
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-limited-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-limited-juris-admin-wrong-juris.e2e-spec.ts
@@ -989,10 +989,10 @@ describe('Testing Permissioning of endpoints as Limited Jurisdictional Admin in 
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -931,10 +931,10 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -1009,10 +1009,10 @@ describe('Testing Permissioning of endpoints as partner with wrong listing', () 
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -1002,10 +1002,10 @@ describe('Testing Permissioning of endpoints as public user', () => {
   describe('Testing listing endpoints', () => {
     it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/listings?`)
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(200);
+        .expect(201);
     });
 
     it('should succeed for retrieveListings endpoint', async () => {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -539,6 +539,10 @@ describe('Testing listing service', () => {
             [ListingFilterKeys.bedrooms]: 2,
             $comparison: Compare['>='],
           },
+          {
+            [ListingFilterKeys.jurisdiction]: 'Jurisdiction',
+            $comparison: Compare.IN,
+          },
         ],
       };
 
@@ -574,6 +578,15 @@ describe('Testing listing service', () => {
                         mode: 'insensitive',
                       },
                     },
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
+                  jurisdictionId: {
+                    in: ['jurisdiction'],
                   },
                 },
               ],
@@ -634,6 +647,15 @@ describe('Testing listing service', () => {
                         mode: 'insensitive',
                       },
                     },
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
+                  jurisdictionId: {
+                    in: ['jurisdiction'],
                   },
                 },
               ],

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -155,120 +155,15 @@ export class ListingsService {
    */
   list(
     params: {
-      /**  */
-      page?: number
-      /**  */
-      limit?: number | "all"
-      /**  */
-      $comparison: string
-      /**  */
-      name?: string
-      /**  */
-      status?: ListingsStatusEnum
-      /**  */
-      neighborhood?: string
-      /**  */
-      bedrooms?: number
-      /**  */
-      bathrooms?: number
-      /**  */
-      zipcode?: string
-      /**  */
-      leasingAgents?: string
-      /**  */
-      jurisdiction?: string
-      /**  */
-      isExternal?: boolean
-      /**  */
-      availability?: FilterAvailabilityEnum
-      /**  */
-      city?: string
-      /**  */
-      monthlyRent?: number
-      /**  */
-      counties?: []
-      /**  */
-      ids?: []
-      /**  */
-      view?: ListingViews
-      /**  */
-      orderBy?: ListingOrderByKeys[]
-      /**  */
-      orderDir?: OrderByEnum[]
-      /**  */
-      search?: string
+      /** requestBody */
+      body?: ListingsQueryParams
     } = {} as any,
     options: IRequestOptions = {}
   ): Promise<PaginatedListing> {
     return new Promise((resolve, reject) => {
-      let url = basePath + "/listings"
-
-      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-      configs.params = {
-        page: params["page"],
-        limit: params["limit"],
-        $comparison: params["$comparison"],
-        name: params["name"],
-        status: params["status"],
-        neighborhood: params["neighborhood"],
-        bedrooms: params["bedrooms"],
-        bathrooms: params["bathrooms"],
-        zipcode: params["zipcode"],
-        leasingAgents: params["leasingAgents"],
-        jurisdiction: params["jurisdiction"],
-        isExternal: params["isExternal"],
-        availability: params["availability"],
-        city: params["city"],
-        monthlyRent: params["monthlyRent"],
-        counties: params["counties"],
-        ids: params["ids"],
-        view: params["view"],
-        orderBy: params["orderBy"],
-        orderDir: params["orderDir"],
-        search: params["search"],
-      }
-
-      /** 适配ios13，get请求不允许带body */
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
-   * Create listing
-   */
-  create(
-    params: {
-      /** requestBody */
-      body?: ListingCreate
-    } = {} as any,
-    options: IRequestOptions = {}
-  ): Promise<Listing> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/listings"
+      let url = basePath + "/listings/list"
 
       const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
-
-      let data = params.body
-
-      configs.data = data
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
-   * Delete listing by id
-   */
-  delete(
-    params: {
-      /** requestBody */
-      body?: IdDTO
-    } = {} as any,
-    options: IRequestOptions = {}
-  ): Promise<any> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/listings"
-
-      const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
       let data = params.body
 
@@ -364,6 +259,50 @@ export class ListingsService {
       configs.params = { view: params["view"], combined: params["combined"] }
 
       /** 适配ios13，get请求不允许带body */
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Create listing
+   */
+  create(
+    params: {
+      /** requestBody */
+      body?: ListingCreate
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<Listing> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings"
+
+      const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Delete listing by id
+   */
+  delete(
+    params: {
+      /** requestBody */
+      body?: IdDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings"
+
+      const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
 
       axios(configs, resolve, reject)
     })

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -49,7 +49,7 @@ type UseListingsDataProps = PaginationProps & {
   search?: string
   sort?: ColumnOrder[]
   roles?: UserRole
-  userJurisidctionIds?: string[]
+  userJurisdictionIds?: string[]
 }
 
 export function useSingleListingData(listingId: string) {
@@ -72,7 +72,7 @@ export function useListingsData({
   search = "",
   sort,
   roles,
-  userJurisidctionIds,
+  userJurisdictionIds,
 }: UseListingsDataProps) {
   const params = {
     page,
@@ -101,7 +101,7 @@ export function useListingsData({
   } else if (roles?.isJurisdictionalAdmin || roles?.isLimitedJurisdictionalAdmin) {
     params.filter.push({
       $comparison: EnumListingFilterParamsComparison.IN,
-      jurisdiction: userJurisidctionIds[0],
+      jurisdiction: userJurisdictionIds[0],
     })
   }
 
@@ -113,7 +113,7 @@ export function useListingsData({
 
   const { listingsService } = useContext(AuthContext)
 
-  const fetcher = () => listingsService.list(params)
+  const fetcher = () => listingsService.list({ body: { ...params } })
 
   const paramsString = qs.stringify(params)
 

--- a/sites/partners/src/pages/index.tsx
+++ b/sites/partners/src/pages/index.tsx
@@ -158,7 +158,7 @@ export default function ListingsList() {
     userId: profile?.id,
     sort: tableOptions.sort.sortOptions,
     roles: profile?.userRoles,
-    userJurisidctionIds: profile?.jurisdictions?.map((jurisdiction) => jurisdiction.id),
+    userJurisdictionIds: profile?.jurisdictions?.map((jurisdiction) => jurisdiction.id),
   })
 
   return (


### PR DESCRIPTION
This PR addresses #1014

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The partners list was no longer filtering by jurisdiction. The cause was that for the map, we changed the structure of the combined list to send filter parameters in the body, which updated some of the swagger for the filters, but we didn't update the generic list to send parameters in the body as well.

## How Can This Be Tested/Reviewed?

Create a partner and assign them only to some jurisdictions / listings. Ensure they only see those listings in the list.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
