### PR TITLE
fix: add null check for csv export

### DIFF
--- a/api/src/services/application-exporter.service.ts
+++ b/api/src/services/application-exporter.service.ts
@@ -465,6 +465,8 @@ export class ApplicationExporterService {
       forLottery,
     );
 
+    console.log('workBook', workbook.worksheets);
+
     if (forLottery) {
       const sortedPreferences = await this.sortPreferencesByOrdinal(
         multiSelectQuestions,
@@ -512,6 +514,7 @@ export class ApplicationExporterService {
       preference,
     );
     spreadsheet.columns = this.buildExportColumns(csvHeaders, preference);
+    console.log(`------${preference?.name}-------`);
 
     const filteredApplications = preference
       ? applications.filter((app) =>
@@ -603,6 +606,9 @@ export class ApplicationExporterService {
           let value = header.path.split('.').reduce((acc, curr) => {
             // return preference/program as value for the format function to accept
             if (multiselectQuestionValue) {
+              if (header.path === `preferences.Work in the city.address`) {
+                console.log('multiselectQuestionValue', acc);
+              }
               return acc;
             }
 
@@ -619,6 +625,9 @@ export class ApplicationExporterService {
                 (preference) => preference.key === curr,
               );
               multiselectQuestionValue = true;
+              if (header.path === `preferences.Work in the city.address`) {
+                console.log('isPreference', preference);
+              }
               return preference;
             } else if (parseProgram) {
               // curr should equal the preference id we're pulling from
@@ -655,13 +664,23 @@ export class ApplicationExporterService {
 
             return acc[curr];
           }, app);
+          if (header.path === `preferences.Work in the city.address`) {
+            console.log('after getting value', value);
+          }
           value = value === undefined ? '' : value === null ? '' : value;
           if (header.format) {
+            if (header.path === `preferences.Work in the city.address`) {
+              console.log('header.format', header.format(value));
+            }
             value = header.format(value);
+          }
+          if (header.path === `preferences.Work in the city.address`) {
+            console.log('value', value);
           }
 
           rowData[`${header.path}`] = value ? value.toString() : '';
         });
+        console.log('row', rowData);
         spreadsheet.addRow(rowData).commit();
       });
     }
