### PR TITLE
refactor: update sizes of clusters

### DIFF
--- a/sites/public/src/components/listings/MapClusterer.tsx
+++ b/sites/public/src/components/listings/MapClusterer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState, useContext } from "react"
 import { InfoWindow, useMap } from "@vis.gl/react-google-maps"
-import { MarkerClusterer } from "@googlemaps/markerclusterer"
+import { MarkerClusterer, SuperClusterAlgorithm } from "@googlemaps/markerclusterer"
 import { AuthContext } from "@bloom-housing/shared-helpers"
 import { MapMarkerData } from "./ListingsMap"
 import { MapMarker } from "./MapMarker"
@@ -164,8 +164,9 @@ export const MapClusterer = ({
           const clusterMarker = document.createElement("div")
           clusterMarker.className = styles["cluster-icon"]
           clusterMarker.textContent = cluster.count.toString()
-          const DEFAULT_REM = 1.5
-          const calculatedSize = DEFAULT_REM + 0.02 * cluster.count
+          const DEFAULT_REM = 2
+          let calculatedSize = DEFAULT_REM + 0.04 * cluster.count
+          if (calculatedSize > 3.5) calculatedSize = 3.5
           clusterMarker.style.width = `${calculatedSize}rem`
           clusterMarker.style.height = `${calculatedSize}rem`
           clusterMarker.setAttribute("data-testid", "map-cluster")
@@ -179,6 +180,7 @@ export const MapClusterer = ({
           })
         },
       },
+      algorithm: new SuperClusterAlgorithm({ radius: 80 }),
       onClusterClick: (_, cluster, map) => {
         setInfoWindowIndex(null)
         const zoomLevel = getBoundsZoomLevel(cluster.bounds)


### PR DESCRIPTION
This PR addresses #1074

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Following the map release, given the specific data set we have in production, we're less satisfied with the cluster sizes compared to what was in staging. The cluster sizes feel as though they are not big enough compared to a single pin, and there's not enough disparity between clusters of different numbers. Google has a few different algorithms you can use for clustering.

I updated some settings on one of their algorithms and increased slightly both the size and disparity between clusters.

## How Can This Be Tested/Reviewed?

This has been approved w design. 

This PR with updated cluster algorithm and slightly larger size and disparity:
![Screenshot 2025-01-29 at 8 28 38 AM](https://github.com/user-attachments/assets/74e6a1d8-05eb-4be3-ae83-3ec367ee836d)
Production:
![Screenshot 2025-01-29 at 8 28 44 AM](https://github.com/user-attachments/assets/f8b158b6-4402-472f-b863-685f4126aee2)


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
