### PR TITLE
fix: add tay community type to email

### DIFF
--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -632,7 +632,8 @@ export class EmailService {
     if (listing.reservedCommunityTypes?.name) {
       tableRows.push({
         label: this.polyglot.t('rentalOpportunity.community'),
-        value: this.formatCommunityType[listing.reservedCommunityTypes.name],
+        value:
+          this.formatCommunityType[listing.reservedCommunityTypes.name] || '',
       });
     }
     if (listing.applicationDueDate) {
@@ -891,5 +892,6 @@ export class EmailService {
     seniorVeterans: 'Senior Veteran',
     veteran: 'Veteran',
     schoolEmployee: 'School Employee',
+    tay: 'TAY - Transition Aged Youth',
   };
 }


### PR DESCRIPTION
Last step for the new TAY community type https://github.com/housingbayarea/bloom/pull/848

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When sending listing opportunity emails as well as the CSV export, there needs to be a mapping of the community type name to the human readable name. This was missed when adding the TAY community type

## How Can This Be Tested/Reviewed?

The main requirement to test this is to setup a listing that has the new community type set.

Testing the email for listing opportunity is not the easiest, but can be tested by enabling the listing opportunity for a jurisdiction and swapping out the `.govSend` in the `listingOpportunity` function within `email.service.ts` for the `sendSingleSES` function. You will need to enter your own email information for the email to information

Testing the CSV export is much more straightforward, you can just export the listing CSV and your newly created listing should appear there with the appropriate community type

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
