### PR TITLE
feat: secure download via s3

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -73,10 +73,20 @@ ENABLE_RECAPTCHA=TRUE
 # Doorway specific values
 ASSET_UPLOAD_MAX_SIZE=
 ASSET_FILE_SERVICE=
+# public s3 bucket's region (used for files)
 ASSET_FS_CONFIG_s3_REGION=
+# public s3 bucket (used for files)
 ASSET_FS_CONFIG_s3_BUCKET=
+# public s3 bucket url format (used for files)
 ASSET_FS_CONFIG_s3_URL_FORMAT=public
 SITE_EMAIL=
+
+# private s3 bucket (used for nonpublic files)
+ASSET_FS_PRIVATE_CONFIG_s3_BUCKET=
+# private s3 bucket url format (used for nonpublic files)
+ASSET_FS_PRIVATE_CONFIG_s3_URL_FORMAT=private
+
+
 # aws api keys, used for ses
 AWS_ACCESS_KEY_ID=
 AWS_REGION=us-west-1

--- a/api/src/controllers/application.controller.ts
+++ b/api/src/controllers/application.controller.ts
@@ -3,14 +3,12 @@ import {
   Controller,
   Delete,
   Get,
-  Header,
   Param,
   Post,
   Put,
   Query,
   Request,
   Res,
-  StreamableFile,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -115,13 +113,13 @@ export class ApplicationController {
     summary: 'Get applications as csv',
     operationId: 'listAsCsv',
   })
-  @Header('Content-Type', 'application/zip')
   @UseInterceptors(ExportLogInterceptor)
