### PR TITLE
feat: caching the choose-language page

### DIFF
--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from "react"
 import { useRouter } from "next/router"
+import { GetStaticPaths, GetStaticProps } from "next"
 import dayjs from "dayjs"
 import { ImageCard, t } from "@bloom-housing/ui-components"
 import {
@@ -236,10 +237,15 @@ const ApplicationChooseLanguage = (props: ChooseLanguageProps) => {
 
 export default ApplicationChooseLanguage
 
-export function getServerSideProps() {
+export const getStaticPaths: GetStaticPaths = () => {
+  return { paths: [], fallback: "blocking" }
+}
+
+export const getStaticProps: GetStaticProps = () => {
   const backendApiBase = runtimeConfig.getBackendApiBase()
 
   return {
     props: { backendApiBase: backendApiBase },
+    revalidate: Number(process.env.cacheRevalidate),
   }
 }


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1302

- [x] Addresses the issue in full

## Description
This converts the choose-language page (first page of an application on the public) to using `getStaticProps` instead of `getServerSideProps` and getting cached 

## How Can This Be Tested/Reviewed?
Stand up the public site locally
go to fill in an application
try in a few different languages
everything should function the same 

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
