### PR TITLE
fix: less likely to flood the connection pools

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -564,7 +564,9 @@ export class ScriptRunnerService {
           console.log(
             `migrating ${listingMultiselectQuestions.length} listing multiselect questions`,
           );
-          listingMultiselectQuestions.forEach(async (lmq) => {
+          for (let i = 0; i < listingMultiselectQuestions.length; i++) {
+            const lmq = listingMultiselectQuestions[i];
+
             try {
               await this.prisma.listingMultiselectQuestions.create({
                 data: {
@@ -579,7 +581,7 @@ export class ScriptRunnerService {
                 `unable to migrate listing multiselect question ${lmq.multiselect_question_id} to listing ${createdListing.id}`,
               );
             }
-          });
+          }
         }
 
         // Migrate all events that don't have a file associated to it


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1230
- [x] Addresses only certain aspects of the issue

## Description
During the listing transfer script we were not properly waiting for multiselect question writes, this should fix that

## How Can This Be Tested/Reviewed?
you need to run the transfer scripts up to and including the listing transfer script

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
