### PR TITLE
fix: turn off autofill

### DIFF
--- a/sites/public/src/pages/applications/start/autofill.tsx
+++ b/sites/public/src/pages/applications/start/autofill.tsx
@@ -67,21 +67,23 @@ export default () => {
 
   useEffect(() => {
     if (!previousApplication && initialStateLoaded) {
-      if (profile) {
-        void applicationsService
-          .mostRecentlyCreated({
-            userId: profile.id,
-          })
-          .then((res) => {
-            if (res && res.applicant) {
-              setPreviousApplication(new AutofillCleaner(res).clean())
-            } else {
-              onSubmit()
-            }
-          })
-      } else {
-        onSubmit()
-      }
+      // Temporarily turning autofill off
+      // if (profile) {
+      //   void applicationsService
+      //     .mostRecentlyCreated({
+      //       userId: profile.id,
+      //     })
+      //     .then((res) => {
+      //       if (res && res.applicant) {
+      //         setPreviousApplication(new AutofillCleaner(res).clean())
+      //       } else {
+      //         onSubmit()
+      //       }
+      //     })
+      // } else {
+      //   onSubmit()
+      // }
+      onSubmit()
     }
   }, [profile, applicationsService, onSubmit, previousApplication, initialStateLoaded])
 


### PR DESCRIPTION
## Description

This PR temporarily turns autofill off based on [this Slack support issue](https://exygy.slack.com/archives/C02G1S19QA2/p1734480633580029).

## How Can This Be Tested/Reviewed?

Ensure you don't hit the autofill page after already submitting an application.

## Author Checklist:

Partially addresses #1016 

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
