### PR TITLE
feat: creating new listing image asset transfer script

### DIFF
--- a/api/prisma/migrations/24_temp_listing_map/migration.sql
+++ b/api/prisma/migrations/24_temp_listing_map/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "listing_transfer_map" (
+    "listing_id" UUID NOT NULL,
+    "old_id" UUID NOT NULL,
+
+    CONSTRAINT "listing_transfer_map_pkey" PRIMARY KEY ("listing_id")
+);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1023,6 +1023,13 @@ model ScriptRuns {
   @@map("script_runs")
 }
 
+model ListingTransferMap {
+  listingId String @id() @map("listing_id") @db.Uuid
+  oldId     String @map("old_id") @db.Uuid
+
+  @@map("listing_transfer_map")
+}
+
 view ApplicationFlaggedSetPossibilities {
   key           String
   listingId     String @map("listing_id") @db.Uuid

--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -19,6 +19,7 @@ import { AmiChartImportDTO } from '../dtos/script-runner/ami-chart-import.dto';
 import { AmiChartUpdateImportDTO } from '../dtos/script-runner/ami-chart-update-import.dto';
 import { CommunityTypeDTO } from '../dtos/script-runner/community-type.dto';
 import { ApiKeyGuard } from '../guards/api-key.guard';
+import { AssetTransferDTO } from '../dtos/script-runner/asset-transfer.dto';
 
 @Controller('scriptRunner')
 @ApiTags('scriptRunner')
@@ -66,6 +67,23 @@ export class ScirptRunnerController {
     @Request() req: ExpressRequest,
   ): Promise<SuccessDTO> {
     return await this.scriptRunnerService.transferJurisdictionListingData(
+      req,
+      dataTransferDTO,
+    );
+  }
+
+  @Put('transferListingAssetData')
+  @ApiOperation({
+    summary:
+      'A script that pulls listing asset data from one source into the current db',
+    operationId: 'transferListingAssetData',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async transferListingAssetData(
+    @Body() dataTransferDTO: AssetTransferDTO,
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.transferListingAssetData(
       req,
       dataTransferDTO,
     );

--- a/api/src/dtos/script-runner/asset-transfer.dto.ts
+++ b/api/src/dtos/script-runner/asset-transfer.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsDefined, IsString } from 'class-validator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+import { DataTransferDTO } from './data-transfer.dto';
+
+export class AssetTransferDTO extends DataTransferDTO {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  cloudinaryName: string;
+}

--- a/api/src/modules/script-runner.module.ts
+++ b/api/src/modules/script-runner.module.ts
@@ -5,9 +5,16 @@ import { AmiChartModule } from './ami-chart.module';
 import { FeatureFlagModule } from './feature-flag.module';
 import { PermissionModule } from './permission.module';
 import { PrismaModule } from './prisma.module';
+import { AssetModule } from './asset.module';
 
 @Module({
-  imports: [AmiChartModule, FeatureFlagModule, PermissionModule, PrismaModule],
+  imports: [
+    AmiChartModule,
+    FeatureFlagModule,
+    PermissionModule,
+    PrismaModule,
+    AssetModule,
+  ],
   controllers: [ScirptRunnerController],
   providers: [ScriptRunnerService],
   exports: [ScriptRunnerService],

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -695,7 +695,7 @@ export class ScriptRunnerService {
         FROM listing_images li
             JOIN assets a ON a.id = li.image_id
         WHERE li.listing_id = ${listingTransferMap[i].oldId} :: UUID
-          AND a.file_id IS NOT NULL`;
+          AND a.file_id IS NOT NULL AND a.file_id != ''`;
       console.log(
         `moving ${oldAssetInfo.length || 0} assets for listing: ${
           listingTransferMap[i].oldId

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -757,7 +757,9 @@ export class ScriptRunnerService {
 
     // script runner standard spin down
     await this.markScriptAsComplete(
-      `data transfer assets ${dataTransferDTO.jurisdiction}`,
+      `data transfer assets ${dataTransferDTO.jurisdiction} page: ${
+        dataTransferDTO.page || 1
+      }`,
       requestingUser,
     );
     return { success: true };

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -694,7 +694,8 @@ export class ScriptRunnerService {
             label
         FROM listing_images li
             JOIN assets a ON a.id = li.image_id
-        WHERE li.listing_id = ${listingTransferMap[i].oldId} :: UUID`;
+        WHERE li.listing_id = ${listingTransferMap[i].oldId} :: UUID
+          AND a.file_id IS NOT NULL`;
       console.log(
         `moving ${oldAssetInfo.length || 0} assets for listing: ${
           listingTransferMap[i].oldId

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -21,6 +21,9 @@ import { AmiChartUpdate } from '../dtos/ami-charts/ami-chart-update.dto';
 import { AmiChartUpdateImportDTO } from '../dtos/script-runner/ami-chart-update-import.dto';
 import { HouseholdMemberRelationship } from '../../src/enums/applications/household-member-relationship-enum';
 import { calculateSkip, calculateTake } from '../utilities/pagination-helpers';
+import axios from 'axios';
+import { AssetTransferDTO } from '../dtos/script-runner/asset-transfer.dto';
+import { AssetService } from './asset.service';
 
 /**
   this is the service for running scripts
@@ -31,6 +34,7 @@ export class ScriptRunnerService {
   constructor(
     private amiChartService: AmiChartService,
     private featureFlagService: FeatureFlagService,
+    private assetService: AssetService,
     private prisma: PrismaService,
   ) {}
 
@@ -438,6 +442,13 @@ export class ScriptRunnerService {
           },
         });
 
+        await this.prisma.listingTransferMap.create({
+          data: {
+            listingId: createdListing.id,
+            oldId: listing['id'],
+          },
+        });
+
         // upload units
         const units: any[] = await client.$queryRawUnsafe(
           `SELECT u.*, ut.name FROM units u, unit_types ut WHERE ut.id = u.unit_type_id AND u.listing_id = '${listing['id']}'`,
@@ -600,6 +611,151 @@ export class ScriptRunnerService {
     // script runner standard spin down
     await this.markScriptAsComplete(
       `data transfer listings ${dataTransferDTO.jurisdiction}`,
+      requestingUser,
+    );
+    return { success: true };
+  }
+
+  /**
+   *
+   * @param req incoming request object
+   * @param dataTransferDTO data transfer endpoint args. Should contain foreign db connection string
+   * @returns successDTO
+   * @description transfers assets for listings in the specified space into the new space
+   */
+  async transferListingAssetData(
+    req: ExpressRequest,
+    dataTransferDTO: AssetTransferDTO,
+    prisma?: PrismaClient,
+  ): Promise<SuccessDTO> {
+    // script runner standard start up
+    const requestingUser = mapTo(User, req['user']);
+    await this.markScriptAsRunStart(
+      `data transfer assets ${dataTransferDTO.jurisdiction}`,
+      requestingUser,
+    );
+
+    // connect to foreign db based on incoming connection string
+    const client =
+      prisma ||
+      new PrismaClient({
+        datasources: {
+          db: {
+            url: dataTransferDTO.connectionString,
+          },
+        },
+      });
+    await client.$connect();
+
+    const doorwayJurisdiction = await this.prisma.jurisdictions.findFirst({
+      where: { name: dataTransferDTO.jurisdiction },
+    });
+
+    if (!doorwayJurisdiction) {
+      throw new Error(
+        `${dataTransferDTO.jurisdiction} county doesn't exist in Doorway database`,
+      );
+    }
+
+    // get jurisdiction
+    const jurisdiction: { id: string }[] =
+      await client.$queryRaw`SELECT id, name FROM jurisdictions WHERE name = ${dataTransferDTO.jurisdiction}`;
+
+    if (!jurisdiction) {
+      throw new Error(
+        `${dataTransferDTO.jurisdiction} county doesn't exist in foreign database`,
+      );
+    }
+
+    const take = calculateTake(40);
+    const skip = calculateSkip(take, dataTransferDTO.page || 1);
+    const listingTransferMap = await this.prisma.listingTransferMap.findMany({
+      take,
+      skip,
+    });
+    console.log(
+      `Found ${listingTransferMap.length} listings on page ${
+        dataTransferDTO.page || 1
+      } out of a possible 40 for this page`,
+    );
+    // loop over each new listing id <-> old listing id relation
+    for (let i = 0; i < listingTransferMap.length; i++) {
+      const oldAssetInfo: {
+        ordinal: number;
+        created_at: Date;
+        updated_at: Date;
+        file_id: string;
+        label: string;
+      }[] = await client.$queryRaw`SELECT
+            li.ordinal,
+            a.created_at,
+            a.updated_at,
+            a.file_id,
+            label
+        FROM listing_images li
+            JOIN assets a ON a.id = li.image_id
+        WHERE li.listing_id = ${listingTransferMap[i].oldId} :: UUID`;
+      console.log(
+        `moving ${oldAssetInfo.length || 0} assets for listing: ${
+          listingTransferMap[i].oldId
+        }:`,
+      );
+      // loop over each listing image on the old listing
+      for (let j = 0; j < oldAssetInfo.length; j++) {
+        // pull down image from cloudinary
+        const image = await axios.get(
+          `https://res.cloudinary.com/${dataTransferDTO.cloudinaryName}/image/upload/${oldAssetInfo[j].file_id}.jpg`,
+          {
+            responseType: 'arraybuffer',
+          },
+        );
+        const newFileId = (oldAssetInfo[j].file_id as string).replace(
+          'housingbayarea/',
+          '',
+        );
+
+        // upload image to s3
+        const res = await this.assetService.upload(newFileId, {
+          filename: null,
+          buffer: image.data,
+          fieldname: null,
+          originalname: `${newFileId}.jpg`,
+          encoding: null,
+          mimetype: 'image/jpeg',
+          size: image.data.length,
+          destination: null,
+          path: null,
+          stream: null,
+        });
+
+        // update new listing with these assets
+        await this.prisma.listings.update({
+          where: {
+            id: listingTransferMap[i].listingId,
+          },
+          data: {
+            listingImages: {
+              create: {
+                assets: {
+                  create: {
+                    fileId: res.url,
+                    label: 'cloudinaryBuilding',
+                  },
+                },
+                ordinal: oldAssetInfo[j].ordinal,
+              },
+            },
+          },
+        });
+      }
+    }
+
+    // disconnect from foreign db
+    await client.$disconnect();
+
+    // script runner standard spin down
+    await this.markScriptAsComplete(
+      `data transfer assets ${dataTransferDTO.jurisdiction}`,
       requestingUser,
     );
     return { success: true };

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -631,7 +631,9 @@ export class ScriptRunnerService {
     // script runner standard start up
     const requestingUser = mapTo(User, req['user']);
     await this.markScriptAsRunStart(
-      `data transfer assets ${dataTransferDTO.jurisdiction}`,
+      `data transfer assets ${dataTransferDTO.jurisdiction} page: ${
+        dataTransferDTO.page || 1
+      }`,
       requestingUser,
     );
 
@@ -710,10 +712,9 @@ export class ScriptRunnerService {
             responseType: 'arraybuffer',
           },
         );
-        const newFileId = (oldAssetInfo[j].file_id as string).replace(
-          'housingbayarea/',
-          '',
-        );
+        const newFileId = (oldAssetInfo[j].file_id as string)
+          .replace('housingbayarea/', '')
+          .replace('dev/', '');
 
         // upload image to s3
         const res = await this.assetService.upload(newFileId, {

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -381,6 +381,7 @@ describe('Testing script runner service', () => {
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.listingTransferMap.create = jest.fn().mockResolvedValue(null);
       prisma.unitAccessibilityPriorityTypes.findMany = jest
         .fn()
         .mockResolvedValue([]);
@@ -636,6 +637,7 @@ describe('Testing script runner service', () => {
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.listingTransferMap.create = jest.fn().mockResolvedValue(null);
       prisma.unitAccessibilityPriorityTypes.findMany = jest
         .fn()
         .mockResolvedValue([]);
@@ -803,6 +805,7 @@ describe('Testing script runner service', () => {
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.listingTransferMap.create = jest.fn().mockResolvedValue(null);
       const doorwayPriorityTypeId = randomUUID();
       const priorityTypeId = randomUUID();
       prisma.unitAccessibilityPriorityTypes.findMany = jest
@@ -1000,6 +1003,7 @@ describe('Testing script runner service', () => {
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.listingTransferMap.create = jest.fn().mockResolvedValue(null);
       prisma.unitAccessibilityPriorityTypes.findMany = jest
         .fn()
         .mockResolvedValue([]);
@@ -1097,6 +1101,7 @@ describe('Testing script runner service', () => {
       prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
       prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+      prisma.listingTransferMap.create = jest.fn().mockResolvedValue(null);
       prisma.unitAccessibilityPriorityTypes.findMany = jest
         .fn()
         .mockResolvedValue([]);

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -18,6 +18,8 @@ import { FeatureFlagService } from '../../../src/services/feature-flag.service';
 import { JurisdictionService } from '../../../src/services/jurisdiction.service';
 import { PrismaService } from '../../../src/services/prisma.service';
 import { ScriptRunnerService } from '../../../src/services/script-runner.service';
+import { AssetModule } from '../../../src/modules/asset.module';
+import { PrismaModule } from '../../../src/modules/prisma.module';
 
 const externalPrismaClient = mockDeep<PrismaClient>();
 
@@ -28,11 +30,11 @@ describe('Testing script runner service', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ScriptRunnerService,
-        PrismaService,
         AmiChartService,
         FeatureFlagService,
         JurisdictionService,
       ],
+      imports: [AssetModule, PrismaModule],
     }).compile();
 
     service = module.get<ScriptRunnerService>(ScriptRunnerService);

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2301,6 +2301,28 @@ export class ScriptRunnerService {
     })
   }
   /**
+   * A script that pulls listing asset data from one source into the current db
+   */
+  transferListingAssetData(
+    params: {
+      /** requestBody */
+      body?: AssetTransferDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/transferListingAssetData"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
    * A script that pulls partner user data from one source into the current db
    */
   transferJurisdictionPartnerUserData(
@@ -6534,6 +6556,20 @@ export interface DataTransferDTO {
 
   /**  */
   page?: number
+}
+
+export interface AssetTransferDTO {
+  /**  */
+  connectionString: string
+
+  /**  */
+  jurisdiction: string
+
+  /**  */
+  page?: number
+
+  /**  */
+  cloudinaryName: string
 }
 
 export interface AmiChartImportDTO {


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1051

- [x] Addresses only certain aspects of the issue

## Description
This creates a new transfer script runner that transfers over the listing images so we don't have to move those by hand. This pattern can be repeated for each of the other assets

## How Can This Be Tested/Reviewed?
you will need to set up and run through the:
- jurisdiction transfer script
- listing transfer script
- then run this script

This is a paginated transfer so you'll need to run it a few times to get through all the listings, but once thats complete you should be able to head into the partner and public portal and verify that the listing images are all present as they were in the "foreign" db 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
