### PR TITLE
fix: allow not listed with no language

### DIFF
--- a/api/src/services/application-exporter.service.ts
+++ b/api/src/services/application-exporter.service.ts
@@ -656,6 +656,7 @@ export class ApplicationExporterService {
                   sexualOrientation: true,
                   howDidYouHear: true,
                   race: true,
+                  spokenLanguage: true,
                 },
               }
             : false,

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -712,7 +712,10 @@ export const convertDemographicSexualOrientationToReadable = (
  * @returns outputs the readable version of the string
  */
 export const convertDemographicLanguageToReadable = (type: string): string => {
+  // Not Listed is saved as "notListed:<custom text here>"
   const [rootKey, customValue = ''] = type.split(':');
+  let notListedString = 'Not Listed';
+  if (customValue) notListedString = notListedString + `:${customValue}`;
   const typeMap = {
     chineseCantonese: 'Chinese - Cantonese',
     chineseMandarin: 'Chinese - Mandarin',
@@ -722,7 +725,7 @@ export const convertDemographicLanguageToReadable = (type: string): string => {
     russian: 'Russian',
     spanish: 'Spanish',
     vietnamese: 'Vietnamese',
-    notListed: `Not Listed:${customValue}`,
+    notListed: notListedString,
   };
   return typeMap[rootKey] ?? rootKey;
 };

--- a/api/test/unit/utilities/application-export-helpers.spec.ts
+++ b/api/test/unit/utilities/application-export-helpers.spec.ts
@@ -6,6 +6,7 @@ import { UnitType } from '../../../src/dtos/unit-types/unit-type.dto';
 import { InputType } from '../../../src/enums/shared/input-type-enum';
 import {
   addressToString,
+  convertDemographicLanguageToReadable,
   convertDemographicRaceToReadable,
   getExportHeaders,
   getHouseholdCsvHeaders,
@@ -292,6 +293,29 @@ describe('Testing application export helpers', () => {
     it('tests convertDemographicRaceToReadable with type not in typeMap', () => {
       const custom = 'This is a custom value';
       expect(convertDemographicRaceToReadable(custom)).toBe(custom);
+    });
+  });
+
+  describe('Testing convertDemographicLanguageToReadable', () => {
+    it('tests convertDemographicLanguageToReadable with standard key', () => {
+      expect(convertDemographicLanguageToReadable('chineseMandarin')).toEqual(
+        'Chinese - Mandarin',
+      );
+    });
+    it('tests convertDemographicLanguageToReadable with invalid key', () => {
+      expect(convertDemographicLanguageToReadable('wrongKey')).toEqual(
+        'wrongKey',
+      );
+    });
+    it('tests convertDemographicLanguageToReadable with not listed key and custom value', () => {
+      expect(convertDemographicLanguageToReadable('notListed:Greek')).toEqual(
+        'Not Listed:Greek',
+      );
+    });
+    it('tests convertDemographicLanguageToReadable with not listed key and no custom value', () => {
+      expect(convertDemographicLanguageToReadable('notListed:')).toEqual(
+        'Not Listed',
+      );
     });
   });
 

--- a/sites/partners/__tests__/components/applications/sections/FormDemographics.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormDemographics.test.tsx
@@ -96,4 +96,41 @@ describe("<FormDemographics>", () => {
     expect(screen.getByLabelText(/South American/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Other Latino/i)).toBeInTheDocument()
   })
+
+  it("should show spoken language", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormDemographics
+          formValues={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            race: [],
+            howDidYouHear: [],
+          }}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByRole("combobox", { name: "Spoken Language" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Chinese - Cantonese" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Chinese - Mandarin" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "English" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Filipino" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Korean" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Russian" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Spanish" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Vietnamese" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Not Listed" })).toBeInTheDocument()
+    expect(screen.queryAllByRole("textbox", { name: "Please specify:" })).toHaveLength(0)
+
+    await act(async () => {
+      await userEvent.selectOptions(
+        screen.getByRole("combobox", { name: "Spoken Language" }),
+        screen.getByRole("option", { name: "Not Listed" })
+      )
+    })
+
+    expect(screen.getByRole("textbox", { name: "Please specify:" })).toBeInTheDocument()
+  })
 })

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
@@ -74,11 +74,10 @@ const FormDemographics = ({ formValues }: FormDemographicsProps) => {
             <Select
               id="application.demographics.spokenLanguage"
               name="application.demographics.spokenLanguage"
-              placeholder={t("t.selectOne")}
               label={t("application.add.spokenLanguage")}
               register={register}
               controlClassName="control"
-              options={spokenLanguageKeys}
+              options={["", ...spokenLanguageKeys]}
               keyPrefix="application.review.demographics.spokenLanguageOptions"
             />
             {spokenLanguageValue === "notListed" && (
@@ -93,22 +92,20 @@ const FormDemographics = ({ formValues }: FormDemographicsProps) => {
             <Select
               id="application.demographics.gender"
               name="application.demographics.gender"
-              placeholder={t("t.selectOne")}
               label={t("application.add.gender")}
               register={register}
               controlClassName="control"
-              options={genderKeys}
+              options={["", ...genderKeys]}
               keyPrefix="application.review.demographics.genderOptions"
             />
 
             <Select
               id="application.demographics.sexualOrientation"
               name="application.demographics.sexualOrientation"
-              placeholder={t("t.selectOne")}
               label={t("application.add.sexualOrientation")}
               register={register}
               controlClassName="control"
-              options={sexualOrientationKeys}
+              options={["", ...sexualOrientationKeys]}
               keyPrefix="application.review.demographics.sexualOrientationOptions"
             />
           </Grid.Cell>

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
@@ -86,7 +86,6 @@ const FormDemographics = ({ formValues }: FormDemographicsProps) => {
                 id="application.demographics.spokenLanguageNotListed"
                 name="application.demographics.spokenLanguageNotListed"
                 label={t("application.review.demographics.spokenLanguageSpecify")}
-                validation={{ required: true }}
                 register={register}
               />
             )}


### PR DESCRIPTION
This PR addresses #1422 and [This slack message](https://exygy.slack.com/archives/C02G1S19QA2/p1752069802228349)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Doorway would like be able to select "not listed" for spoken language and not be required to enter any additional information in the partner site. The scenario where that is needed is when a paper application comes in with nothing filled in for the "spoken language".

Also a bug was found in the CSV export when you have `APPLICATION_EXPORT_AS_SPREADSHEET` environment variable set to true the "Spoken Language" column is not properly populated

Lastly there is a change here that allows the deselection of a language, gender, and sexual orientation on the paper application if one has been selected

## How Can This Be Tested/Reviewed?

This can be tested by  filling out a paper application and select "Not Listed" for the "Spoken Language" and then don't fill in the field that appears. You should be able to save the listing

Also you should be able to select a spoken language then go back to "select one" and properly save

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
