### PR TITLE
fix: add limited jurisdiction admin back

### DIFF
--- a/sites/partners/__tests__/components/users/FormUserManage.test.tsx
+++ b/sites/partners/__tests__/components/users/FormUserManage.test.tsx
@@ -96,10 +96,13 @@ describe("<FormUserManage>", () => {
           expect(screen.getByRole("textbox", { name: "First Name" })).toBeInTheDocument()
           expect(screen.getByRole("textbox", { name: "Last Name" })).toBeInTheDocument()
           expect(screen.getByRole("textbox", { name: "Email" })).toBeInTheDocument()
-          // "Role" select should have all three role option
+          // "Role" select should have all four role option
           expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Jurisdictional Admin" })).toBeInTheDocument()
+          expect(
+            screen.getByRole("option", { name: "Jurisdictional Admin - No PII" })
+          ).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
           expect(screen.getByRole("button", { name: "Invite" })).toBeInTheDocument()
           await userEvent.type(screen.getByRole("textbox", { name: "First Name" }), "firstName")
@@ -167,6 +170,9 @@ describe("<FormUserManage>", () => {
           expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Jurisdictional Admin" })).toBeInTheDocument()
+          expect(
+            screen.getByRole("option", { name: "Jurisdictional Admin - No PII" })
+          ).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
           await userEvent.type(screen.getByRole("textbox", { name: "First Name" }), "firstName")
           await userEvent.type(screen.getByRole("textbox", { name: "Last Name" }), "lastName")
@@ -248,10 +254,13 @@ describe("<FormUserManage>", () => {
           )
 
           await waitFor(() => screen.getByText("Jurisdictional Admin"))
-          // "Role" select should have all three role option
+          // "Role" select should have all four role option
           expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Jurisdictional Admin" })).toBeInTheDocument()
+          expect(
+            screen.getByRole("option", { name: "Jurisdictional Admin - No PII" })
+          ).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
           await userEvent.type(screen.getByRole("textbox", { name: "First Name" }), "firstName")
           await userEvent.type(screen.getByRole("textbox", { name: "Last Name" }), "lastName")
@@ -335,6 +344,9 @@ describe("<FormUserManage>", () => {
           await waitFor(() => screen.getByText("Jurisdictional Admin"))
           expect(screen.queryByRole("option", { name: "Administrator" })).not.toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Jurisdictional Admin" })).toBeInTheDocument()
+          expect(
+            screen.getByRole("option", { name: "Jurisdictional Admin - No PII" })
+          ).toBeInTheDocument()
           expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
         })
       })
@@ -383,6 +395,9 @@ describe("<FormUserManage>", () => {
         expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
         expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
         expect(screen.getByRole("option", { name: "Jurisdictional Admin" })).toBeInTheDocument()
+        expect(
+          screen.getByRole("option", { name: "Jurisdictional Admin - No PII" })
+        ).toBeInTheDocument()
         expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
         expect(screen.getByRole("button", { name: "Invite" })).toBeInTheDocument()
 
@@ -448,6 +463,9 @@ describe("<FormUserManage>", () => {
         expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
         expect(
           screen.queryByRole("option", { name: "Jurisdictional Admin" })
+        ).not.toBeInTheDocument()
+        expect(
+          screen.queryByRole("option", { name: "Jurisdictional Admin - No PII" })
         ).not.toBeInTheDocument()
       })
     })

--- a/sites/partners/src/components/users/FormUserManage.tsx
+++ b/sites/partners/src/components/users/FormUserManage.tsx
@@ -64,6 +64,7 @@ const FormUserManage = ({
     !doJurisdictionsHaveFeatureFlagOn(FeatureFlagEnum.disableJurisdictionalAdmin, undefined, true)
   ) {
     possibleUserRoles.push(RoleOption.JurisdictionalAdmin)
+    possibleUserRoles.push(RoleOption.LimitedJurisdictionalAdmin)
   }
   if (profile?.userRoles?.isAdmin) {
     possibleUserRoles.push(RoleOption.Administrator)


### PR DESCRIPTION
This PR addresses <bug fix from release bash>

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Limited Jurisdiction admin was accidentally removed from the user role drop down in the last release PR

## How Can This Be Tested/Reviewed?

* Log in as an admin and go to the user page http://localhost:3001/users.
* Verify that "Jurisdictional Admin - No PII" is an option in the role field


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