+  @ApiOkResponse({ type: String })
   async listAsCsv(
     @Request() req: ExpressRequest,
     @Query(new ValidationPipe(defaultValidationPipeOptions))
     queryParams: ApplicationCsvQueryParams,
-  ): Promise<StreamableFile> {
+  ): Promise<string> {
     return await this.applicationExportService.exporter(
       req,
       queryParams,
@@ -135,14 +133,14 @@ export class ApplicationController {
     summary: 'Get applications as spreadsheet',
     operationId: 'listAsSpreadsheet',
   })
-  @Header('Content-Type', 'application/zip')
   @UseInterceptors(ExportLogInterceptor)
+  @ApiOkResponse({ type: String })
   async spreadsheetExport(
     @Request() req: ExpressRequest,
     @Res({ passthrough: true }) res: Response,
     @Query(new ValidationPipe(defaultValidationPipeOptions))
     queryParams: ApplicationCsvQueryParams,
-  ): Promise<StreamableFile> {
+  ): Promise<string> {
     return await this.applicationExportService.exporter(
       req,
       queryParams,

--- a/api/src/controllers/lottery.controller.ts
+++ b/api/src/controllers/lottery.controller.ts
@@ -2,14 +2,12 @@ import {
   Body,
   Controller,
   Get,
-  Header,
   Param,
   ParseUUIDPipe,
   Put,
   Query,
   Request,
   Res,
-  StreamableFile,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -76,14 +74,14 @@ export class LotteryController {
     summary: 'Get applications lottery results',
     operationId: 'lotteryResults',
   })
-  @Header('Content-Type', 'application/zip')
   @UseInterceptors(ExportLogInterceptor)
+  @ApiOkResponse({ type: String })
   async lotteryExport(
     @Request() req: ExpressRequest,
     @Res({ passthrough: true }) res: Response,
     @Query(new ValidationPipe(defaultValidationPipeOptions))
     queryParams: ApplicationCsvQueryParams,
-  ): Promise<StreamableFile> {
+  ): Promise<string> {
     return await this.applicationExporterService.exporter(
       req,
       queryParams,

--- a/api/src/modules/application-exporter.module.ts
+++ b/api/src/modules/application-exporter.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 import { ApplicationExporterService } from '../services/application-exporter.service';
+import { AssetModule } from './asset.module';
 import { ListingModule } from './listing.module';
 import { MultiselectQuestionModule } from './multiselect-question.module';
 import { PermissionModule } from './permission.module';
@@ -9,6 +10,7 @@ import { PrismaModule } from './prisma.module';
 @Module({
   imports: [
     ApplicationExporterModule,
+    AssetModule,
     PrismaModule,
     ListingModule,
     MultiselectQuestionModule,

--- a/api/src/services/asset.service.ts
+++ b/api/src/services/asset.service.ts
@@ -23,7 +23,12 @@ export class AssetService {
     await this.prismaService.assets.create({ data: assetCreateDto });
   }
 
-  async upload(label: string, file: Express.Multer.File) {
+  async upload(
+    label: string,
+    file: Express.Multer.File,
+    optionalBucket?: string,
+    optionalUrlFormat?: string,
+  ) {
     const fileService = this.fileServiceProvider.activeFileService;
 
     // convert the express File type to a package-specific interface
@@ -37,7 +42,13 @@ export class AssetService {
         : fs.createReadStream(file.path),
     };
 
-    const result = await fileService.putFile('assets', label, fileUpload);
+    const result = await fileService.putFile(
+      'assets',
+      label,
+      fileUpload,
+      optionalBucket,
+      optionalUrlFormat,
+    );
     return result;
 
     /*

--- a/api/src/services/uploads/types.ts
+++ b/api/src/services/uploads/types.ts
@@ -8,6 +8,8 @@ export interface FileService {
     prefix: string,
     key: string,
     file: FileUpload,
+    optionalBucket?: string,
+    optionalUrlFormat?: string,
   ): Promise<FileUploadResult>;
   generateDownloadUrl(id: string): Promise<string>;
 }

--- a/api/src/utilities/zip-export.ts
+++ b/api/src/utilities/zip-export.ts
@@ -1,6 +1,5 @@
-import { StreamableFile } from '@nestjs/common';
 import archiver from 'archiver';
-import fs, { createReadStream, ReadStream } from 'fs';
+import fs, { ReadStream } from 'fs';
 import { join } from 'path';
 
 /**
@@ -16,7 +15,7 @@ export const zipExport = (
   zipFilename: string,
   filename: string,
   isSpreadsheet: boolean,
-): Promise<StreamableFile> => {
+): Promise<string> => {
   const zipFilePath = join(process.cwd(), `src/temp/${zipFilename}.zip`);
 
   return new Promise((resolve) => {
@@ -26,8 +25,7 @@ export const zipExport = (
       zlib: { level: 9 },
     });
     output.on('close', () => {
-      const zipFile = createReadStream(zipFilePath);
-      resolve(new StreamableFile(zipFile));
+      resolve(zipFilePath);
     });
 
     archive.pipe(output);

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -1523,7 +1523,7 @@ export class ApplicationsService {
       timeZone?: string
     } = {} as any,
     options: IRequestOptions = {}
-  ): Promise<any> {
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/applications/csv"
 
@@ -1552,7 +1552,7 @@ export class ApplicationsService {
       timeZone?: string
     } = {} as any,
     options: IRequestOptions = {}
-  ): Promise<any> {
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/applications/spreadsheet"
 
@@ -2804,7 +2804,7 @@ export class LotteryService {
       timeZone?: string
     } = {} as any,
     options: IRequestOptions = {}
-  ): Promise<any> {
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/lottery/getLotteryResults"
 
@@ -6961,12 +6961,6 @@ export enum UnitRentTypeEnum {
 export enum EnumUnitGroupAmiLevelMonthlyRentDeterminationType {
   "flatRent" = "flatRent",
   "percentageOfIncome" = "percentageOfIncome",
-}
-export enum HomeTypeEnum {
-  "apartment" = "apartment",
-  "duplex" = "duplex",
-  "house" = "house",
-  "townhome" = "townhome",
 }
 export enum EnumUnitGroupAmiLevelCreateMonthlyRentDeterminationType {
   "flatRent" = "flatRent",

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -528,28 +528,29 @@ export const useZipExport = (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let content: any
       if (isLottery) {
-        content = await lotteryService.lotteryResults(
-          { id: listingId, includeDemographics, timeZone: dayjs.tz.guess() },
-          { responseType: "arraybuffer" }
-        )
+        content = await lotteryService.lotteryResults({
+          id: listingId,
+          includeDemographics,
+          timeZone: dayjs.tz.guess(),
+        })
       } else {
         if (isSpreadsheet) {
-          content = await applicationsService.listAsSpreadsheet(
-            { id: listingId, includeDemographics, timeZone: dayjs.tz.guess() },
-            { responseType: "arraybuffer" }
-          )
+          content = await applicationsService.listAsSpreadsheet({
+            id: listingId,
+            includeDemographics,
+            timeZone: dayjs.tz.guess(),
+          })
         } else {
-          content = await applicationsService.listAsCsv(
-            { id: listingId, includeDemographics, timeZone: dayjs.tz.guess() },
-            { responseType: "arraybuffer" }
-          )
+          content = await applicationsService.listAsCsv({
+            id: listingId,
+            includeDemographics,
+            timeZone: dayjs.tz.guess(),
+          })
         }
       }
 
-      const blob = new Blob([new Uint8Array(content)], { type: "application/zip" })
-      const url = window.URL.createObjectURL(blob)
       const link = document.createElement("a")
-      link.href = url
+      link.href = content
       link.setAttribute(
         "download",
         `${isLottery ? "lottery" : "applications"}-${listingId}-${createDateStringFromNow(

--- a/sites/partners/src/pages/api/adapter/[...backendUrl].ts
+++ b/sites/partners/src/pages/api/adapter/[...backendUrl].ts
@@ -13,12 +13,7 @@ import { logger } from "../../../logger"
 */
 
 // all endpoints that return a zip file
-const zipEndpoints = [
-  "listings/csv",
-  "lottery/getLotteryResults",
-  "applications/spreadsheet",
-  "applications/csv",
-]
+const zipEndpoints = ["listings/csv"]
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const jar = new CookieJar()


### PR DESCRIPTION
This PR addresses https://github.com/bloom-housing/bloom/issues/4592

- [x] Addresses the issue in full

## Description
This switches to the secure download via s3 bucket for application exports (both csv and spreadsheet) and lottery export

## How Can This Be Tested/Reviewed?
- You will need to add the 2 new env variables to your api .env file
- head to the partner's site
- try to download the application export off of a listing
- close the listing
- run the lottery
- export the lottery results

both of those should work (from the new private s3 bucket)


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
