### PR TITLE
refactor: fetch less data in partner user drawer (#5014)

### DIFF
--- a/api/src/enums/listings/view-enum.ts
+++ b/api/src/enums/listings/view-enum.ts
@@ -1,7 +1,8 @@
 export enum ListingViews {
-  fundamentals = 'fundamentals',
   base = 'base',
-  full = 'full',
-  details = 'details',
   csv = 'csv',
+  details = 'details',
+  full = 'full',
+  fundamentals = 'fundamentals',
+  name = 'name',
 }

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -94,6 +94,21 @@ export const views: Partial<Record<ListingViews, Prisma.ListingsInclude>> = {
   },
 };
 
+views.name = {
+  Listings: {
+    select: {
+      name: true,
+      id: true,
+    },
+  },
+  jurisdictions: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+};
+
 views.base = {
   ...views.fundamentals,
   units: {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -2309,6 +2309,32 @@ describe('Testing listing service', () => {
       });
     });
 
+    it('should return records from findOne() with name view', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(mockListing(0));
+
+      await service.findOne('listingId', LanguagesEnum.en, ListingViews.name);
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'listingId',
+        },
+        include: {
+          Listings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          jurisdictions: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      });
+    });
+
     it('should handle no records returned when findOne() is called with details view', async () => {
       prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
 

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -7231,11 +7231,12 @@ export enum EnumListingFilterParamsComparison {
   "NA" = "NA",
 }
 export enum ListingViews {
-  "fundamentals" = "fundamentals",
   "base" = "base",
-  "full" = "full",
-  "details" = "details",
   "csv" = "csv",
+  "details" = "details",
+  "full" = "full",
+  "fundamentals" = "fundamentals",
+  "name" = "name",
 }
 
 export enum ListingOrderByKeys {

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -50,6 +50,7 @@ type UseListingsDataProps = PaginationProps & {
   sort?: ColumnOrder[]
   roles?: UserRole
   userJurisdictionIds?: string[]
+  view?: ListingViews
 }
 
 export function useSingleListingData(listingId: string) {
@@ -73,14 +74,15 @@ export function useListingsData({
   sort,
   roles,
   userJurisdictionIds,
+  view,
 }: UseListingsDataProps) {
   const params = {
     page,
     limit,
     filter: [],
     search,
-    view: ListingViews.base,
     $comparison: null,
+    view: view ?? ListingViews.base,
   }
 
   if (sort) {

--- a/sites/partners/src/pages/users/index.tsx
+++ b/sites/partners/src/pages/users/index.tsx
@@ -3,7 +3,7 @@ import Head from "next/head"
 import dayjs from "dayjs"
 import { useSWRConfig } from "swr"
 import { AgTable, useAgTable, t, AlertBox } from "@bloom-housing/ui-components"
-import { User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { ListingViews, User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { Button, Icon } from "@bloom-housing/ui-seeds"
 import { AuthContext } from "@bloom-housing/shared-helpers"
 import Layout from "../../layouts"
@@ -133,6 +133,7 @@ const Users = () => {
 
   const { listingDtos } = useListingsData({
     limit: "all",
+    view: ListingViews.name,
   })
 
   if (error) return <div>{t("t.errorOccurred")}</div>


### PR DESCRIPTION
Releases the below commit from core

Currently in our smallest testing dynos in Heroku, if we have a good number of listings (currently testing with over 300), you're unable to add a partner user. This is because we are fetching every single listing to be able to show the drawer that has checkboxes for each listing to give access. We are fetching much more data than we need to, and we're running out of memory.

We should instead fetch only the name, id, and jurisdiction.

To test, you should add a new partner user and ensure you can check and uncheck individual listings.