### PR TITLE
fix: updating reset translations from bash

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -2054,6 +2054,8 @@ export class ScriptRunnerService {
             'Para confirmar el cambio de su dirección de correo electrónico, haga clic en el enlace a continuación',
         },
         footer: {
+          line1:
+            'Doorway Housing Portal es un programa de Bay Area Housing Finance Authority (BAHFA)',
           footer:
             'Autoridad de Finanzas de Vivienda del Área de la Bahía (BAHFA)',
           thankYou: 'Gracias',
@@ -2128,8 +2130,7 @@ export class ScriptRunnerService {
       'vi',
       {
         changeEmail: {
-          message:
-            'An email address change has been requested for your account.',
+          message: 'Đã có yêu cầu thay đổi địa chỉ email cho tài khoản của bạn',
           changeMyEmail: 'Xác nhận thay đổi email',
           onChangeEmailMessage:
             'Để xác nhận thay đổi địa chỉ email của bạn, vui lòng nhấp vào liên kết bên dưới',
@@ -2195,6 +2196,8 @@ export class ScriptRunnerService {
         },
         footer: {
           footer: 'Cơ quan Tài chính Nhà ở Khu Vực Vịnh (BAHFA)',
+          line1:
+            'Doorway Housing Portal là một chương trình của Bay Area Housing Finance Authority (BAHFA)',
           thankYou: 'Cảm ơn bạn',
         },
         forgotPassword: {
@@ -2314,6 +2317,8 @@ export class ScriptRunnerService {
         },
         footer: {
           footer: '海灣區住房金融管理局（BAHFA）',
+          line1:
+            'Doorway Housing Portal 是 Bay Area Housing Finance Authority（BAHFA）的一個項目',
           thankYou: '謝謝',
         },
         forgotPassword: {
@@ -2442,7 +2447,7 @@ export class ScriptRunnerService {
         },
         footer: {
           line1:
-            'Doorway Housing Portal is a program of the Bay Area Housing Finance Authority (BAHFA)',
+            'Ang Doorway Housing Portal ay isang programa ng Bay Area Housing Finance Authority (BAHFA)',
           line2: '',
           footer: 'Bay Area Housing Finance Authority (BAHFA)',
           thankYou: 'Salamat',

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -2116,7 +2116,7 @@ export class ScriptRunnerService {
         },
         t: {
           hello: 'Hola',
-          seeListing: 'See Listing',
+          seeListing: 'Ver listado',
           editListing: 'Edit Listing',
           viewListing: 'View Listing',
           reviewListing: 'Review Listing',
@@ -2255,6 +2255,7 @@ export class ScriptRunnerService {
         },
         t: {
           hello: 'Chào',
+          seeListing: 'Xem danh sách',
         },
       },
       true,
@@ -2371,6 +2372,7 @@ export class ScriptRunnerService {
         },
         t: {
           hello: '你好',
+          seeListing: '查看房源',
         },
       },
       true,
@@ -2508,6 +2510,7 @@ export class ScriptRunnerService {
         },
         t: {
           hello: 'Kamusta',
+          seeListing: 'Tingnan ang listahan',
         },
       },
       true,


### PR DESCRIPTION
- [x] Addresses the issue in full

## Description
This updates the translation reset script with the following:
- adds translations to the footer of the application confirmation and lottery results emails
- updates a missing translation for Vietnamese for the update email address email

## How Can This Be Tested/Reviewed?
- apply for a listing with an account created in the various languages. Make sure you create an account in each language
- attempt to update the email on the Vietnamese language account and you should get an email in Vietnamese properly translated  

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
