### PR TITLE
fix: pagination fix for desktop view

### DIFF
--- a/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
+++ b/sites/public/src/components/listings/search/ListingsSearchCombined.tsx
@@ -116,13 +116,16 @@ function ListingsSearchCombined(props: ListingsSearchCombinedProps) {
     // Wait until markers have been fetched for the first time before searching listings for the first time
     // Don't search the listings if the filter is changing - first search the markers, which will update the listings
     if (
+      // Mobile view doesn't rely on the map
+      !isDesktop ||
+      // A page change should still fetch listings as the map markers won't change
+      page !== searchResults.currentPage ||
       (!isFirstBoundsLoad &&
         !!map &&
         oldMarkersSearch !== newMarkersSearch &&
         !changingFilter &&
         (isDesktop || listView) &&
-        !(visibleMarkers?.length === 0 && changingFilter)) ||
-      !isDesktop
+        !(visibleMarkers?.length === 0 && changingFilter))
     ) {
       setIsLoading(true)
       const result = await searchListings(


### PR DESCRIPTION
This PR addresses [slack thread](https://exygy.slack.com/archives/C02G1S19QA2/p1739982449113979)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When changing pages in desktop view of the listing search page the listing data is not getting updated. This is because since the map markers don't change when changing pages we are not doing the call to get the new listings

## How Can This Be Tested/Reviewed?

All functionality on the listing search page should be tested.

Primary test:
1. Seed enough listings to have more than one page.
2. Load the [listing search page](http://localhost:3000/listings) and make sure map and listings loads correctly
3. Click into a different page by using the pagination underneath the listings
4. Verify new listings have loaded but map stays the same

Other things that should be tested
1. Moving map and zooming still properly filters the listings. Also verify pagination works with this.
2. Use the filters to change the expected listings. Also verify pagination works with this.
3. Verify that forward and back pagination works
4. Clear all filters still works

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
