### PR TITLE
fix: handle empty other race options (#4513)

### DIFF
--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -543,6 +543,8 @@ export const getHouseholdCsvHeaders = (
  */
 export const convertDemographicRaceToReadable = (type: string): string => {
   const [rootKey, customValue = ''] = type.split(':');
+  //only show colon if user entered a custom value
+  const customValueFormatted = customValue ? `:${customValue}` : '';
   const typeMap = {
     asian: 'Asian',
     'asian-chinese': 'Asian[Chinese]',
@@ -554,39 +556,39 @@ export const convertDemographicRaceToReadable = (type: string): string => {
     'asian-centralAsian': 'Asian[Central Asian]',
     'asian-southAsian': 'Asian[South Asian]',
     'asian-southeastAsian': 'Asian[Southeast Asian]',
-    'asian-otherAsian': `Asian[Other Asian:${customValue}]`,
+    'asian-otherAsian': `Asian[Other Asian${customValueFormatted}]`,
     black: 'Black',
     'black-african': 'Black[African]',
     'black-africanAmerican': 'Black[African American]',
     'black-caribbeanCentralSouthAmericanMexican':
       'Black[Caribbean, Central American, South American or Mexican]',
-    'black-otherBlack': `Black[Other Black:${customValue}]`,
+    'black-otherBlack': `Black[Other Black${customValueFormatted}]`,
     indigenous: 'Indigenous',
     'indigenous-alaskanNative': 'Indigenous[Alaskan Native]',
     'indigenous-nativeAmerican': 'Indigenous[American Indian/Native American]',
     'indigenous-indigenousFromMexicoCaribbeanCentralSouthAmerica':
       'Indigenous[Indigenous from Mexico, the Caribbean, Central America, or South America]',
-    'indigenous-otherIndigenous': `Indigenous[Other Indigenous:${customValue}]`,
+    'indigenous-otherIndigenous': `Indigenous[Other Indigenous${customValueFormatted}]`,
     latino: 'Latino',
     'latino-caribbean': 'Latino[Caribbean]',
     'latino-centralAmerican': 'Latino[Central American]',
     'latino-mexican': 'Latino[Mexican]',
     'latino-southAmerican': 'Latino[South American]',
-    'latino-otherLatino': `Latino[Other Latino:${customValue}]`,
+    'latino-otherLatino': `Latino[Other Latino${customValueFormatted}]`,
     middleEasternOrAfrican: 'Middle Eastern, West African or North African',
     'middleEasternOrAfrican-northAfrican':
       'Middle Eastern, West African or North African[North African]',
     'middleEasternOrAfrican-westAsian':
       'Middle Eastern, West African or North African[West Asian]',
-    'middleEasternOrAfrican-otherMiddleEasternNorthAfrican': `Middle Eastern, West African or North African[Other Middle Eastern or North African:${customValue}]`,
+    'middleEasternOrAfrican-otherMiddleEasternNorthAfrican': `Middle Eastern, West African or North African[Other Middle Eastern or North African${customValueFormatted}]`,
     pacificIslander: 'Pacific Islander',
     'pacificIslander-chamorro': 'Pacific Islander[Chamorro]',
     'pacificIslander-nativeHawaiian': 'Pacific Islander[Native Hawaiian]',
     'pacificIslander-samoan': 'Pacific Islander[Samoan]',
-    'pacificIslander-otherPacificIslander': `Pacific Islander[Other Pacific Islander:${customValue}]`,
+    'pacificIslander-otherPacificIslander': `Pacific Islander[Other Pacific Islander${customValueFormatted}]`,
     white: 'White',
     'white-european': 'White[European]',
-    'white-otherWhite': `White[Other White:${customValue}]`,
+    'white-otherWhite': `White[Other White${customValueFormatted}]`,
   };
   return typeMap[rootKey] ?? rootKey;
 };

--- a/api/test/unit/utilities/application-export-helpers.spec.ts
+++ b/api/test/unit/utilities/application-export-helpers.spec.ts
@@ -277,6 +277,12 @@ describe('Testing application export helpers', () => {
       ).toBe('Pacific Islander[Other Pacific Islander:Fijian]');
     });
 
+    it('tests convertDemographicRaceToReadable with valid type and empty custom value', () => {
+      expect(convertDemographicRaceToReadable('otherMultiracial')).toBe(
+        'Other / Multiracial',
+      );
+    });
+
     it('tests convertDemographicRaceToReadable with type not in typeMap', () => {
       const custom = 'This is a custom value';
       expect(convertDemographicRaceToReadable(custom)).toBe(custom);

--- a/api/test/unit/utilities/application-export-helpers.spec.ts
+++ b/api/test/unit/utilities/application-export-helpers.spec.ts
@@ -278,8 +278,8 @@ describe('Testing application export helpers', () => {
     });
 
     it('tests convertDemographicRaceToReadable with valid type and empty custom value', () => {
-      expect(convertDemographicRaceToReadable('otherMultiracial')).toBe(
-        'Other / Multiracial',
+      expect(convertDemographicRaceToReadable('black-otherBlack')).toBe(
+        'Black[Other Black]',
       );
     });
 

--- a/shared-helpers/__tests__/formKeys.test.ts
+++ b/shared-helpers/__tests__/formKeys.test.ts
@@ -52,4 +52,15 @@ describe("formKeys helpers", () => {
     const expectedArray = ["A", "B", "C", "D: 1,2"]
     expect(fieldGroupObjectToArray(testObj, "root")).toStrictEqual(expectedArray)
   })
+
+  it("fieldGroupObjectToArray with empty additional inputs", () => {
+    const testObj = {
+      ["root-A"]: "A",
+      ["root-B"]: "B",
+      ["root-C"]: "C",
+      ["root-D"]: "",
+    }
+    const expectedArray = ["A", "B", "C", "D"]
+    expect(fieldGroupObjectToArray(testObj, "root")).toStrictEqual(expectedArray)
+  })
 })

--- a/shared-helpers/src/utilities/formKeys.ts
+++ b/shared-helpers/src/utilities/formKeys.ts
@@ -184,10 +184,17 @@ export const fieldGroupObjectToArray = (
   const modifiedArray: string[] = []
   const getValue = (elem: string) => {
     const formSubKey = elem.substring(elem.indexOf("-") + 1)
-    return formSubKey === formObject[elem] ? formSubKey : `${formSubKey}: ${formObject[elem]}`
+    return formSubKey === formObject[elem] || formObject[elem] === ""
+      ? formSubKey
+      : `${formSubKey}: ${formObject[elem]}`
   }
   Object.keys(formObject)
-    .filter((formValue) => formValue.split("-")[0] === rootKey && formObject[formValue])
+    .filter(
+      (formValue) =>
+        formValue.split("-")[0] === rootKey &&
+        //empty string handles selected checkbox fields with empty additionalText
+        (formObject[formValue] || formObject[formValue] === "")
+    )
     .forEach((elem) => {
       if (formObject[elem].isArray) {
         formObject[elem].forEach(() => {


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1009

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue
The ticket also mentions cleaning up the instances where doorway entered a space to get the "other" field to save which this PR doesn't cover.

## Description

This PR includes two different empty string checks in the formKeys file which prevents the selection of other without entering further information from being filtered out or being stored with a colon and space. 

## How Can This Be Tested/Reviewed?

This can be tested by 
a) submitting an online app with a mix of demographic data (including other selections without any text inputted) and going to the partners portal to see that it was stored correctly
b) submit a **paper** app to the same listing with a unique mix of demographic data also including empty other selections and then edit this paper app multiple times to ensure that the selections are saved
c) export the applications to that listing to see that they print in a legible way.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
