### PR TITLE
fix: wait for map load

### DIFF
--- a/sites/public/src/components/listings/ListingsCombined.module.scss
+++ b/sites/public/src/components/listings/ListingsCombined.module.scss
@@ -111,6 +111,7 @@
 
   [class*="loading-overlay__spinner"] {
     top: var(--seeds-s20);
+    color: var(--seeds-color-primary);
   }
 }
 

--- a/sites/public/src/components/listings/ListingsCombined.tsx
+++ b/sites/public/src/components/listings/ListingsCombined.tsx
@@ -101,6 +101,7 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
             isFirstBoundsLoad={props.isFirstBoundsLoad}
             setIsFirstBoundsLoad={props.setIsFirstBoundsLoad}
             isDesktop={props.isDesktop}
+            isLoading={props.loading}
           />
         </div>
       </div>
@@ -132,6 +133,7 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
               isFirstBoundsLoad={props.isFirstBoundsLoad}
               setIsFirstBoundsLoad={props.setIsFirstBoundsLoad}
               isDesktop={props.isDesktop}
+              isLoading={props.loading}
             />
           </div>
           <div id="listings-outer-container" className={styles["listings-outer-container"]}>

--- a/sites/public/src/components/listings/ListingsCombined.tsx
+++ b/sites/public/src/components/listings/ListingsCombined.tsx
@@ -67,7 +67,6 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
               onPageChange={props.onPageChange}
               loading={getListLoading() || (props.isFirstBoundsLoad && props.isDesktop)}
               mapMarkers={props.markers}
-              visibleMarkers={props.visibleMarkers}
             />
           </div>
           <div>
@@ -144,7 +143,6 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
                 loading={getListLoading() || (props.isFirstBoundsLoad && props.isDesktop)}
                 onPageChange={props.onPageChange}
                 mapMarkers={props.markers}
-                visibleMarkers={props.visibleMarkers}
               />
               <CustomSiteFooter />
             </div>

--- a/sites/public/src/components/listings/ListingsCombined.tsx
+++ b/sites/public/src/components/listings/ListingsCombined.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { APIProvider } from "@vis.gl/react-google-maps"
 import { useJsApiLoader } from "@react-google-maps/api"
 import { Listing, ListingMapMarker } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import CustomSiteFooter from "../shared/CustomSiteFooter"
