### PR TITLE
fix: Jurisdictional Admin - No PII account emails

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -403,6 +403,12 @@ export class ListingService implements OnModuleInit {
         jurisdictions: { some: { id: jurisId } },
       });
     }
+    if (userRoles.includes(UserRoleEnum.limitedJurisdictionAdmin)) {
+      userRolesWhere.push({
+        userRoles: { isLimitedJurisdictionalAdmin: true },
+        jurisdictions: { some: { id: jurisId } },
+      });
+    }
 
     const rawUsers = await this.prisma.userAccounts.findMany({
       select: {
@@ -445,7 +451,10 @@ export class ListingService implements OnModuleInit {
     previousStatus?: ListingsStatusEnum;
     jurisId: string;
   }) {
-    const nonApprovingRoles: UserRoleEnum[] = [UserRoleEnum.partner];
+    const nonApprovingRoles: UserRoleEnum[] = [
+      UserRoleEnum.limitedJurisdictionAdmin,
+      UserRoleEnum.partner,
+    ];
     if (!params.approvingRoles.includes(UserRoleEnum.jurisdictionAdmin))
       nonApprovingRoles.push(UserRoleEnum.jurisdictionAdmin);
     if (

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -404,6 +404,7 @@ export class UserService {
     const isPartnerPortalUser =
       storedUser.userRoles?.isAdmin ||
       storedUser.userRoles?.isJurisdictionalAdmin ||
+      storedUser.userRoles?.isLimitedJurisdictionalAdmin ||
       storedUser.userRoles?.isPartner;
     const isUserSiteMatch = async () => {
       if (isPartnerPortalUser) {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -3195,7 +3195,7 @@ describe('Testing listing service', () => {
       });
 
       expect(service.getUserEmailInfo).toBeCalledWith(
-        ['partner', 'jurisdictionAdmin'],
+        ['limitedJurisdictionAdmin', 'partner', 'jurisdictionAdmin'],
         'id',
         'jurisId',
         false,
@@ -3226,7 +3226,7 @@ describe('Testing listing service', () => {
       });
 
       expect(service.getUserEmailInfo).toBeCalledWith(
-        ['partner', 'jurisdictionAdmin'],
+        ['limitedJurisdictionAdmin', 'partner', 'jurisdictionAdmin'],
         'id',
         'jurisId',
         true,


### PR DESCRIPTION
This PR addresses [#(1035)](https://github.com/metrotranscom/doorway/issues/1035)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Jurisdictional Admin - No PII accounts are not receiving `Forgot password` or `Approved and published` emails.
This is cause the user role was not added to the partner forgot password or the listingApprovalNotify flows.
Corrected by added the user role to both.

## How Can This Be Tested/Reviewed?

- Create a  Jurisdictional Admin - No PII account using an admin account.
- Confirm the account and sign in.
- Create a new listing and submitted it
- Sign out
- Try Forgot Password flow, confirm email is received
- Sign in as an admin again
- Navigate to Pending listing
- Request changes, confirm email is received
- Approve and publish, confirm email is received

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
