### PR TITLE
fix: temporarily return access of lottery results past the 45 day mark

### DIFF
--- a/api/src/services/application.service.ts
+++ b/api/src/services/application.service.ts
@@ -426,6 +426,7 @@ export class ApplicationService {
         if (params.filterType === ApplicationsFilterEnum.open)
           displayApplications.push(app);
       } else if (
+        // NOTE: Allowing expired lotteries to show temporarily
         (app.listings?.lotteryStatus === LotteryStatusEnum.publishedToPublic ||
           app.listings?.lotteryStatus === LotteryStatusEnum.expired) &&
         params.includeLotteryApps

--- a/sites/public/src/components/account/StatusItem.tsx
+++ b/sites/public/src/components/account/StatusItem.tsx
@@ -38,7 +38,12 @@ const StatusItem = (props: StatusItemProps) => {
   let tagVariant: "primary" | "secondary" | "success"
   let deadlineText = ""
   let dueDate = ""
-  if (props.lotteryStatus === LotteryStatusEnum.publishedToPublic && showPublicLottery) {
+  // NOTE: Allowing expired lotteries to show temporarily
+  if (
+    (props.lotteryStatus === LotteryStatusEnum.publishedToPublic ||
+      props.lotteryStatus === LotteryStatusEnum.expired) &&
+    showPublicLottery
+  ) {
     tagText = t("account.lotteryRun")
     tagVariant = "success"
     deadlineText = t("account.lotteryPosted")

--- a/sites/public/src/components/account/StatusItemWrapper.tsx
+++ b/sites/public/src/components/account/StatusItemWrapper.tsx
@@ -34,6 +34,7 @@ const StatusItemWrapper = (props: StatusItemWrapperProps) => {
         lotteryLastPublishedAt && dayjs(lotteryLastPublishedAt).format("MMM D, YYYY")
       }
       lotteryResults={
+        // NOTE: Allowing expired lotteries to show temporarily
         (props.application?.listings?.lotteryStatus === LotteryStatusEnum.expired ||
           props.application?.listings?.lotteryStatus === LotteryStatusEnum.publishedToPublic) &&
         !!props.application?.applicationLotteryPositions?.length


### PR DESCRIPTION
This PR addresses #1207

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

On public site it will return applications that got status `expired`. This means env on partners will still hide lotteries for partners, but they will be accessible on public.
Just be aware that i am not super familiar with lotteries so i might miss some edge case.

## How Can This Be Tested/Reviewed?

Apply for lottery listing, then close it and run lottery. 
Now we should somehow trigger `expireLotteries()`. But i couldn't do this so i altered listing to have `lotteryStatus='exipred'`.
It should still display it for public user, and be hidden for partner in partners portal

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
