### PR TITLE
fix: remove echo housing card

### DIFF
--- a/sites/public/src/tsx_content/housing-help-cards.tsx
+++ b/sites/public/src/tsx_content/housing-help-cards.tsx
@@ -127,12 +127,6 @@ export function housingHelpLinkableCards(): React.ReactElement<CardProps>[] {
             {t("help.housingHelp.counseling.alamedaEden")}
           </a>
           {t("help.housingHelp.counseling.alamedaEdeninfo")}
-          <br />
-          <br />
-          <a href="https://www.echofairhousing.org" target="_blank">
-            {t("help.housingHelp.counseling.alamedaECHO")}
-          </a>
-          {t("help.housingHelp.counseling.alamedaECHOinfo")}
         </DoorwayCollapsibleSection>
         <DoorwayCollapsibleSection title={t("counties.fullname.SanFrancisco")}>
           <a href="https://housing.sfgov.org/housing-counselors" target="_blank">


### PR DESCRIPTION
This PR addresses #1209 1209

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Removes the ECHO housing card from the Housing Counselor section of the housing help page

Before:
![image](https://github.com/user-attachments/assets/0003490f-a7cb-4052-bd62-5307aae926da)

After:
![image](https://github.com/user-attachments/assets/40664a84-557c-40a4-8297-8c847ac1a332)


## How Can This Be Tested/Reviewed?

Go to the [housing help page](http://localhost:3000/help/housing-help) 
Under the "Housing Counseling" section and the "Alameda County" accordion you should no longer see the link and description for "ECHO Housing"

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
