### PR TITLE
fix: help tracking what error is causing detail not found

### DIFF
--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -107,6 +107,7 @@ export const getStaticProps: GetStaticProps = async (context: {
       },
     })
   } catch (e) {
+    console.error("slug notFound Error:", e)
     return { notFound: true }
   }
   return {


### PR DESCRIPTION
- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description
This puts in place some logging so that we can track down what is causing our intermittent "not found" error on prod listing detail pages. 

The error is currently getting swallowed so its tough to know what is going on

## How Can This Be Tested/Reviewed?
if you can stand up public locally you gouda

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
