### PR TITLE
release: migrate detroit to multiselect questions (#4851)

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -356,4 +356,18 @@ export class ScriptRunnerController {
   ): Promise<SuccessDTO> {
     return await this.scriptRunnerService.updateForgotEmailTranslations(req);
   }
+  @Put('migrateDetroitToMultiselectQuestions')
+  @ApiOperation({
+    summary:
+      'A script that moves preferences and programs to multiselect questions in Detroit db',
+    operationId: 'migrateDetroitToMultiselectQuestions',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async migrateDetroitToMultiselectQuestions(
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.migrateDetroitToMultiselectQuestions(
+      req,
+    );
+  }
 }

--- a/api/src/modules/script-runner.module.ts
+++ b/api/src/modules/script-runner.module.ts
@@ -3,6 +3,7 @@ import { ScriptRunnerController } from '../controllers/script-runner.controller'
 import { ScriptRunnerService } from '../services/script-runner.service';
 import { AmiChartModule } from './ami-chart.module';
 import { FeatureFlagModule } from './feature-flag.module';
+import { MultiselectQuestionModule } from './multiselect-question.module';
 import { PermissionModule } from './permission.module';
 import { PrismaModule } from './prisma.module';
 import { AssetModule } from './asset.module';
@@ -11,6 +12,7 @@ import { AssetModule } from './asset.module';
   imports: [
     AmiChartModule,
     FeatureFlagModule,
+    MultiselectQuestionModule,
     PermissionModule,
     PrismaModule,
     AssetModule,

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -8,8 +8,10 @@ import {
   ReviewOrderTypeEnum,
 } from '@prisma/client';
 import { Request as ExpressRequest } from 'express';
+import https from 'https';
 import { AmiChartService } from './ami-chart.service';
 import { FeatureFlagService } from './feature-flag.service';
+import { MultiselectQuestionService } from './multiselect-question.service';
 import { PrismaService } from './prisma.service';
 import { SuccessDTO } from '../dtos/shared/success.dto';
 import { User } from '../dtos/users/user.dto';
@@ -18,6 +20,7 @@ import { DataTransferDTO } from '../dtos/script-runner/data-transfer.dto';
 import { AmiChartImportDTO } from '../dtos/script-runner/ami-chart-import.dto';
 import { AmiChartCreate } from '../dtos/ami-charts/ami-chart-create.dto';
 import { AmiChartUpdate } from '../dtos/ami-charts/ami-chart-update.dto';
+import MultiselectQuestion from '../dtos/multiselect-questions/multiselect-question.dto';
 import { AmiChartUpdateImportDTO } from '../dtos/script-runner/ami-chart-update-import.dto';
 import { HouseholdMemberRelationship } from '../../src/enums/applications/household-member-relationship-enum';
 import { calculateSkip, calculateTake } from '../utilities/pagination-helpers';
@@ -36,6 +39,7 @@ export class ScriptRunnerService {
     private amiChartService: AmiChartService,
     private featureFlagService: FeatureFlagService,
     private assetService: AssetService,
+    private multiselectQuestionService: MultiselectQuestionService,
     private prisma: PrismaService,
   ) {}
 
@@ -1840,6 +1844,181 @@ export class ScriptRunnerService {
   }
 
   /**
+   *
+   * @param req incoming request object
+   * @returns successDTO
+   * @description migrates the preferences and programs in Detroit to the multiselectQuestions table
+   */
+  async migrateDetroitToMultiselectQuestions(
+    req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    const requestingUser = mapTo(User, req['user']);
+    await this.markScriptAsRunStart(
+      'migrate Detroit to multiselect questions',
+      requestingUser,
+    );
+    const translationURLs = [
+      {
+        url: 'https://raw.githubusercontent.com/bloom-housing/bloom/dev/ui-components/src/locales/general.json',
+        key: 'generalCore',
+      },
+      {
+        url: 'https://raw.githubusercontent.com/bloom-housing/bloom/dev/sites/partners/page_content/locale_overrides/general.json',
+        key: 'generalPartners',
+      },
+      {
+        url: 'https://raw.githubusercontent.com/bloom-housing/bloom/dev/sites/public/page_content/locale_overrides/general.json',
+        key: 'generalPublic',
+      },
+      {
+        url: 'https://raw.githubusercontent.com/CityOfDetroit/bloom/9f2084c107ec865e3c13393e600a5ac45ee5f424/detroit-ui-components/src/locales/general.json',
+        key: 'detroitCore',
+      },
+      {
+        url: 'https://raw.githubusercontent.com/CityOfDetroit/bloom/dev/sites/partners/src/page_content/locale_overrides/general.json',
+        key: 'detroitPartners',
+      },
+      {
+        url: 'https://raw.githubusercontent.com/CityOfDetroit/bloom/dev/sites/public/src/page_content/locale_overrides/general.json',
+        key: 'detroitPublic',
+      },
+    ];
+
+    const translations = {};
+
+    for (let i = 0; i < translationURLs.length; i++) {
+      const { url, key } = translationURLs[i];
+      translations[key] = await this.getTranslationFile(url);
+    }
+
+    // begin migration from preferences
+    const preferences: {
+      id;
+      title;
+      subtitle;
+      description;
+      links;
+      form_metadata;
+    }[] = await this.prisma.$queryRawUnsafe(`
+      SELECT 
+        p.id,
+        p.title,
+        p.subtitle,
+        p.description,
+        p.links,
+        p.form_metadata
+      FROM preferences p
+    `);
+
+    for (let i = 0; i < preferences.length; i++) {
+      const pref = preferences[i];
+      const jurisInfo: { id; name }[] = await this.prisma.$queryRawUnsafe(`
+          SELECT
+            j.id,
+            j.name
+          FROM jurisdictions_preferences_preferences jp
+            JOIN jurisdictions j ON jp.jurisdictions_id = j.id
+          WHERE jp.preferences_id = '${pref.id}'
+      `);
+      const { optOutText, options } = this.resolveOptionValues(
+        pref.form_metadata,
+        'preferences',
+        jurisInfo?.length ? jurisInfo[0].name : '',
+        translations,
+      );
+      await this.multiselectQuestionService.create({
+        text: pref.title,
+        subText: pref.subtitle,
+        description: pref.description,
+        links: pref.links ?? null,
+        hideFromListing: this.resolveHideFromListings(pref),
+        optOutText: optOutText ?? null,
+        options: options,
+        applicationSection:
+          MultiselectQuestionsApplicationSectionEnum.preferences,
+        jurisdictions: jurisInfo.map((juris) => {
+          return { id: juris.id };
+        }),
+      });
+    }
+
+    // begin migration from programs
+    const programs: {
+      id;
+      title;
+      subtitle;
+      description;
+      form_metadata;
+    }[] = await this.prisma.$queryRawUnsafe(`
+      SELECT 
+        p.id,
+        p.title,
+        p.subtitle,
+        p.description,
+        p.form_metadata
+      FROM programs p
+    `);
+
+    for (let i = 0; i < programs.length; i++) {
+      const prog = programs[i];
+      const jurisInfo: { id; name }[] = await this.prisma.$queryRawUnsafe(`
+          SELECT
+            j.id,
+            j.name
+          FROM jurisdictions_programs_programs jp
+            JOIN jurisdictions j ON jp.jurisdictions_id = j.id
+          WHERE jp.programs_id = '${prog.id}'
+        `);
+
+      const res: MultiselectQuestion =
+        await this.multiselectQuestionService.create({
+          text: prog.title,
+          subText: prog.subtitle,
+          description: prog.description,
+          links: null,
+          hideFromListing: this.resolveHideFromListings(prog),
+          optOutText: null,
+          options: null,
+          applicationSection:
+            MultiselectQuestionsApplicationSectionEnum.programs,
+          jurisdictions: jurisInfo.map((juris) => {
+            return { id: juris.id };
+          }),
+        });
+
+      const listingsInfo: { ordinal; listing_id }[] = await this.prisma
+        .$queryRawUnsafe(`
+        SELECT
+          ordinal,
+          listing_id
+        FROM listing_programs
+        WHERE program_id = '${prog.id}';
+      `);
+      for (const listingInfo of listingsInfo) {
+        await this.prisma.listings.update({
+          data: {
+            listingMultiselectQuestions: {
+              create: {
+                ordinal: listingInfo.ordinal,
+                multiselectQuestionId: res.id,
+              },
+            },
+          },
+          where: {
+            id: listingInfo.listing_id,
+          },
+        });
+      }
+    }
+
+    await this.markScriptAsComplete(
+      'migrate Detroit to multiselect questions',
+      requestingUser,
+    );
+    return { success: true };
+  }
+
+  /**
     this is simply an example
   */
   async example(req: ExpressRequest): Promise<SuccessDTO> {
@@ -2856,5 +3035,141 @@ export class ScriptRunnerService {
       requestingUser,
     );
     return { success: true };
+  }
+
+  resolveHideFromListings(pref): boolean {
+    if (pref.form_metadata && 'hideFromListing' in pref.form_metadata) {
+      if (pref.form_metadata.hideFromListing) {
+        return true;
+      }
+      return false;
+    }
+    return null;
+  }
+
+  resolveOptionValues(formMetaData, type, juris, translations) {
+    let optOutText = null;
+    const options = [];
+    let shouldPush = true;
+
+    formMetaData?.options?.forEach((option, index) => {
+      const toPush: Record<string, any> = {
+        ordinal: index + 1,
+        text: this.getTranslated(
+          type,
+          formMetaData.key,
+          option.key === 'preferNotToSay'
+            ? 'preferNotToSay'
+            : `${option.key}.label`,
+          juris,
+          translations,
+        ),
+      };
+
+      if (
+        option.exclusive &&
+        formMetaData.hideGenericDecline &&
+        index !== formMetaData.options.length - 1
+      ) {
+        // for all but the last exlusive option push into options array
+        toPush.exclusive = true;
+      } else if (
+        option.exclusive &&
+        formMetaData.hideGenericDecline &&
+        index === formMetaData.options.length - 1
+      ) {
+        // for the last exclusive option add as optOutText
+        optOutText = this.getTranslated(
+          type,
+          formMetaData.key,
+          option.key === 'preferNotToSay'
+            ? 'preferNotToSay'
+            : `${option.key}.label`,
+          juris,
+          translations,
+        );
+        shouldPush = false;
+      }
+
+      if (option.description) {
+        toPush.description = this.getTranslated(
+          type,
+          formMetaData.key,
+          option.key === 'preferNotToSay'
+            ? 'preferNotToSay'
+            : `${option.key}.description`,
+          juris,
+          translations,
+        );
+      }
+
+      if (option?.extraData.some((extraData) => extraData.type === 'address')) {
+        toPush.collectAddress = true;
+      }
+
+      if (shouldPush) {
+        options.push(toPush);
+      } else {
+        shouldPush = true;
+      }
+    });
+
+    return {
+      optOutText,
+      options: options.length ? options : null,
+    };
+  }
+
+  getTranslated(type, prefKey, translationKey, juris, translations) {
+    let searchKey = `application.${type}.${prefKey}.${translationKey}`;
+    if (translationKey === 'preferNotToSay') {
+      searchKey = 't.preferNotToSay';
+    }
+
+    if (juris === 'Detroit') {
+      if (translations['detroitPublic'][searchKey]) {
+        return translations['detroitPublic'][searchKey];
+      } else if (translations['detroitPartners'][searchKey]) {
+        return translations['detroitPartners'][searchKey];
+      } else if (translations['detroitCore'][searchKey]) {
+        return translations['detroitCore'][searchKey];
+      }
+    }
+
+    if (translations['generalPublic'][searchKey]) {
+      return translations['generalPublic'][searchKey];
+    } else if (translations['generalPartners'][searchKey]) {
+      return translations['generalPartners'][searchKey];
+    } else if (translations['generalCore'][searchKey]) {
+      return translations['generalCore'][searchKey];
+    }
+    return 'no translation';
+  }
+
+  getTranslationFile(url) {
+    return new Promise((resolve, reject) =>
+      https
+        .get(url, (res) => {
+          let body = '';
+
+          res.on('data', (chunk) => {
+            body += chunk;
+          });
+
+          res.on('end', () => {
+            try {
+              const json = JSON.parse(body);
+              resolve(json);
+            } catch (error) {
+              console.error('on end error:', error.message);
+              reject(`parsing broke: ${url}`);
+            }
+          });
+        })
+        .on('error', (error) => {
+          console.error('on error error:', error.message);
+          reject(`getting broke: ${url}`);
+        }),
+    );
   }
 }

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -19,6 +19,7 @@ import { FeatureFlagService } from '../../../src/services/feature-flag.service';
 import { JurisdictionService } from '../../../src/services/jurisdiction.service';
 import { PrismaService } from '../../../src/services/prisma.service';
 import { ScriptRunnerService } from '../../../src/services/script-runner.service';
+import { MultiselectQuestionService } from '../../../src/services/multiselect-question.service';
 import { AssetModule } from '../../../src/modules/asset.module';
 import { PrismaModule } from '../../../src/modules/prisma.module';
 
@@ -27,6 +28,7 @@ const externalPrismaClient = mockDeep<PrismaClient>();
 describe('Testing script runner service', () => {
   let service: ScriptRunnerService;
   let prisma: PrismaService;
+  let multiselectQuestionService: MultiselectQuestionService;
   let mockConsoleLog;
 
   beforeEach(() => {
@@ -40,12 +42,23 @@ describe('Testing script runner service', () => {
         FeatureFlagService,
         JurisdictionService,
         Logger,
+        {
+          provide: MultiselectQuestionService,
+          useValue: {
+            create: jest.fn().mockResolvedValue({
+              id: 'new id',
+            }),
+          },
+        },
       ],
       imports: [AssetModule, PrismaModule],
     }).compile();
 
     service = module.get<ScriptRunnerService>(ScriptRunnerService);
     prisma = module.get<PrismaService>(PrismaService);
+    multiselectQuestionService = module.get<MultiselectQuestionService>(
+      MultiselectQuestionService,
+    );
   });
 
   afterEach(() => {
@@ -2173,6 +2186,83 @@ describe('Testing script runner service', () => {
     expect(prisma.translations.update).toHaveBeenCalledTimes(5);
   });
 
+  it('should migrate preferences and programs to the multiselect question table', async () => {
+    const id = randomUUID();
+    const scriptName = 'migrate Detroit to multiselect questions';
+
+    prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+    prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+    prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+    prisma.$queryRawUnsafe = jest.fn().mockResolvedValue([
+      {
+        id: 'example id',
+        title: 'example title',
+        subtitle: 'example subtitle',
+        description: 'example description',
+        links: [{ url: 'https://www.example.com', title: 'Link Title' }],
+        form_metadata: {
+          key: 'liveWork',
+          options: [
+            { key: 'live', extraData: [] },
+            { key: 'work', extraData: [] },
+          ],
+          hideFromListing: true,
+        },
+        name: 'example name',
+        listing_id: 'example listing_id',
+        ordinal: 1,
+      },
+    ]);
+    prisma.multiselectQuestions.create = jest.fn().mockResolvedValue({
+      id: 'new id',
+    });
+    prisma.listings.update = jest.fn().mockResolvedValue(null);
+
+    const res = await service.migrateDetroitToMultiselectQuestions({
+      user: {
+        id,
+      } as unknown as User,
+    } as unknown as ExpressRequest);
+
+    expect(res.success).toBe(true);
+
+    expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
+      where: {
+        scriptName,
+      },
+    });
+    expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
+      data: {
+        scriptName,
+        triggeringUser: id,
+      },
+    });
+    expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
+      data: {
+        didScriptRun: true,
+        triggeringUser: id,
+      },
+      where: {
+        scriptName,
+      },
+    });
+    expect(prisma.$queryRawUnsafe).toHaveBeenCalledTimes(5);
+    expect(multiselectQuestionService.create).toHaveBeenCalledTimes(2);
+    expect(prisma.listings.update).toHaveBeenCalledWith({
+      data: {
+        listingMultiselectQuestions: {
+          create: {
+            ordinal: 1,
+            multiselectQuestionId: 'new id',
+          },
+        },
+      },
+      where: {
+        id: 'example listing_id',
+      },
+    });
+  }, 100000);
+
   // | ---------- HELPER TESTS BELOW ---------- | //
   it('should mark script run as started if no script run present in db', async () => {
     prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
@@ -2268,6 +2358,234 @@ describe('Testing script runner service', () => {
       where: {
         scriptName,
       },
+    });
+  });
+
+  describe('migrateDetroitToMultiselectQuestions helpers', () => {
+    const translations = {
+      generalCore: {
+        'application.type.core.translationKey': 'general core translation',
+        't.preferNotToSay': 'general core prefer not to say',
+      },
+      generalPartners: {
+        'application.type.partners.translationKey':
+          'general partners translation',
+      },
+      generalPublic: {
+        'application.type.public.translationKey': 'general public translation',
+      },
+      detroitCore: {
+        'application.type.core.translationKey': 'detroit core translation',
+      },
+      detroitPartners: {
+        'application.type.partners.translationKey':
+          'detroit partners translation',
+      },
+      detroitPublic: {
+        'application.type.public.translationKey': 'detroit public translation',
+        'application.preferences.liveWork.live.label': 'Live in city',
+        'application.preferences.liveWork.work.label': 'Work in city',
+        'application.preferences.PBV.residency.label': 'Residency',
+        'application.preferences.PBV.homeless.label': 'Homeless',
+        'application.preferences.PBV.homeless.description':
+          'Unhoused or in temporary housing',
+        'application.preferences.PBV.noneApplyButConsider.label':
+          'None Apply But Consider',
+        'application.preferences.PBV.doNotConsider.label': 'Do Not Consider',
+      },
+    };
+
+    describe('test resolvehideFromListing', () => {
+      it('should find hideFromListing in object and return true', () => {
+        const pref = { form_metadata: { hideFromListing: true } };
+
+        const res = service.resolveHideFromListings(pref);
+
+        expect(res).toBe(true);
+      });
+
+      it('should find hideFromListing in object and return false', () => {
+        const pref = { form_metadata: { hideFromListing: false } };
+
+        const res = service.resolveHideFromListings(pref);
+
+        expect(res).toBe(false);
+      });
+
+      it('should not find hideFromListing in object and return null', () => {
+        const pref1 = {};
+
+        const res1 = service.resolveHideFromListings(pref1);
+
+        expect(res1).toBeNull();
+
+        const pref2 = { form_metadata: {} };
+
+        const res2 = service.resolveHideFromListings(pref2);
+
+        expect(res2).toBeNull();
+      });
+    });
+
+    describe('test resolveOptionValues', () => {
+      it('should resolve simple option values', () => {
+        const formMetaData = {
+          key: 'liveWork',
+          options: [
+            { key: 'live', extraData: [] },
+            { key: 'work', extraData: [] },
+          ],
+        };
+
+        const res = service.resolveOptionValues(
+          formMetaData,
+          'preferences',
+          'Detroit',
+          translations,
+        );
+
+        expect(res).toStrictEqual({
+          optOutText: null,
+          options: [
+            { ordinal: 1, text: 'Live in city' },
+            { ordinal: 2, text: 'Work in city' },
+          ],
+        });
+      });
+
+      it('should resolve complex option values', () => {
+        const formMetaData = {
+          key: 'PBV',
+          options: [
+            {
+              key: 'residency',
+              extraData: [
+                { key: 'name', type: 'text' },
+                { key: 'address', type: 'address' },
+              ],
+            },
+            { key: 'homeless', extraData: [], description: true },
+            {
+              key: 'noneApplyButConsider',
+              exclusive: true,
+              extraData: [],
+            },
+            {
+              key: 'doNotConsider',
+              exclusive: true,
+              extraData: [],
+              description: false,
+            },
+          ],
+          hideGenericDecline: true,
+        };
+
+        const res = service.resolveOptionValues(
+          formMetaData,
+          'preferences',
+          'Detroit',
+          translations,
+        );
+
+        expect(res).toStrictEqual({
+          optOutText: 'Do Not Consider',
+          options: [
+            { ordinal: 1, text: 'Residency', collectAddress: true },
+            {
+              ordinal: 2,
+              text: 'Homeless',
+              description: 'Unhoused or in temporary housing',
+            },
+            { ordinal: 3, text: 'None Apply But Consider', exclusive: true },
+          ],
+        });
+      });
+    });
+
+    describe('test getTranslated', () => {
+      it('should return no translation when no searchkey is matched', () => {
+        const res = service.getTranslated('', '', '', '', translations);
+
+        expect(res).toBe('no translation');
+      });
+
+      it('should return preferNotToSay when translationKey is preferNotToSay', () => {
+        const res = service.getTranslated(
+          '',
+          '',
+          'preferNotToSay',
+          '',
+          translations,
+        );
+
+        expect(res).toBe('general core prefer not to say');
+      });
+
+      it('should return jurisdiction specific translation if found', () => {
+        const res = service.getTranslated(
+          'type',
+          'core',
+          'translationKey',
+          'Detroit',
+          translations,
+        );
+
+        expect(res).toBe('detroit core translation');
+      });
+
+      it('should return generic translation if jurisdiction not found', () => {
+        const res = service.getTranslated(
+          'type',
+          'core',
+          'translationKey',
+          'juris',
+          translations,
+        );
+
+        expect(res).toBe('general core translation');
+      });
+
+      it('should return translation based on full searchkey', () => {
+        const generalPartnersRes = service.getTranslated(
+          'type',
+          'partners',
+          'translationKey',
+          '',
+          translations,
+        );
+
+        expect(generalPartnersRes).toBe('general partners translation');
+
+        const generalPublicRes = service.getTranslated(
+          'type',
+          'public',
+          'translationKey',
+          '',
+          translations,
+        );
+
+        expect(generalPublicRes).toBe('general public translation');
+
+        const detroitPartnersRes = service.getTranslated(
+          'type',
+          'partners',
+          'translationKey',
+          'Detroit',
+          translations,
+        );
+
+        expect(detroitPartnersRes).toBe('detroit partners translation');
+
+        const detroitPublicRes = service.getTranslated(
+          'type',
+          'public',
+          'translationKey',
+          'Detroit',
+          translations,
+        );
+
+        expect(detroitPublicRes).toBe('detroit public translation');
+      });
     });
   });
 });

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2735,6 +2735,22 @@ export class ScriptRunnerService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * A script that moves preferences and programs to multiselect questions in Detroit db
+   */
+  migrateDetroitToMultiselectQuestions(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/migrateDetroitToMultiselectQuestions"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export class FeatureFlagsService {


### PR DESCRIPTION
This PR addresses [#(4763)](https://github.com/bloom-housing/bloom/issues/4763)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Detroit has yet to move to the Multiselect Questions tables. This script moves the preference and program data to the appropriate tables with the correct relationships (jurisdictions, listings).

## How Can This Be Tested/Reviewed?

This does not need to be tested as it is only used in Detroit. As long as tests pass, this can be merged.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
