### PR TITLE
release: refactor and extend zip code (#4588)

### DIFF
--- a/api/src/controllers/application.controller.ts
+++ b/api/src/controllers/application.controller.ts
@@ -115,15 +115,19 @@ export class ApplicationController {
     summary: 'Get applications as csv',
     operationId: 'listAsCsv',
   })
-  @Header('Content-Type', 'text/csv')
+  @Header('Content-Type', 'application/zip')
   @UseInterceptors(ExportLogInterceptor)
   async listAsCsv(
     @Request() req: ExpressRequest,
-    @Res({ passthrough: true }) res: Response,
     @Query(new ValidationPipe(defaultValidationPipeOptions))
     queryParams: ApplicationCsvQueryParams,
   ): Promise<StreamableFile> {
-    return await this.applicationExportService.csvExport(req, res, queryParams);
+    return await this.applicationExportService.exporter(
+      req,
+      queryParams,
+      false,
+      false,
+    );
   }
 
   @Get(`spreadsheet`)
@@ -139,11 +143,11 @@ export class ApplicationController {
     @Query(new ValidationPipe(defaultValidationPipeOptions))
     queryParams: ApplicationCsvQueryParams,
   ): Promise<StreamableFile> {
-    return await this.applicationExportService.spreadsheetExport(
+    return await this.applicationExportService.exporter(
       req,
-      res,
       queryParams,
       false,
+      true,
     );
   }
 

--- a/api/src/controllers/lottery.controller.ts
+++ b/api/src/controllers/lottery.controller.ts
@@ -84,10 +84,11 @@ export class LotteryController {
     @Query(new ValidationPipe(defaultValidationPipeOptions))
     queryParams: ApplicationCsvQueryParams,
   ): Promise<StreamableFile> {
-    return await this.applicationExporterService.spreadsheetExport(
+    return await this.applicationExporterService.exporter(
       req,
-      res,
       queryParams,
+      true,
+      true,
     );
   }
 

--- a/api/src/services/application-exporter.service.ts
+++ b/api/src/services/application-exporter.service.ts
@@ -1,9 +1,9 @@
 import { ForbiddenException, Injectable, StreamableFile } from '@nestjs/common';
 import { MultiselectQuestionsApplicationSectionEnum } from '@prisma/client';
-import archiver from 'archiver';
+import dayjs from 'dayjs';
 import Excel, { Column } from 'exceljs';
-import { Request as ExpressRequest, Response } from 'express';
-import fs, { createReadStream } from 'fs';
+import { Request as ExpressRequest } from 'express';
+import fs, { createReadStream, ReadStream } from 'fs';
 import { join } from 'path';
 import { view } from './application.service';
 import { Application } from '../dtos/applications/application.dto';
@@ -21,6 +21,7 @@ import { PrismaService } from './prisma.service';
 import { CsvHeader } from '../types/CsvExportInterface';
 import { getExportHeaders } from '../utilities/application-export-helpers';
 import { mapTo } from '../utilities/mapTo';
+import { zipExport } from '../utilities/zip-export';
 
 view.csv = {
   ...view.details,
@@ -43,31 +44,69 @@ export class ApplicationExporterService {
     private permissionService: PermissionService,
   ) {}
 
-  // csv export functions
   /**
    *
-   * @param queryParams
    * @param req
+   * @param queryParams
+   * @param isLottery a boolean indicating if the export is a lottery
+   * @param isSpreadsheet a boolean indicating if the export is a spreadsheet
    * @returns a promise containing a streamable file
    */
-  async csvExport<QueryParams extends ApplicationCsvQueryParams>(
+  async exporter<QueryParams extends ApplicationCsvQueryParams>(
     req: ExpressRequest,
-    res: Response,
     queryParams: QueryParams,
+    isLottery: boolean,
+    isSpreadsheet: boolean,
   ): Promise<StreamableFile> {
     const user = mapTo(User, req['user']);
     await this.authorizeExport(user, queryParams.id);
 
+    let filename: string;
+    let readStream: ReadStream;
+    let zipFilename: string;
+    const now = new Date();
+    const dateString = dayjs(now).format('YYYY-MM-DD_HH-mm');
+    if (isLottery) {
+      readStream = await this.spreadsheetExport(queryParams, user.id, true);
+      zipFilename = `listing-${queryParams.id}-lottery-${
+        user.id
+      }-${now.getTime()}`;
+      filename = `lottery-${queryParams.id}-${dateString}`;
+    } else {
+      if (isSpreadsheet) {
+        readStream = await this.spreadsheetExport(queryParams, user.id, false);
+      } else {
+        readStream = await this.csvExport(queryParams, user.id);
+      }
+      zipFilename = `listing-${queryParams.id}-applications-${
+        user.id
+      }-${now.getTime()}`;
+      filename = `applications-${queryParams.id}-${dateString}`;
+    }
+
+    return await zipExport(readStream, zipFilename, filename, isSpreadsheet);
+  }
+
+  // csv export functions
+  /**
+   *
+   * @param queryParams
+   * @param user_id
+   * @returns a promise containing a file read stream
+   */
+  async csvExport<QueryParams extends ApplicationCsvQueryParams>(
+    queryParams: QueryParams,
+    user_id: string,
+  ): Promise<ReadStream> {
     const filename = join(
       process.cwd(),
-      `src/temp/listing-${queryParams.id}-applications-${
-        user.id
-      }-${new Date().getTime()}.csv`,
+      `src/temp/listing-${
+        queryParams.id
+      }-applications-${user_id}-${new Date().getTime()}.csv`,
     );
 
     await this.createCsv(filename, queryParams);
-    const file = createReadStream(filename);
-    return new StreamableFile(file);
+    return createReadStream(filename);
   }
 
   /**
@@ -319,36 +358,26 @@ export class ApplicationExporterService {
   /**
    *
    * @param queryParams
-   * @param req
-   * @returns generates the lottery export file via helper function and returns the streamable file
+   * @param user
+   * @param forLottery
+   * @returns generates the applications or lottery spreadsheet export and returns a promise containing a file read stream
    */
   async spreadsheetExport<QueryParams extends ApplicationCsvQueryParams>(
-    req: ExpressRequest,
-    res: Response,
     queryParams: QueryParams,
+    user_id: string,
     forLottery = true,
-  ): Promise<StreamableFile> {
-    const user = mapTo(User, req['user']);
-    await this.authorizeExport(user, queryParams.id);
-
+  ): Promise<ReadStream> {
     const filename = join(
       process.cwd(),
       `src/temp/${forLottery ? 'lottery-' : ''}listing-${
         queryParams.id
-      }-applications-${user.id}-${new Date().getTime()}.xlsx`,
+      }-applications-${user_id}-${new Date().getTime()}.xlsx`,
     );
 
     const workbook = new Excel.stream.xlsx.WorkbookWriter({
       filename,
       useSharedStrings: false,
     });
-
-    const zipFilePath = join(
-      process.cwd(),
-      `src/temp/${forLottery ? 'lottery-' : ''}listing-${
-        queryParams.id
-      }-applications-${user.id}-${new Date().getTime()}.zip`,
-    );
 
     await this.createSpreadsheets(
       workbook,
@@ -359,27 +388,7 @@ export class ApplicationExporterService {
     );
 
     await workbook.commit();
-    const readStream = createReadStream(filename);
-
-    return new Promise((resolve) => {
-      // Create a writable stream to the zip file
-      const output = fs.createWriteStream(zipFilePath);
-      const archive = archiver('zip', {
-        zlib: { level: 9 },
-      });
-      output.on('close', () => {
-        const zipFile = createReadStream(zipFilePath);
-        resolve(new StreamableFile(zipFile));
-      });
-
-      archive.pipe(output);
-      archive.append(readStream, {
-        name: `${forLottery ? 'lottery-' : ''}${
-          queryParams.id
-        }-${new Date().getTime()}.xlsx`,
-      });
-      archive.finalize();
-    });
+    return createReadStream(filename);
   }
 
   /**

--- a/api/src/utilities/zip-export.ts
+++ b/api/src/utilities/zip-export.ts
@@ -1,0 +1,39 @@
+import { StreamableFile } from '@nestjs/common';
+import archiver from 'archiver';
+import fs, { createReadStream, ReadStream } from 'fs';
+import { join } from 'path';
+
+/**
+ *
+ * @param readStream
+ * @param zipFilename
+ * @param filename
+ * @param isSpreadsheet
+ * @returns a promise containing a streamable file
+ */
+export const zipExport = (
+  readStream: ReadStream,
+  zipFilename: string,
+  filename: string,
+  isSpreadsheet: boolean,
+): Promise<StreamableFile> => {
+  const zipFilePath = join(process.cwd(), `src/temp/${zipFilename}.zip`);
+
+  return new Promise((resolve) => {
+    // Create a writable stream to the zip file
+    const output = fs.createWriteStream(zipFilePath);
+    const archive = archiver('zip', {
+      zlib: { level: 9 },
+    });
+    output.on('close', () => {
+      const zipFile = createReadStream(zipFilePath);
+      resolve(new StreamableFile(zipFile));
+    });
+
+    archive.pipe(output);
+    archive.append(readStream, {
+      name: `${filename}.${isSpreadsheet ? 'xlsx' : 'csv'}`,
+    });
+    archive.finalize();
+  });
+};

--- a/api/test/unit/services/application-exporter.service.spec.ts
+++ b/api/test/unit/services/application-exporter.service.spec.ts
@@ -3,7 +3,6 @@ import { PassThrough } from 'stream';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MultiselectQuestionsApplicationSectionEnum } from '@prisma/client';
 import { HttpModule } from '@nestjs/axios';
-import { Request as ExpressRequest, Response } from 'express';
 import { PrismaService } from '../../../src/services/prisma.service';
 import { ApplicationCsvQueryParams } from '../../../src/dtos/applications/application-csv-query-params.dto';
 import { User } from '../../../src/dtos/users/user.dto';
@@ -97,12 +96,11 @@ describe('Testing application export service', () => {
     ]);
 
     const exportResponse = await service.csvExport(
-      { user: requestingUser } as unknown as ExpressRequest,
-      {} as unknown as Response,
       {
         id: randomUUID(),
         includeDemographics: false,
       } as unknown as ApplicationCsvQueryParams,
+      requestingUser.id,
     );
 
     const headerRow =
@@ -111,7 +109,7 @@ describe('Testing application export service', () => {
       '"application 0 firstName","application 0 middleName","application 0 lastName","application 0 birthDay","application 0 birthMonth","application 0 birthYear","application 0 emailaddress","application 0 phoneNumber","application 0 phoneNumberType","additionalPhoneNumber 0","application 0 applicantAddress street","application 0 applicantAddress street2","application 0 applicantAddress city","application 0 applicantAddress state","application 0 applicantAddress zipCode",,,,,,,,,,,,,,,,,,"income 0","per month",,,,"true","true","true","Studio,One Bedroom",,,,,,,,,,,,,,,,,,,';
 
     const mockedStream = new PassThrough();
-    exportResponse.getStream().pipe(mockedStream);
+    exportResponse.pipe(mockedStream);
 
     // In order to make sure the last expect statements are properly hit we need to wrap in a promise and resolve it
     const readable = await new Promise((resolve) => {
@@ -156,12 +154,11 @@ describe('Testing application export service', () => {
       ]);
 
     const exportResponse = await service.csvExport(
-      { user: requestingUser } as unknown as ExpressRequest,
-      {} as unknown as Response,
       {
         id: 'test',
         includeDemographics: true,
       } as unknown as ApplicationCsvQueryParams,
+      requestingUser.id,
     );
 
     const headerRow =
@@ -170,7 +167,7 @@ describe('Testing application export service', () => {
       '"application 0 firstName","application 0 middleName","application 0 lastName","application 0 birthDay","application 0 birthMonth","application 0 birthYear","application 0 emailaddress","application 0 phoneNumber","application 0 phoneNumberType","additionalPhoneNumber 0","application 0 applicantAddress street","application 0 applicantAddress street2","application 0 applicantAddress city","application 0 applicantAddress state","application 0 applicantAddress zipCode",,,,,,,,,,,,,,,,,,"income 0","per month",,,,"true","true","true","Studio,One Bedroom",,,,,,"Indigenous",,,,"Other"';
 
     const mockedStream = new PassThrough();
-    exportResponse.getStream().pipe(mockedStream);
+    exportResponse.pipe(mockedStream);
     const readable = await new Promise((resolve) => {
       mockedStream.on('data', async (d) => {
         const value = Buffer.from(d).toString();
@@ -227,13 +224,12 @@ describe('Testing application export service', () => {
       .spyOn({ unitTypeToReadable }, 'unitTypeToReadable')
       .mockReturnValue('Studio');
     const exportResponse = await service.csvExport(
-      { user: requestingUser } as unknown as ExpressRequest,
-      {} as unknown as Response,
-      { id: randomUUID() } as unknown as ApplicationCsvQueryParams,
+      { listingId: randomUUID() } as unknown as ApplicationCsvQueryParams,
+      requestingUser.id,
     );
 
     const mockedStream = new PassThrough();
-    exportResponse.getStream().pipe(mockedStream);
+    exportResponse.pipe(mockedStream);
 
     // In order to make sure the last expect statements are properly hit we need to wrap in a promise and resolve it
     const readable = await new Promise((resolve) => {
@@ -290,16 +286,15 @@ describe('Testing application export service', () => {
       .spyOn({ unitTypeToReadable }, 'unitTypeToReadable')
       .mockReturnValue('Studio');
     const exportResponse = await service.csvExport(
-      { user: requestingUser } as unknown as ExpressRequest,
-      {} as unknown as Response,
       {
         id: randomUUID(),
         timeZone: 'America/New_York',
       } as unknown as ApplicationCsvQueryParams,
+      requestingUser.id,
     );
 
     const mockedStream = new PassThrough();
-    exportResponse.getStream().pipe(mockedStream);
+    exportResponse.pipe(mockedStream);
 
     // In order to make sure the last expect statements are properly hit we need to wrap in a promise and resolve it
     const readable = await new Promise((resolve) => {
@@ -359,16 +354,15 @@ describe('Testing application export service', () => {
       .spyOn({ unitTypeToReadable }, 'unitTypeToReadable')
       .mockReturnValue('Studio');
     const exportResponse = await service.csvExport(
-      { user: requestingUser } as unknown as ExpressRequest,
-      {} as unknown as Response,
       {
         listingId: randomUUID(),
         timeZone: 'America/New_York',
       } as unknown as ApplicationCsvQueryParams,
+      requestingUser.id,
     );
 
     const mockedStream = new PassThrough();
-    exportResponse.getStream().pipe(mockedStream);
+    exportResponse.pipe(mockedStream);
 
     // In order to make sure the last expect statements are properly hit we need to wrap in a promise and resolve it
     const readable = await new Promise((resolve) => {

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -512,37 +512,11 @@ export const createDateStringFromNow = (format = "YYYY-MM-DD_HH:mm:ss"): string 
   return dayjs(now).format(format)
 }
 
-export const useApplicationsExport = (
+export const useZipExport = (
   listingId: string,
   includeDemographics: boolean,
-  spreadSheetExport = false
-) => {
-  if (spreadSheetExport) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useSpreadsheetExport(listingId, includeDemographics, false)
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { applicationsService } = useContext(AuthContext)
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const res = useCsvExport(
-    () =>
-      applicationsService.listAsCsv({
-        id: listingId,
-        includeDemographics,
-        timeZone: dayjs.tz.guess(),
-      }),
-    `applications-${listingId}-${createDateStringFromNow()}.csv`
-  )
-
-  return { onExport: res.onExport, exportLoading: res.csvExportLoading }
-}
-
-export const useSpreadsheetExport = (
-  listingId: string,
-  includeDemographics: boolean,
-  forLottery: boolean
+  isLottery: boolean,
+  isSpreadsheet = false
 ) => {
   const { applicationsService, lotteryService } = useContext(AuthContext)
   const [exportLoading, setExportLoading] = useState(false)
@@ -551,24 +525,36 @@ export const useSpreadsheetExport = (
   const onExport = useCallback(async () => {
     setExportLoading(true)
     try {
-      const content = forLottery
-        ? await lotteryService.lotteryResults(
-            { id: listingId, includeDemographics },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let content: any
+      if (isLottery) {
+        content = await lotteryService.lotteryResults(
+          { id: listingId, includeDemographics, timeZone: dayjs.tz.guess() },
+          { responseType: "arraybuffer" }
+        )
+      } else {
+        if (isSpreadsheet) {
+          content = await applicationsService.listAsSpreadsheet(
+            { id: listingId, includeDemographics, timeZone: dayjs.tz.guess() },
             { responseType: "arraybuffer" }
           )
-        : await applicationsService.listAsSpreadsheet(
-            { id: listingId, includeDemographics },
+        } else {
+          content = await applicationsService.listAsCsv(
+            { id: listingId, includeDemographics, timeZone: dayjs.tz.guess() },
             { responseType: "arraybuffer" }
           )
+        }
+      }
+
       const blob = new Blob([new Uint8Array(content)], { type: "application/zip" })
       const url = window.URL.createObjectURL(blob)
       const link = document.createElement("a")
       link.href = url
-      const now = new Date()
-      const dateString = dayjs(now).format("YYYY-MM-DD_HH-mm")
       link.setAttribute(
         "download",
-        `${listingId}-${dateString}-${forLottery ? "lottery" : "applications"}.zip`
+        `${isLottery ? "lottery" : "applications"}-${listingId}-${createDateStringFromNow(
+          "YYYY-MM-DD_HH-mm"
+        )}.zip`
       )
       document.body.appendChild(link)
       link.click()

--- a/sites/partners/src/pages/api/adapter/[...backendUrl].ts
+++ b/sites/partners/src/pages/api/adapter/[...backendUrl].ts
@@ -13,7 +13,12 @@ import { logger } from "../../../logger"
 */
 
 // all endpoints that return a zip file
-const zipEndpoints = ["listings/csv", "lottery/getLotteryResults", "applications/spreadsheet"]
+const zipEndpoints = [
+  "listings/csv",
+  "lottery/getLotteryResults",
+  "applications/spreadsheet",
+  "applications/csv",
+]
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const jar = new CookieJar()

--- a/sites/partners/src/pages/listings/[id]/applications/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/index.tsx
@@ -19,7 +19,7 @@ import {
   useSingleListingData,
   useFlaggedApplicationsList,
   useApplicationsData,
-  useApplicationsExport,
+  useZipExport,
 } from "../../../../lib/hooks"
 import { ListingStatusBar } from "../../../../components/listings/ListingStatusBar"
 import Layout from "../../../../layouts"
@@ -50,12 +50,13 @@ const ApplicationsList = () => {
   )
   const includeDemographicsPartner =
     profile?.userRoles?.isPartner && listingJurisdiction?.enablePartnerDemographics
-  const { onExport, exportLoading } = useApplicationsExport(
+  const { onExport, exportLoading } = useZipExport(
     listingId,
     (profile?.userRoles?.isAdmin ||
       profile?.userRoles?.isJurisdictionalAdmin ||
       includeDemographicsPartner) ??
       false,
+    false,
     !!process.env.applicationExportAsSpreadsheet
   )
 

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -28,11 +28,7 @@ import ListingGuard from "../../../components/shared/ListingGuard"
 import { NavigationHeader } from "../../../components/shared/NavigationHeader"
 import { ListingStatusBar } from "../../../components/listings/ListingStatusBar"
 import { logger } from "../../../logger"
-import {
-  useFlaggedApplicationsMeta,
-  useLotteryActivityLog,
-  useSpreadsheetExport,
-} from "../../../lib/hooks"
+import { useFlaggedApplicationsMeta, useLotteryActivityLog, useZipExport } from "../../../lib/hooks"
 dayjs.extend(advancedFormat)
 
 import styles from "../../../../styles/lottery.module.scss"
@@ -65,7 +61,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
   const includeDemographicsPartner =
     profile?.userRoles?.isPartner && listingJurisdiction?.enablePartnerDemographics
 
-  const { onExport, exportLoading } = useSpreadsheetExport(
+  const { onExport, exportLoading } = useZipExport(
     listing?.id,
     (profile?.userRoles?.isAdmin ||
       profile?.userRoles?.isJurisdictionalAdmin ||


### PR DESCRIPTION
This PR addresses [#(4370)](https://github.com/bloom-housing/bloom/issues/4370)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Generalized zip exporting code to allow for applications export to be zipped.

## How Can This Be Tested/Reviewed?

With a listing that has applications, go to the applications tab.
Export the applications.
Confirm export was a zip file.
Open zip file, confirm csv is created.
Open CSV file and check contents.

Edit listing to be a lottery.
Run lottery.
Export lottery.
Confirm export was a zip file.
Open zip file, confirm XSLX is created.
Open XSLX file and check contents.

Bring down the app.
Change `APPLICATION_EXPORT_AS_SPREADSHEET` to TRUE in the sites/partners/.env file.
With a listing that has applications, go to the applications tab.
Export the applications.
Confirm export was a zip file.
Open zip file, confirm XSLX is created.
Open XSLX file and check contents.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
