### PR TITLE
fix: turn autofill on

### DIFF
--- a/sites/public/src/pages/applications/start/autofill.tsx
+++ b/sites/public/src/pages/applications/start/autofill.tsx
@@ -67,22 +67,21 @@ export default () => {
 
   useEffect(() => {
     if (!previousApplication && initialStateLoaded) {
-      // Temporarily turning autofill off
-      // if (profile) {
-      //   void applicationsService
-      //     .mostRecentlyCreated({
-      //       userId: profile.id,
-      //     })
-      //     .then((res) => {
-      //       if (res && res.applicant) {
-      //         setPreviousApplication(new AutofillCleaner(res).clean())
-      //       } else {
-      //         onSubmit()
-      //       }
-      //     })
-      // } else {
-      //   onSubmit()
-      // }
+      if (profile) {
+        void applicationsService
+          .mostRecentlyCreated({
+            userId: profile.id,
+          })
+          .then((res) => {
+            if (res && res.applicant) {
+              setPreviousApplication(new AutofillCleaner(res).clean())
+            } else {
+              onSubmit()
+            }
+          })
+      } else {
+        onSubmit()
+      }
       onSubmit()
     }
   }, [profile, applicationsService, onSubmit, previousApplication, initialStateLoaded])


### PR DESCRIPTION
This PR addresses #1022

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Turns autofill back on now that the household member relationship script has been run

## How Can This Be Tested/Reviewed?

Ensure you can get to the autofill page!

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes https://github.com/bloom-housing/bloom/issues/4525
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
