### PR TITLE
fix: oval icons

### DIFF
--- a/sites/public/src/components/listings/ListingsCombined.module.scss
+++ b/sites/public/src/components/listings/ListingsCombined.module.scss
@@ -130,8 +130,6 @@
     width: var(--seeds-s8);
     height: var(--seeds-s8);
   }
-  padding: 0rem var(--seeds-s1_5);
-  margin-right: var(--seeds-s1_5);
   border-radius: 50%;
   border: 1px solid white;
   box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.2);

--- a/sites/public/src/components/listings/MapClusterer.tsx
+++ b/sites/public/src/components/listings/MapClusterer.tsx
@@ -169,7 +169,7 @@ export const MapClusterer = ({
           clusterMarker.className = styles["cluster-icon"]
           clusterMarker.textContent = cluster.count.toString()
           const DEFAULT_REM = 2
-          let calculatedSize = DEFAULT_REM + 0.04 * cluster.count
+          let calculatedSize = DEFAULT_REM + 0.03 * cluster.count
           if (calculatedSize > 3.5) calculatedSize = 3.5
           clusterMarker.style.width = `${calculatedSize}rem`
           clusterMarker.style.height = `${calculatedSize}rem`
@@ -184,7 +184,7 @@ export const MapClusterer = ({
           })
         },
       },
-      algorithm: new SuperClusterAlgorithm({ radius: 80 }),
+      algorithm: new SuperClusterAlgorithm({ radius: 110 }),
       onClusterClick: (_, cluster, map) => {
         setInfoWindowIndex(null)
         const zoomLevel = getBoundsZoomLevel(cluster.bounds)


### PR DESCRIPTION
## Description

Addresses the issue noticed in bash [here](https://exygy.slack.com/archives/C01Q4QG5R8Q/p1741025321036199) that the cluster icons are ovals.

## How Can This Be Tested/Reviewed?

Run locally with `yarn setup:large` to get more clusters, and ensure the clusters are circles.

I can walk this back tons of commits and it still happens, so I don't think it was a code change - I wonder if it was an update to the package.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
