### PR TITLE
fix: dialog footer and banner css fixes

### DIFF
--- a/shared-helpers/src/views/layout/AlertBanner.module.scss
+++ b/shared-helpers/src/views/layout/AlertBanner.module.scss
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 99999;
+  z-index: calc(var(--seeds-z-index-overlay) - 1);
 
   &[data-variant="primary"] {
     background-color: var(--seeds-color-primary-lighter);

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -239,6 +239,7 @@
 
   .seeds-dialog {
     max-height: 100dvh;
+    --overlay-footer-background-color: var(--seeds-color-blue-100);
   }
 
   .seeds-dialog.listings-search-dialog {


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Two bugs were found in the bug bash of Doorway. Both related to the filter dialog.

1. The "Show matching listings" button is the same color as the footer background
2. The site banner has a higher z-index then the dialog
![image](https://github.com/user-attachments/assets/174fde72-3161-442b-8d3f-02475f2cb25a)

* The fix for the footer is to revert back to the grayish color that is in production instead of the new blue color
* The fix for the banner is to switch from 99999 as the z-index to 9

## How Can This Be Tested/Reviewed?

Locally you should now see the above mentioned fixes.

Note: you will have to have the `SITE_MESSAGE_WINDOW` env variable set in the public .env file to see the banner
Note: the fix for the grayish footer also carries over to other dialogs such as the agree to terms modal

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
