### PR TITLE
fix: search field without flag

### DIFF
--- a/sites/public/src/components/listings/search/ListingsSearchModalDeprecated.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModalDeprecated.tsx
@@ -25,7 +25,6 @@ const hyphenContainerStyle: React.CSSProperties = {
 const hyphenStyle: React.CSSProperties = {
   fontSize: "2rem",
   position: "relative",
-  bottom: "1px",
   padding: "0.5rem .7rem",
   width: "100%",
 }

--- a/sites/public/src/components/listings/search/ListingsSearchModalDeprecated.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchModalDeprecated.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react"
+import React, { ChangeEvent, useCallback, useEffect, useState } from "react"
 import { ListingSearchParams, parseSearchString } from "../../../lib/listings/search"
 import { t } from "@bloom-housing/ui-components"
 import {
@@ -26,7 +26,7 @@ const hyphenStyle: React.CSSProperties = {
   fontSize: "2rem",
   position: "relative",
   bottom: "1px",
-  padding: ".7rem",
+  padding: "0.5rem .7rem",
   width: "100%",
 }
 
@@ -43,6 +43,10 @@ const sectionTitleTopBorder: React.CSSProperties = {
 const rentStyle: React.CSSProperties = {
   margin: "0px 0px",
   display: "flex",
+}
+
+const propertySearchTitle: React.CSSProperties = {
+  paddingBlock: "var(--seeds-s4)",
 }
 
 const clearButtonStyle: React.CSSProperties = {
@@ -133,6 +137,9 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     document.querySelector("#monthlyRent").value = null
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    document.querySelector("#propertyName").value = null
   }
 
   const onSubmit = () => {
@@ -221,6 +228,12 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
   const minRentFormatted = watch("minRent")
   const currencyFormatting = /,|\.\d{2}/g
 
+  const validateSearchInput = (e: ChangeEvent<HTMLInputElement>) => {
+    // handle semicolon by searching text before since removing could lead to missing exact match
+    const searchableValue = e.target.value.split(";")[0]
+    updateValue("propertyName", searchableValue)
+  }
+
   // workarounds to leverage UI-C's currency formatting without full refactor
   useEffect(() => {
     if (typeof minRentFormatted !== "undefined") {
@@ -292,8 +305,8 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
               getValues={getValues}
               defaultValue={formValues.minRent}
               placeholder={t("t.minPrice")}
-              className="doorway-field pb-6"
-              inputClassName="rent-input"
+              className="doorway-field"
+              inputClassName="typed-input"
               labelClassName="input-label"
             ></Field>
             <div style={hyphenContainerStyle}>
@@ -308,13 +321,29 @@ export function ListingsSearchModal(props: ListingsSearchModalProps) {
               getValues={getValues}
               defaultValue={formValues.monthlyRent}
               placeholder={t("t.maxPrice")}
-              className="doorway-field pb-6"
-              inputClassName="rent-input"
+              className="doorway-field"
+              inputClassName="typed-input"
               labelClassName="input-label"
             ></Field>
           </div>
         </div>
-
+        <div style={inputSectionStyle}>
+          <div style={{ ...sectionTitle, ...propertySearchTitle }}>
+            {t("listings.propertyName")}
+          </div>
+          <Field
+            type="text"
+            id="propertyName"
+            name="propertyName"
+            subNote={t("listings.propertyName.helper")}
+            register={register}
+            onChange={validateSearchInput}
+            defaultValue={formValues.propertyName}
+            className="doorway-field pb-4"
+            inputClassName="typed-input"
+            labelClassName="input-label"
+          />
+        </div>
         <div style={inputSectionStyle}>
           <div style={sectionTitleTopBorder}>{t("t.counties")}</div>
           <FieldGroup


### PR DESCRIPTION
This PR is a follow up from #972 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR adds the search field to the deprecated modal so that whether the new map is enabled or not, the search is functional.

## How Can This Be Tested/Reviewed?

This can be tested by changing the SHOW_ALL_MAP_PINS flag to false and testing the search field in the modal.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
