### PR TITLE
fix: use correct ami percentage in csv

### DIFF
--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -845,7 +845,7 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
         label: 'AMI Chart',
       },
       {
-        path: 'unit.amiChart.items.0.percentOfAmi',
+        path: 'unit.amiPercentage',
         label: 'AMI Level',
       },
       {


### PR DESCRIPTION
This PR addresses #1027 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The listing units csv export is displaying the incorrect AMI Chart percentage. It is grabbing the first value from the amiChart instead of getting the percentage off of the unit table

Note:
- There are currently no tests that cover this part of the code and we should add those as a separate issue
- A separate PR will be created in core and HBA

## How Can This Be Tested/Reviewed?

After a clean reseed In the partner site click the "Export to CSV" button on the listings page and compare the values to the listings

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
