### PR TITLE
fix: loading state

### DIFF
--- a/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
@@ -146,6 +146,13 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
         setIsLoading(false)
         setIsFirstBoundsLoad(false)
       }
+
+      // If the filter change resulted in the same markers, set loading to false
+      const oldMarkers = JSON.stringify(searchResults.markers?.sort((a, b) => a.lat - b.lat))
+      const updatedMarkers = JSON.stringify(newMarkers?.sort((a, b) => a.lat - b.lat))
+      if (oldMarkers === updatedMarkers) {
+        setIsLoading(false)
+      }
     }
 
     setSearchResults({
@@ -248,6 +255,9 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
   }, [isFirstBoundsLoad])
 
   const onFormSubmit = (params: ListingSearchParams) => {
+    // If the search filter did not change, don't re-search listings
+    if (JSON.stringify(params) === JSON.stringify(searchFilter)) return
+    setIsLoading(true)
     setSearchFilter(params)
   }
 

--- a/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
@@ -248,7 +248,6 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
   }, [isFirstBoundsLoad])
 
   const onFormSubmit = (params: ListingSearchParams) => {
-    setIsLoading(true)
     setSearchFilter(params)
   }
 


### PR DESCRIPTION
This PR addresses [slack thread](https://exygy.slack.com/archives/C02G1S19QA2/p1739471658290209)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When updating the filters on the map view the spinner for the list of listings immediately pops up after submission. However, in the case where the results returned are the same we do not do a backend api call to get the list and the spinner never gets turned off.

This can be seen in a couple of scenarios:

Do two different filter searches and the same results are returned
e.g search "elmwoo" the first time and then "elmwood" the second.
Do the exact same search
Open up the filter click "Show matching listings" without changing any filters

## How Can This Be Tested/Reviewed?

Seed the backend with plenty of listings (you can use yarn db:setup:staging-large)

These are three of the scenarios that should be tested:

1. different filters that return the same
- Load the map page
- Open the filter modal and enter a filter that returns at least one listing
- Submit filter
- Open the filter modal and enter a different filter that returns the same set
- Submit filter
2. The exact same filter
- Load the map page
- Open the filter modal and enter a filter that returns at least one listing
- Submit filter
- Open the filter modal and don't change any of the filters
- Submit filter
3. Different filters that return different sets
- Load the map page
- Open the filter modal and enter a filter that returns at least one listing
- Submit filter
- Open the filter modal enter a filter that returns a different set of listings
- Submit filter


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
