### PR TITLE
fix: correct import on test

### DIFF
--- a/sites/public/__tests__/pages/finder.test.tsx
+++ b/sites/public/__tests__/pages/finder.test.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import RentalsFinder from "../../src/components/finder/RentalsFinder"
-import { render, screen } from "../testUtils"
-import { mockNextRouter, waitFor, within } from "../../../partners/__tests__/testUtils"
+import { render, screen, mockNextRouter, waitFor, within } from "../testUtils"
 import userEvent from "@testing-library/user-event"
 import { act } from "react-dom/test-utils"
 import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"


### PR DESCRIPTION
This PR addresses #1297

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

After merging the large core changes PR the tests failed because we accidentally used an import from the partner package in the public directory. This change was not noticed because the tests pass locally and in the github action. Only when we don't have access to the partner site code does the test fail

## How Can This Be Tested/Reviewed?

All tests should still pass locally.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
