### PR TITLE
feat: portal of origin script

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -356,6 +356,7 @@ export class ScriptRunnerController {
   ): Promise<SuccessDTO> {
     return await this.scriptRunnerService.updateForgotEmailTranslations(req);
   }
+
   @Put('migrateDetroitToMultiselectQuestions')
   @ApiOperation({
     summary:
@@ -369,5 +370,18 @@ export class ScriptRunnerController {
     return await this.scriptRunnerService.migrateDetroitToMultiselectQuestions(
       req,
     );
+  }
+
+  @Put('markTransferedData')
+  @ApiOperation({
+    summary:
+      'A script that marks transferred data in Doorway as externally created',
+    operationId: 'markTransferedData',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async markTransferedData(
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.markTransferedData(req);
   }
 }

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -2042,20 +2042,24 @@ export class ScriptRunnerService {
         where: { name: 'Alameda' },
       });
 
-    await this.prisma.applications.updateMany({
+    const alamedaAppsCount = await this.prisma.applications.updateMany({
       data: { wasCreatedExternally: true },
       where: {
         appUrl: 'https://housing.acgov.org',
       },
     });
 
-    await this.prisma.listings.updateMany({
+    console.log(`Alameda applications updated: ${alamedaAppsCount}`);
+
+    const alamedaListingsCount = await this.prisma.listings.updateMany({
       data: { wasCreatedExternally: true },
       where: {
         createdAt: { lt: alamedaMigrationDate },
         jurisdictionId: alamedaJurisdiction.id,
       },
     });
+
+    console.log(`Alameda listings updated: ${alamedaListingsCount}`);
 
     const alamedaMultiSelectQuestionIds = (
       await this.multiselectQuestionService.list({
@@ -2070,12 +2074,17 @@ export class ScriptRunnerService {
       .filter((question) => question.createdAt < alamedaMigrationDate)
       .map((question) => question.id);
 
-    await this.prisma.multiselectQuestions.updateMany({
-      data: { wasCreatedExternally: true },
-      where: {
-        id: { in: alamedaMultiSelectQuestionIds },
-      },
-    });
+    const alamedaMultiselectCount =
+      await this.prisma.multiselectQuestions.updateMany({
+        data: { wasCreatedExternally: true },
+        where: {
+          id: { in: alamedaMultiSelectQuestionIds },
+        },
+      });
+
+    console.log(
+      `Alameda multiselectQuestions updated: ${alamedaMultiselectCount}`,
+    );
 
     console.log('Alameda data has been updated');
 
@@ -2090,20 +2099,24 @@ export class ScriptRunnerService {
         where: { name: 'San Mateo' },
       });
 
-    await this.prisma.applications.updateMany({
+    const sanMateoAppsCount = await this.prisma.applications.updateMany({
       data: { wasCreatedExternally: true },
       where: {
         appUrl: 'https://smc.housingbayarea.org',
       },
     });
 
-    await this.prisma.listings.updateMany({
+    console.log(`San Mateo applications updated: ${sanMateoAppsCount}`);
+
+    const sanMateoListingsCount = await this.prisma.listings.updateMany({
       data: { wasCreatedExternally: true },
       where: {
         createdAt: { lt: sanMateo25 },
         jurisdictionId: sanMateoJurisdiction.id,
       },
     });
+
+    console.log(`San Mateo listings updated: ${sanMateoListingsCount}`);
 
     const sanMateoMultiSelectQuestionIds = (
       await this.multiselectQuestionService.list({
@@ -2118,12 +2131,17 @@ export class ScriptRunnerService {
       .filter((question) => question.createdAt < sanMateo22)
       .map((question) => question.id);
 
-    await this.prisma.multiselectQuestions.updateMany({
-      data: { wasCreatedExternally: true },
-      where: {
-        id: { in: sanMateoMultiSelectQuestionIds },
-      },
-    });
+    const sanMateoMultiselectCount =
+      await this.prisma.multiselectQuestions.updateMany({
+        data: { wasCreatedExternally: true },
+        where: {
+          id: { in: sanMateoMultiSelectQuestionIds },
+        },
+      });
+
+    console.log(
+      `San Mateo multiselectQuestions updated: ${sanMateoMultiselectCount}`,
+    );
 
     console.log('San Mateo data has been updated');
 

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -2082,7 +2082,6 @@ export class ScriptRunnerService {
     // San Mateo ==========================================================
     const sanMateoBase = dayjs('2024-10-22 00:00', 'YYYY-MM-DD HH:mm Z');
     const sanMateo22 = sanMateoBase.toDate();
-    const sanMateo24 = sanMateoBase.add(2, 'day').toDate();
     const sanMateo25 = sanMateoBase.add(3, 'day').toDate();
 
     const sanMateoJurisdiction =

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -48,6 +48,15 @@ describe('Testing script runner service', () => {
             create: jest.fn().mockResolvedValue({
               id: 'new id',
             }),
+            list: jest.fn().mockResolvedValue([
+              {
+                id: 'new id',
+                createdAt: dayjs(
+                  '2024-10-22 00:00',
+                  'YYYY-MM-DD HH:mm Z',
+                ).toDate(),
+              },
+            ]),
           },
         },
       ],
@@ -2262,6 +2271,78 @@ describe('Testing script runner service', () => {
       },
     });
   }, 100000);
+
+  it('should mark transfered data', async () => {
+    const id = randomUUID();
+    const scriptName = 'mark transfered data';
+
+    prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+    prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+    prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+    prisma.multiselectQuestions.findMany = jest.fn().mockResolvedValue(null);
+    prisma.applications.updateMany = jest.fn().mockResolvedValue(null);
+    prisma.listings.updateMany = jest.fn().mockResolvedValue(null);
+    prisma.multiselectQuestions.updateMany = jest.fn().mockResolvedValue(null);
+
+    const res = await service.markTransferedData({
+      user: {
+        id,
+      } as unknown as User,
+    } as unknown as ExpressRequest);
+
+    expect(res.success).toBe(true);
+
+    expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
+      where: {
+        scriptName,
+      },
+    });
+    expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
+      data: {
+        scriptName,
+        triggeringUser: id,
+      },
+    });
+    expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
+      data: {
+        didScriptRun: true,
+        triggeringUser: id,
+      },
+      where: {
+        scriptName,
+      },
+    });
+    expect(prisma.applications.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.applications.updateMany).toHaveBeenCalledWith({
+      data: {
+        wasCreatedExternally: true,
+      },
+      where: {
+        appUrl: expect.anything(),
+      },
+    });
+
+    expect(prisma.listings.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.listings.updateMany).toHaveBeenCalledWith({
+      data: {
+        wasCreatedExternally: true,
+      },
+      where: {
+        createdAt: { lt: expect.anything() },
+        jurisdictionId: expect.anything(),
+      },
+    });
+
+    expect(multiselectQuestionService.list).toHaveBeenCalledTimes(2);
+    expect(prisma.multiselectQuestions.updateMany).toHaveBeenCalledWith({
+      data: {
+        wasCreatedExternally: true,
+      },
+      where: {
+        id: { in: ['new id'] },
+      },
+    });
+  });
 
   // | ---------- HELPER TESTS BELOW ---------- | //
   it('should mark script run as started if no script run present in db', async () => {

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -2281,6 +2281,9 @@ describe('Testing script runner service', () => {
     prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
     prisma.multiselectQuestions.findMany = jest.fn().mockResolvedValue(null);
     prisma.applications.updateMany = jest.fn().mockResolvedValue(null);
+    prisma.jurisdictions.findFirstOrThrow = jest
+      .fn()
+      .mockResolvedValue({ id: 'jurisId' });
     prisma.listings.updateMany = jest.fn().mockResolvedValue(null);
     prisma.multiselectQuestions.updateMany = jest.fn().mockResolvedValue(null);
 
@@ -2329,7 +2332,7 @@ describe('Testing script runner service', () => {
       },
       where: {
         createdAt: { lt: expect.anything() },
-        jurisdictionId: expect.anything(),
+        jurisdictionId: 'jurisId',
       },
     });
 

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2751,6 +2751,22 @@ export class ScriptRunnerService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * A script that marks transferred data in Doorway as externally created
+   */
+  markTransferedData(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/markTransferedData"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export class FeatureFlagsService {


### PR DESCRIPTION
This PR addresses #(4977)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Script to update the data in regards to the `wasCreatedExternally` columns.

## How Can This Be Tested/Reviewed?

Using a copy of HBA prod data, insert data into db.
Run `yarn db:migration:run` to add doorway specific migrations

Run backend api
Login as admin
Run script `scriptRunner/markTransferedData`
Check in DB that applications, listings and multiselect questions from Alameda and San Mateo are now marked as true in the `wasCreatedExternally` column on the respective tables.


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
