### PR TITLE
fix: language not persisting through navigation

### DIFF
--- a/doorway-ui-components/package.json
+++ b/doorway-ui-components/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@bloom-housing/ui-components": "12.4.0",
+    "@bloom-housing/ui-seeds": "1.17.0",
     "ag-grid-community": "^26.0.0",
     "markdown-to-jsx": "7.1.8",
     "nanoid": "^3.3.6",

--- a/doorway-ui-components/src/page_components/listing/ListingCard.tsx
+++ b/doorway-ui-components/src/page_components/listing/ListingCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from "react"
 import Link from "next/link"
+import { Button as SeedsButton } from "@bloom-housing/ui-seeds"
 import {
   Heading,
   AppearanceStyleType,
@@ -8,9 +9,7 @@ import {
   Icon,
   IconFillColors,
   Tag,
-  LinkButton,
   StackedTableProps,
-  AppearanceSizeType,
 } from "@bloom-housing/ui-components"
 import { ImageCard, ImageCardProps, ImageTag } from "../../blocks/ImageCard"
 import { AppearanceShadeType } from "../../global/AppearanceTypes"
@@ -230,15 +229,14 @@ const ListingCard = (props: ListingCardProps) => {
           <div className={footerContainerClass ?? "listings-row_footer"}>
             {footerButtons?.map((footerButton, index) => {
               return (
-                <LinkButton
+                <SeedsButton
                   href={footerButton.href}
                   ariaHidden={footerButton.ariaHidden}
                   key={index}
-                  className={"is-secondary doorway-button"}
-                  size={AppearanceSizeType.small}
+                  variant="secondary"
                 >
                   {footerButton.text}
-                </LinkButton>
+                </SeedsButton>
               )
             })}
           </div>

--- a/sites/public/src/components/listings/ListingsList.tsx
+++ b/sites/public/src/components/listings/ListingsList.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { Listing, ListingMapMarker } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { Heading } from "@bloom-housing/ui-seeds"
+import { Button, Heading } from "@bloom-housing/ui-seeds"
 import { ZeroListingsItem } from "@bloom-housing/doorway-ui-components"
-import { LoadingOverlay, t, InfoCard, LinkButton } from "@bloom-housing/ui-components"
+import { LoadingOverlay, t, InfoCard } from "@bloom-housing/ui-components"
 import { getListings } from "../../lib/helpers"
 import { Pagination } from "./Pagination"
 import styles from "./ListingsCombined.module.scss"
@@ -42,13 +42,13 @@ const ListingsList = (props: ListingsListProps) => {
           subtitle={t("t.subscribeToListingAlerts")}
           className="is-normal-primary-lighter"
         >
-          <LinkButton
+          <Button
             href={process.env.notificationsSignUpUrl}
-            newTab={true}
             className="is-primary"
+            hideExternalLinkIcon={true}
           >
             {t("t.signUp")}
-          </LinkButton>
+          </Button>
         </InfoCard>
       )}
       <InfoCard
@@ -56,18 +56,23 @@ const ListingsList = (props: ListingsListProps) => {
         subtitle={t("t.emergencyShelter")}
         className="is-normal-secondary-lighter"
       >
-        <LinkButton href="/help/housing-help" className="is-secondary">
+        <Button href="/help/housing-help" className="capitalize" variant="secondary">
           {t("t.helpCenter")}
-        </LinkButton>
+        </Button>
       </InfoCard>
       <InfoCard
         title={t("t.housingInSanFrancisco")}
         subtitle={t("t.seeSanFranciscoListings")}
         className="is-normal-secondary-lighter"
       >
-        <LinkButton href="https://housing.sfgov.org/" newTab={true} className="is-secondary">
+        <Button
+          href="https://housing.sfgov.org/"
+          className="capitalize"
+          variant="secondary"
+          hideExternalLinkIcon={true}
+        >
           {t("t.seeListings")}
-        </LinkButton>
+        </Button>
       </InfoCard>
     </div>
   )

--- a/sites/public/src/components/listings/search/LandingSearch.tsx
+++ b/sites/public/src/components/listings/search/LandingSearch.tsx
@@ -1,17 +1,15 @@
 import React, { useState, useEffect, ChangeEvent } from "react"
 import { useForm } from "react-hook-form"
+import { Button, Dialog } from "@bloom-housing/ui-seeds"
 import { FilterAvailabilityEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import {
   ButtonGroup,
   FieldGroup,
   FieldSingle,
-  Button,
   ButtonGroupSpacing,
   Field,
-  AppearanceSizeType,
 } from "@bloom-housing/doorway-ui-components"
-import { LinkButton, t, Card } from "@bloom-housing/ui-components"
-import { Dialog } from "@bloom-housing/ui-seeds"
+import { t, Card } from "@bloom-housing/ui-components"
 import { numericSearchFieldGenerator } from "./helpers"
 import styles from "./LandingSearch.module.scss"
 import { FormOption } from "./ListingsSearchModal"
@@ -210,20 +208,16 @@ export function LandingSearch(props: LandingSearchProps) {
       </div>
 
       <div className="flex justify-start p-2">
-        <LinkButton
-          href={createListingsUrl(formValues)}
-          className="is-primary is-borderless bg-primary-dark text-3xs md:text-xs text-white mr-8"
-          size={AppearanceSizeType.small}
-        >
+        <Button href={createListingsUrl(formValues)} className="mr-8">
           {t("nav.viewListings")}
-        </LinkButton>
+        </Button>
 
         <Button
-          className="is-borderless is-inline is-unstyled underline text-primary uppercase tracking-widest text-3xs md:text-xs"
-          size={AppearanceSizeType.small}
+          className="uppercase tracking-widest text-3xs md:text-xs mt-3"
           onClick={() => {
             setOpenCountyMapModal(!openCountyMapModal)
           }}
+          variant={"text"}
         >
           {t("welcome.viewCountyMap")}
         </Button>


### PR DESCRIPTION
This PR addresses #1084

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Fixes a few instances of links not persisting the language selection. The issue was with UIC buttons, so I switched them to Seeds buttons. This did slightly update the styles, but in a way that is a bug fix and now is more consistent w the rest of the site and Seeds decisions - the buttons were not styled in the rounded Doorway theme, and were using all-caps.

## How Can This Be Tested/Reviewed?

Ensure the 3 places now persist language:
1. The see listings button on the home page
2. The see details button on the map page (you have to click the button itself, not the image)
3. The help center button underneath the listings on the map page

Prod:
![Screenshot 2025-03-17 at 2 10 04 PM](https://github.com/user-attachments/assets/90a8eaf0-de9d-4323-83e4-3c6d12c7352f)
This PR:
![Screenshot 2025-03-17 at 2 09 56 PM](https://github.com/user-attachments/assets/a862c41e-8c79-48c3-a7cd-bbc30e090ddc)

Prod:
![Screenshot 2025-03-17 at 2 10 52 PM](https://github.com/user-attachments/assets/597cb9f9-2aa6-4fe9-b1b5-7fab3430b77e)
This PR:
![Screenshot 2025-03-17 at 2 10 59 PM](https://github.com/user-attachments/assets/208a4491-36e6-4c74-bc49-be812ad6a4c0)


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
