### PR TITLE
fix: update to fix pop up translations

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -878,7 +878,6 @@ export class ListingService implements OnModuleInit {
 
     // because we don't need auto translations on the public site map pin pop ups
     // we skip the translation step
-    // this should fix an issue where if auto translations are not recent the pop ups were blanks and we got an error
     if (!combined && lang && lang !== LanguagesEnum.en) {
       result = await this.translationService.translateListing(result, lang);
     }

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -876,7 +876,10 @@ export class ListingService implements OnModuleInit {
 
     let result = mapTo(Listing, listingRaw);
 
-    if (lang && lang !== LanguagesEnum.en) {
+    // because we don't need auto translations on the public site map pin pop ups
+    // we skip the translation step
+    // this should fix an issue where if auto translations are not recent the pop ups were blanks and we got an error
+    if (!combined && lang && lang !== LanguagesEnum.en) {
       result = await this.translationService.translateListing(result, lang);
     }
 


### PR DESCRIPTION
- [x] Addresses the issue in full

## Description
There was an issue with selecting non-english and clicking a map pin on the public site listing map
if the listing wasn't recently translated via the google translation service we were getting a blank pin and an error message

## How Can This Be Tested/Reviewed?
- reseed
- on the public site select a non-english language
- head to the listing map on the public site
- click on the map pin for a listing you'll notice that the pin is working now
   - prior to this fix the pin popup would show as empty and an error would be thrown in the api
   - the error was that the translation attempt was missing required strings

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
