### PR TITLE
fix: adding order by to paginated scripts

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -675,6 +675,9 @@ export class ScriptRunnerService {
     const listingTransferMap = await this.prisma.listingTransferMap.findMany({
       take,
       skip,
+      orderBy: {
+        listingId: OrderByEnum.ASC,
+      },
     });
     console.log(
       `Found ${listingTransferMap.length} listings on page ${


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1216

- [x] Addresses the issue in full

## Description
This adds an order by to the last unordered paginated script runner script for transferring jurisdictional data

## How Can This Be Tested/Reviewed?
You'll need to run the transfer scripts up to and including the asset transfer script (asset transfer script was the only one that got a change)


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
