### PR TITLE
Removing alameda ref

### DIFF
--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -142,7 +142,6 @@
   "authentication.terms.partnersAccept": "You must accept the Terms of Use before continuing.",
   "authentication.terms.partnersTerms": "I have reviewed the <a className='lined' href='https://mtc.ca.gov/doorway-housing-portal-terms-use' target='_blank'>Terms of Use</a> for this Website, as that term is defined in the Terms of Use, and agree to comply with all requirements described therein that relate to my use as a Professional Partner or Local Government. If I am agreeing to comply with the Terms of Use on behalf of a Professional Partner or Local Government, I warrant that I am authorized to enter into agreements such as the Terms of Use on behalf of such Professional Partner or Local Government.",
   "authentication.terms.reviewToc": "Review Terms of Service",
-  "county.goToOtherPortalsAlamedaSanMateo": "Counties of Alameda and San Mateo",
   "county.goToOtherPortalsCitySanJose": "City of San Jose",
   "county.goToOtherPortalsHover": "Doorway Partners Portal only contains listings for:  Contra Costa County, Marin County, Napa County, Santa Clara County (other than the City of San Jose), Solano County, and Sonoma County. If the listing is in Alameda county, San Mateo county, San Francisco City/County, or the City of San Jose, use these links to create listings in the respective portals.",
   "county.goToOtherPortalsSanFrancisco": "City and County of San Francisco - DAHLIA",

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
@@ -359,15 +359,6 @@ const BuildingDetails = ({
                 </Link>
               </li>
               <li className="list-disc list-inside">
-                {t("county.goToOtherPortalsAlamedaSanMateo")}
-                <Link href="https://partners.housingbayarea.org/">
-                  {" "}
-                  <Icon>
-                    <ArrowTopRightOnSquareIcon />
-                  </Icon>{" "}
-                </Link>
-              </li>
-              <li className="list-disc list-inside">
                 {t("county.goToOtherPortalsSanFrancisco")}
                 <Link href="https://www.partner.housing.sfgov.org/">
                   {" "}


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1189

- [x] Addresses the issue in full

## Description
Removes the alameda and smc reference on the partner's county dropdown side info panel

## How Can This Be Tested/Reviewed?
Log into partners, go to create or edit a listing, scroll down to the county dropdown and you should see the info panel beside it. 

the alameda and smc ref should be removed from there 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
