### PR TITLE
fix: autofill bug

### DIFF
--- a/sites/public/src/pages/applications/start/autofill.tsx
+++ b/sites/public/src/pages/applications/start/autofill.tsx
@@ -82,7 +82,6 @@ export default () => {
       } else {
         onSubmit()
       }
-      onSubmit()
     }
   }, [profile, applicationsService, onSubmit, previousApplication, initialStateLoaded])
 


### PR DESCRIPTION
This PR addresses #1090

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Autofill is currently "off", but it should be on!

## How Can This Be Tested/Reviewed?

I'm not sure how the final onSubmit call got in there bc it's not there in core, but it prevents autofill from happening & returns too early.

Ensure locally if you submit an application while logged in that upon starting a second application you are prompted with autofill.

We should pull over the new [autofill Cypress test](https://github.com/bloom-housing/bloom/pull/4607) - it would have caught this.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
