### PR TITLE
fix: switch to Link component from Seeds on forgot password

### DIFF
--- a/shared-helpers/src/views/sign-in/FormSignIn.module.scss
+++ b/shared-helpers/src/views/sign-in/FormSignIn.module.scss
@@ -1,8 +1,6 @@
 .forgot-password {
   float: right;
   font-size: var(--seeds-font-size-sm);
-  text-decoration-line: underline;
-  color: var(--seeds-color-blue-900);
 }
 
 .sign-in-error-container {
@@ -16,13 +14,6 @@
 .create-account-header {
   font-weight: var(--seeds-font-weight-semibold);
   margin-bottom: var(--seeds-s6);
-}
-
-.forgot-password {
-  float: right;
-  font-size: var(--seeds-font-size-sm);
-  text-decoration-line: underline;
-  color: var(--seeds-color-blue-900);
 }
 
 .sign-in-error {

--- a/shared-helpers/src/views/sign-in/FormSignInDefault.tsx
+++ b/shared-helpers/src/views/sign-in/FormSignInDefault.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from "react"
 import { useRouter } from "next/router"
 import type { UseFormMethods } from "react-hook-form"
-import { Field, Form, NavigationContext, t } from "@bloom-housing/ui-components"
-import { Button } from "@bloom-housing/ui-seeds"
+import { Field, Form, t } from "@bloom-housing/ui-components"
+import { Button, Link } from "@bloom-housing/ui-seeds"
 import { getListingRedirectUrl } from "../../utilities/getListingRedirectUrl"
 import styles from "./FormSignIn.module.scss"
 
@@ -31,7 +31,6 @@ const FormSignInDefault = ({
   const onError = () => {
     window.scrollTo(0, 0)
   }
-  const { LinkComponent } = useContext(NavigationContext)
   const router = useRouter()
   const listingIdRedirect = router.query?.listingId as string
   const forgetPasswordURL = getListingRedirectUrl(listingIdRedirect, "/forgot-password")
@@ -50,9 +49,9 @@ const FormSignInDefault = ({
         dataTestId="sign-in-email-field"
       />
       <aside>
-        <LinkComponent href={forgetPasswordURL} className={styles["forgot-password"]}>
+        <Link href={forgetPasswordURL} className={styles["forgot-password"]}>
           {t("authentication.signIn.forgotPassword")}
-        </LinkComponent>
+        </Link>
       </aside>
       <Field
         className={styles["sign-in-password-input"]}

--- a/shared-helpers/src/views/sign-in/FormSignInPwdless.tsx
+++ b/shared-helpers/src/views/sign-in/FormSignInPwdless.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from "react"
 import { useRouter } from "next/router"
 import type { UseFormMethods } from "react-hook-form"
-import { Field, Form, NavigationContext, t } from "@bloom-housing/ui-components"
-import { Button } from "@bloom-housing/ui-seeds"
+import { Field, Form, t } from "@bloom-housing/ui-components"
+import { Button, Link } from "@bloom-housing/ui-seeds"
 import { getListingRedirectUrl } from "../../utilities/getListingRedirectUrl"
 import styles from "./FormSignIn.module.scss"
 
@@ -35,7 +35,6 @@ const FormSignInPwdless = ({
   const onError = () => {
     window.scrollTo(0, 0)
   }
-  const { LinkComponent } = useContext(NavigationContext)
   const router = useRouter()
   const listingIdRedirect = router.query?.listingId as string
   const forgetPasswordURL = getListingRedirectUrl(listingIdRedirect, "/forgot-password")
@@ -58,9 +57,9 @@ const FormSignInPwdless = ({
       {!useCode && (
         <>
           <aside>
-            <LinkComponent href={forgetPasswordURL} className={styles["forgot-password"]}>
+            <Link href={forgetPasswordURL} className={styles["forgot-password"]}>
               {t("authentication.signIn.forgotPassword")}
-            </LinkComponent>
+            </Link>
           </aside>
           <Field
             className={styles["sign-in-password-input"]}


### PR DESCRIPTION
This PR addresses #965

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR ensures the "Forgot password?" link on the username/password sign in flow retains whichever is the current locale.

## How Can This Be Tested/Reviewed?

Check the link when attempting to sign in.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