@@ -48,56 +47,85 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
 
   const getListingsList = () => {
     return (
-      <APIProvider apiKey={props.googleMapsApiKey}>
-        <div className={styles["listings-combined"]}>
-          <ListingsSearchMetadata
-            loading={props.loading}
-            setModalOpen={props.setModalOpen}
-            filterCount={props.filterCount}
-            searchResults={props.searchResults}
-            setListView={props.setListView}
-            listView={props.listView}
-          />
-          <div
-            className={`${styles["listings-map-list-container"]} ${styles["listings-map-list-container-list-only"]}`}
-          >
-            <div id="listings-list-expanded" className={styles["listings-list-expanded"]}>
-              <ListingsList
-                listings={props.searchResults.listings}
-                currentPage={props.searchResults.currentPage}
-                lastPage={props.searchResults.lastPage}
-                onPageChange={props.onPageChange}
-                loading={getListLoading() || (props.isFirstBoundsLoad && props.isDesktop)}
-                mapMarkers={props.markers}
-              />
-            </div>
-            <div>
-              <CustomSiteFooter />
-            </div>
+      <div className={styles["listings-combined"]}>
+        <ListingsSearchMetadata
+          loading={props.loading}
+          setModalOpen={props.setModalOpen}
+          filterCount={props.filterCount}
+          searchResults={props.searchResults}
+          setListView={props.setListView}
+          listView={props.listView}
+        />
+        <div
+          className={`${styles["listings-map-list-container"]} ${styles["listings-map-list-container-list-only"]}`}
+        >
+          <div id="listings-list-expanded" className={styles["listings-list-expanded"]}>
+            <ListingsList
+              listings={props.searchResults.listings}
+              currentPage={props.searchResults.currentPage}
+              lastPage={props.searchResults.lastPage}
+              onPageChange={props.onPageChange}
+              loading={getListLoading() || (props.isFirstBoundsLoad && props.isDesktop)}
+              mapMarkers={props.markers}
+              visibleMarkers={props.visibleMarkers}
+            />
+          </div>
+          <div>
+            <CustomSiteFooter />
           </div>
         </div>
-      </APIProvider>
+      </div>
     )
   }
 
   const getListingsMap = () => {
     return (
-      <APIProvider apiKey={props.googleMapsApiKey}>
-        <div className={styles["listings-combined"]}>
-          <ListingsSearchMetadata
-            loading={props.loading}
-            setModalOpen={props.setModalOpen}
-            filterCount={props.filterCount}
-            searchResults={props.searchResults}
-            setListView={props.setListView}
-            listView={props.listView}
+      <div className={styles["listings-combined"]}>
+        <ListingsSearchMetadata
+          loading={props.loading}
+          setModalOpen={props.setModalOpen}
+          filterCount={props.filterCount}
+          searchResults={props.searchResults}
+          setListView={props.setListView}
+          listView={props.listView}
+        />
+        <div className={styles["listings-map-expanded"]}>
+          <ListingsMap
+            listings={props.markers}
+            googleMapsApiKey={props.googleMapsApiKey}
+            googleMapsMapId={props.googleMapsMapId}
+            isMapExpanded={true}
+            setVisibleMarkers={props.setVisibleMarkers}
+            visibleMarkers={props.visibleMarkers}
+            setIsLoading={props.setIsLoading}
+            searchFilter={props.searchFilter}
+            isFirstBoundsLoad={props.isFirstBoundsLoad}
+            setIsFirstBoundsLoad={props.setIsFirstBoundsLoad}
+            isDesktop={props.isDesktop}
           />
-          <div className={styles["listings-map-expanded"]}>
+        </div>
+      </div>
+    )
+  }
+
+  const getListingsCombined = () => {
+    return (
+      <div className={styles["listings-combined"]}>
+        <ListingsSearchMetadata
+          loading={props.loading}
+          setModalOpen={props.setModalOpen}
+          filterCount={props.filterCount}
+          searchResults={props.searchResults}
+          setListView={props.setListView}
+          listView={props.listView}
+        />
+        <div className={styles["listings-map-list-container"]}>
+          <div className={styles["listings-map"]}>
             <ListingsMap
               listings={props.markers}
               googleMapsApiKey={props.googleMapsApiKey}
               googleMapsMapId={props.googleMapsMapId}
-              isMapExpanded={true}
+              isMapExpanded={false}
               setVisibleMarkers={props.setVisibleMarkers}
               visibleMarkers={props.visibleMarkers}
               setIsLoading={props.setIsLoading}
@@ -107,55 +135,22 @@ const ListingsCombined = (props: ListingsCombinedProps) => {
               isDesktop={props.isDesktop}
             />
           </div>
-        </div>
-      </APIProvider>
-    )
-  }
-
-  const getListingsCombined = () => {
-    return (
-      <APIProvider apiKey={props.googleMapsApiKey}>
-        <div className={styles["listings-combined"]}>
-          <ListingsSearchMetadata
-            loading={props.loading}
-            setModalOpen={props.setModalOpen}
-            filterCount={props.filterCount}
-            searchResults={props.searchResults}
-            setListView={props.setListView}
-            listView={props.listView}
-          />
-          <div className={styles["listings-map-list-container"]}>
-            <div className={styles["listings-map"]}>
-              <ListingsMap
-                listings={props.markers}
-                googleMapsApiKey={props.googleMapsApiKey}
-                googleMapsMapId={props.googleMapsMapId}
-                isMapExpanded={false}
-                setVisibleMarkers={props.setVisibleMarkers}
+          <div id="listings-outer-container" className={styles["listings-outer-container"]}>
+            <div id="listings-list" className={styles["listings-list"]}>
+              <ListingsList
+                listings={props.searchResults.listings}
+                currentPage={props.searchResults.currentPage}
+                lastPage={props.searchResults.lastPage}
+                loading={getListLoading() || (props.isFirstBoundsLoad && props.isDesktop)}
+                onPageChange={props.onPageChange}
+                mapMarkers={props.markers}
                 visibleMarkers={props.visibleMarkers}
-                setIsLoading={props.setIsLoading}
-                searchFilter={props.searchFilter}
-                isFirstBoundsLoad={props.isFirstBoundsLoad}
-                setIsFirstBoundsLoad={props.setIsFirstBoundsLoad}
-                isDesktop={props.isDesktop}
               />
-            </div>
-            <div id="listings-outer-container" className={styles["listings-outer-container"]}>
-              <div id="listings-list" className={styles["listings-list"]}>
-                <ListingsList
-                  listings={props.searchResults.listings}
-                  currentPage={props.searchResults.currentPage}
-                  lastPage={props.searchResults.lastPage}
-                  loading={getListLoading() || (props.isFirstBoundsLoad && props.isDesktop)}
-                  onPageChange={props.onPageChange}
-                  mapMarkers={props.markers}
-                />
-                <CustomSiteFooter />
-              </div>
+              <CustomSiteFooter />
             </div>
           </div>
         </div>
-      </APIProvider>
+      </div>
     )
   }
 

--- a/sites/public/src/components/listings/ListingsList.tsx
+++ b/sites/public/src/components/listings/ListingsList.tsx
@@ -6,6 +6,7 @@ import { LoadingOverlay, t, InfoCard, LinkButton } from "@bloom-housing/ui-compo
 import { getListings } from "../../lib/helpers"
 import { Pagination } from "./Pagination"
 import styles from "./ListingsCombined.module.scss"
+import { MapMarkerData } from "./ListingsMap"
 
 type ListingsListProps = {
   listings: Listing[]
@@ -14,6 +15,7 @@ type ListingsListProps = {
   onPageChange: (page: number) => void
   loading: boolean
   mapMarkers: ListingMapMarker[] | null
+  visibleMarkers: MapMarkerData[]
 }
 
 const ListingsList = (props: ListingsListProps) => {
@@ -23,12 +25,18 @@ const ListingsList = (props: ListingsListProps) => {
       <Heading className={"sr-only"} priority={2}>
         {t("t.listingsList")}
       </Heading>
-      {props.listings.length > 0 || props.loading ? (
+      {props.listings.length > 0 || props.loading || props.visibleMarkers.length > 0 ? (
         <div className={styles["listings-list-container"]}>{getListings(props.listings)}</div>
       ) : (
         <ZeroListingsItem
-          title={moreMarkersOnMap ? t("t.noVisibleListings") : t("t.noMatchingListings")}
-          description={moreMarkersOnMap ? t("t.tryChangingArea") : t("t.tryRemovingFilters")}
+          title={
+            moreMarkersOnMap && !props.loading
+              ? t("t.noVisibleListings")
+              : t("t.noMatchingListings")
+          }
+          description={
+            moreMarkersOnMap && !props.loading ? t("t.tryChangingArea") : t("t.tryRemovingFilters")
+          }
         />
       )}
     </div>

--- a/sites/public/src/components/listings/ListingsList.tsx
+++ b/sites/public/src/components/listings/ListingsList.tsx
@@ -6,7 +6,6 @@ import { LoadingOverlay, t, InfoCard, LinkButton } from "@bloom-housing/ui-compo
 import { getListings } from "../../lib/helpers"
 import { Pagination } from "./Pagination"
 import styles from "./ListingsCombined.module.scss"
-import { MapMarkerData } from "./ListingsMap"
 
 type ListingsListProps = {
   listings: Listing[]
@@ -15,7 +14,6 @@ type ListingsListProps = {
   onPageChange: (page: number) => void
   loading: boolean
   mapMarkers: ListingMapMarker[] | null
-  visibleMarkers: MapMarkerData[]
 }
 
 const ListingsList = (props: ListingsListProps) => {
@@ -25,18 +23,12 @@ const ListingsList = (props: ListingsListProps) => {
       <Heading className={"sr-only"} priority={2}>
         {t("t.listingsList")}
       </Heading>
-      {props.listings.length > 0 || props.loading || props.visibleMarkers.length > 0 ? (
+      {props.listings.length > 0 || props.loading ? (
         <div className={styles["listings-list-container"]}>{getListings(props.listings)}</div>
       ) : (
         <ZeroListingsItem
-          title={
-            moreMarkersOnMap && !props.loading
-              ? t("t.noVisibleListings")
-              : t("t.noMatchingListings")
-          }
-          description={
-            moreMarkersOnMap && !props.loading ? t("t.tryChangingArea") : t("t.tryRemovingFilters")
-          }
+          title={moreMarkersOnMap ? t("t.noVisibleListings") : t("t.noMatchingListings")}
+          description={moreMarkersOnMap ? t("t.tryChangingArea") : t("t.tryRemovingFilters")}
         />
       )}
     </div>

--- a/sites/public/src/components/listings/ListingsMap.tsx
+++ b/sites/public/src/components/listings/ListingsMap.tsx
@@ -28,6 +28,7 @@ type ListingsMapProps = {
   isFirstBoundsLoad: boolean
   setIsFirstBoundsLoad: React.Dispatch<React.SetStateAction<boolean>>
   isDesktop: boolean
+  isLoading: boolean
 }
 
 export type MapMarkerData = {
@@ -82,7 +83,11 @@ const ListingsMap = (props: ListingsMapProps) => {
         clickableIcons={false}
       >
         <MapControl />
-        <MapRecenter mapMarkers={props.listings} visibleMapMarkers={props.visibleMarkers?.length} />
+        <MapRecenter
+          mapMarkers={props.listings}
+          visibleMapMarkers={props.visibleMarkers?.length}
+          isLoading={props.isLoading}
+        />
         <MapClusterer
           mapMarkers={markers}
           infoWindowIndex={infoWindowIndex}

--- a/sites/public/src/components/listings/MapClusterer.tsx
+++ b/sites/public/src/components/listings/MapClusterer.tsx
@@ -210,7 +210,7 @@ export const MapClusterer = ({
     fitBounds(map, mapMarkers, false, setIsFirstBoundsLoad)
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clusterer, markers, currentMapMarkers])
+  }, [clusterer, markers, currentMapMarkers, map])
 
   // Keeps track of the markers on the map, passed to each marker
   const setMarkerRef = useCallback(

--- a/sites/public/src/components/listings/MapClusterer.tsx
+++ b/sites/public/src/components/listings/MapClusterer.tsx
@@ -138,7 +138,7 @@ export const MapClusterer = ({
       resetVisibleMarkers()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapMarkers])
+  }, [mapMarkers, map])
 
   const fetchInfoWindow = async (listingId: string) => {
     try {

--- a/sites/public/src/components/listings/MapClusterer.tsx
+++ b/sites/public/src/components/listings/MapClusterer.tsx
@@ -25,7 +25,8 @@ export type ListingsMapMarkersProps = {
 export const fitBounds = (
   map: google.maps.Map,
   mapMarkers: MapMarkerData[],
-  continueIfEmpty?: boolean
+  continueIfEmpty?: boolean,
+  setIsFirstBoundsLoad?: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   const bounds = new window.google.maps.LatLngBounds()
 
@@ -49,6 +50,9 @@ export const fitBounds = (
       const zoomLevel = getBoundsZoomLevel(bounds)
       map.setZoom(zoomLevel - 7)
     }
+  }
+  if (setIsFirstBoundsLoad) {
+    setIsFirstBoundsLoad(false)
   }
 }
 
@@ -203,11 +207,7 @@ export const MapClusterer = ({
     // Only automatically size the map to fit all pins on first map load
     if (isFirstBoundsLoad === false) return
 
-    fitBounds(map, mapMarkers)
-
-    setTimeout(() => {
-      setIsFirstBoundsLoad(false)
-    }, 1000)
+    fitBounds(map, mapMarkers, false, setIsFirstBoundsLoad)
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clusterer, markers, currentMapMarkers])

--- a/sites/public/src/components/shared/MapRecenter.tsx
+++ b/sites/public/src/components/shared/MapRecenter.tsx
@@ -38,6 +38,7 @@ const MapRecenter = (props: MapRecenterProps) => {
           )
         }}
         size={"sm"}
+        variant={"primary-outlined"}
       >
         {t("t.recenterMap")}
       </Button>

--- a/sites/public/src/components/shared/MapRecenter.tsx
+++ b/sites/public/src/components/shared/MapRecenter.tsx
@@ -9,6 +9,7 @@ import styles from "./MapRecenter.module.scss"
 type MapRecenterProps = {
   visibleMapMarkers: number
   mapMarkers: ListingMapMarker[] | null
+  isLoading: boolean
 }
 
 const MapRecenter = (props: MapRecenterProps) => {
@@ -17,7 +18,8 @@ const MapRecenter = (props: MapRecenterProps) => {
   if (
     !map ||
     props.visibleMapMarkers === undefined ||
-    props.visibleMapMarkers === props.mapMarkers.length
+    props.visibleMapMarkers === props.mapMarkers.length ||
+    props.isLoading
   )
     return null
 

--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Head from "next/head"
+import { APIProvider } from "@vis.gl/react-google-maps"
 import { Heading } from "@bloom-housing/ui-seeds"
 import { t } from "@bloom-housing/ui-components"
 import { MetaTags } from "../components/shared/MetaTags"
@@ -44,14 +45,16 @@ export default function ListingsPage(props: ListingsProps) {
         {t("nav.listings")}
       </Heading>
       {props.showAllMapPins === "TRUE" ? (
-        <ListingsSearchCombined
-          googleMapsApiKey={props.googleMapsApiKey}
-          googleMapsMapId={props.googleMapsMapId}
-          searchString={searchString}
-          bedrooms={props.bedrooms}
-          bathrooms={props.bathrooms}
-          counties={locations}
-        />
+        <APIProvider apiKey={props.googleMapsApiKey}>
+          <ListingsSearchCombined
+            googleMapsApiKey={props.googleMapsApiKey}
+            googleMapsMapId={props.googleMapsMapId}
+            searchString={searchString}
+            bedrooms={props.bedrooms}
+            bathrooms={props.bathrooms}
+            counties={locations}
+          />
+        </APIProvider>
       ) : (
         <ListingsSearchCombinedDeprecated
           googleMapsApiKey={props.googleMapsApiKey}


### PR DESCRIPTION
This PR addresses #1078

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

It is challenging to reproduce and I cannot do so consistently, but on a throttled connection, the listing list will sometimes flash an empty state before the full list has had a chance to actually do its first load.

This PR ensures that on first page load, the loading state persists through a very slow connection until the list has loaded for the first time.

It also tries to protect against a scenario where the google maps API itself loads very slowly, and we potentially are fetching markers and listings before the map has rendered. I don't think this is actually happening for folks though. On the slowest possible throttling w the cache disabled, I still cannot reproduce it.

## How Can This Be Tested/Reviewed?

On both desktop and mobile, throttle your connection in the network tab. Load the page, pan the map, and add/remove filters. Ensure the listing list does not flash an empty state.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