@@ -721,7 +740,7 @@ export class ApplicationExporterService {
   }
 
   /**
-   * 
+   *
    * @param questions a collection of questions which can include more than preferences, the rest will be filtered out
    * @param listingId the id of the listing
    * @returns listing preferences sorted in ordinal order

--- a/api/src/services/application-exporter.service.ts
+++ b/api/src/services/application-exporter.service.ts
@@ -465,8 +465,6 @@ export class ApplicationExporterService {
       forLottery,
     );
 
-    console.log('workBook', workbook.worksheets);
-
     if (forLottery) {
       const sortedPreferences = await this.sortPreferencesByOrdinal(
         multiSelectQuestions,
@@ -514,7 +512,6 @@ export class ApplicationExporterService {
       preference,
     );
     spreadsheet.columns = this.buildExportColumns(csvHeaders, preference);
-    console.log(`------${preference?.name}-------`);
 
     const filteredApplications = preference
       ? applications.filter((app) =>
@@ -606,9 +603,6 @@ export class ApplicationExporterService {
           let value = header.path.split('.').reduce((acc, curr) => {
             // return preference/program as value for the format function to accept
             if (multiselectQuestionValue) {
-              if (header.path === `preferences.Work in the city.address`) {
-                console.log('multiselectQuestionValue', acc);
-              }
               return acc;
             }
 
@@ -625,9 +619,6 @@ export class ApplicationExporterService {
                 (preference) => preference.key === curr,
               );
               multiselectQuestionValue = true;
-              if (header.path === `preferences.Work in the city.address`) {
-                console.log('isPreference', preference);
-              }
               return preference;
             } else if (parseProgram) {
               // curr should equal the preference id we're pulling from
@@ -664,23 +655,13 @@ export class ApplicationExporterService {
 
             return acc[curr];
           }, app);
-          if (header.path === `preferences.Work in the city.address`) {
-            console.log('after getting value', value);
-          }
           value = value === undefined ? '' : value === null ? '' : value;
           if (header.format) {
-            if (header.path === `preferences.Work in the city.address`) {
-              console.log('header.format', header.format(value));
-            }
             value = header.format(value);
-          }
-          if (header.path === `preferences.Work in the city.address`) {
-            console.log('value', value);
           }
 
           rowData[`${header.path}`] = value ? value.toString() : '';
         });
-        console.log('row', rowData);
         spreadsheet.addRow(rowData).commit();
       });
     }

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -687,7 +687,7 @@ export class EmailService {
         if (lotteryEvent.startTime) {
           lotteryDateTime =
             lotteryDateTime +
-            `at ${dayjs(lotteryEvent.startTime)
+            ` at ${dayjs(lotteryEvent.startTime)
               .tz(process.env.TIME_ZONE)
               .format('h:mma z')}`;
         }

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -374,20 +374,7 @@ export const constructMultiselectQuestionHeaders = (
             path: `${applicationSection}.${question.text}.address`,
             label: `${labelString} ${question.text} - ${option.text} - Address`,
             format: (val: ApplicationMultiselectQuestion): string => {
-              console.log(
-                `${labelString} ${question.text} - ${option.text} - Address`,
-                val,
-              );
-              const formatted = multiselectQuestionFormat(
-                val,
-                option.text,
-                'address',
-              );
-              console.log(
-                `${applicationSection}.${question.text}.address formatted`,
-                formatted,
-              );
-              return formatted;
+              return multiselectQuestionFormat(val, option.text, 'address');
             },
           });
           if (option.validationMethod) {
@@ -456,9 +443,7 @@ export const multiselectQuestionFormat = (
     return '';
   }
   if (key === 'address') {
-    const address = addressToString(extraData.value as Address);
-    console.log('address', address);
-    return address;
+    return addressToString(extraData.value as Address);
   }
   if (key === 'geocodingVerified') {
     return extraData.value === 'unknown'

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -294,7 +294,9 @@ export const getExportHeaders = (
         path: 'demographics.race',
         label: 'Race',
         format: (val: string[]): string =>
-          val.map((race) => convertDemographicRaceToReadable(race)).join(','),
+          val
+            ?.map((race) => convertDemographicRaceToReadable(race))
+            .join(',') || '',
       },
       {
         path: 'demographics.gender',
@@ -319,10 +321,10 @@ export const getExportHeaders = (
         label: 'How did you Hear?',
         format: (val: string[]): string =>
           val
-            .map((howDidYouHear) =>
+            ?.map((howDidYouHear) =>
               convertDemographicHowDidYouHearToReadable(howDidYouHear),
             )
-            .join(','),
+            .join(',') || '',
       },
     );
   }
@@ -372,7 +374,20 @@ export const constructMultiselectQuestionHeaders = (
             path: `${applicationSection}.${question.text}.address`,
             label: `${labelString} ${question.text} - ${option.text} - Address`,
             format: (val: ApplicationMultiselectQuestion): string => {
-              return multiselectQuestionFormat(val, option.text, 'address');
+              console.log(
+                `${labelString} ${question.text} - ${option.text} - Address`,
+                val,
+              );
+              const formatted = multiselectQuestionFormat(
+                val,
+                option.text,
+                'address',
+              );
+              console.log(
+                `${applicationSection}.${question.text}.address formatted`,
+                formatted,
+              );
+              return formatted;
             },
           });
           if (option.validationMethod) {
@@ -441,7 +456,9 @@ export const multiselectQuestionFormat = (
     return '';
   }
   if (key === 'address') {
-    return addressToString(extraData.value as Address);
+    const address = addressToString(extraData.value as Address);
+    console.log('address', address);
+    return address;
   }
   if (key === 'geocodingVerified') {
     return extraData.value === 'unknown'

--- a/sites/partners/src/pages/application/[id]/edit.tsx
+++ b/sites/partners/src/pages/application/[id]/edit.tsx
@@ -32,7 +32,7 @@ const NewApplication = () => {
           title={
             <>
               <p className="font-sans font-semibold uppercase text-2xl">
-                {t("t.edit")}: {application.applicant.firstName} {application.applicant.lastName}
+                {t("t.edit")}: {application.applicant?.firstName} {application.applicant?.lastName}
               </p>
 
               <p className="font-sans text-base mt-1">


### PR DESCRIPTION
This PR addresses: [This slack thread](https://exygy.slack.com/archives/C01Q4QG5R8Q/p1736794614377889) and [This comment](https://github.com/metrotranscom/doorway/issues/995#issuecomment-2587789072) 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Due to bad data in staging there are a few listings where there is non applicant attached to applications. When a user attempts to export the applications for the listing these are tied to it crashes the backend.

This PR adds a null check to make sure if this data exists it won't break anything

Also there was a missing space in the updated content of the rental opportunity email

## How Can This Be Tested/Reviewed?

Have an application and remove the applicant_id from it in the db. You should then be able to properly export the applications.

This is blocking the release so no tests have been created, but long term we should add tests for this functionality

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
