### PR TITLE
test: auth with api when not testing sign in (#5108)

### DIFF
--- a/sites/partners/cypress/e2e/default/03-listing.spec.ts
+++ b/sites/partners/cypress/e2e/default/03-listing.spec.ts
@@ -1,10 +1,10 @@
 describe("Listing Management Tests", () => {
   beforeEach(() => {
-    cy.login()
+    cy.loginApi()
   })
 
   after(() => {
-    cy.signOut()
+    cy.signOutApi()
   })
 
   it("error messaging & save dialogs", () => {

--- a/sites/partners/cypress/e2e/default/04-application.spec.ts
+++ b/sites/partners/cypress/e2e/default/04-application.spec.ts
@@ -1,10 +1,10 @@
 describe("Application Management Tests", () => {
   before(() => {
-    cy.login()
+    cy.loginApi()
   })
 
   after(() => {
-    cy.signOut()
+    cy.signOutApi()
   })
 
   it("Application grid should display correct number of results", () => {

--- a/sites/partners/cypress/e2e/default/05-paperApplication.spec.ts
+++ b/sites/partners/cypress/e2e/default/05-paperApplication.spec.ts
@@ -1,13 +1,13 @@
 describe("Paper Application Tests", () => {
   beforeEach(() => {
-    cy.login()
+    cy.loginApi()
     cy.visit("/")
     cy.getByTestId("listing-status-cell-Blue Sky Apartments").click()
     cy.getByID("addApplicationButton").contains("Add Application").click()
   })
 
   afterEach(() => {
-    cy.signOut()
+    cy.signOutApi()
   })
 
   it("fill paper application form completely", () => {

--- a/sites/partners/cypress/e2e/default/06-admin-user-mangement.spec.ts
+++ b/sites/partners/cypress/e2e/default/06-admin-user-mangement.spec.ts
@@ -1,10 +1,10 @@
 describe("Admin User Mangement Tests", () => {
   beforeEach(() => {
-    cy.login()
+    cy.loginApi()
   })
 
   afterEach(() => {
-    cy.signOut()
+    cy.signOutApi()
   })
 
   it("as admin user, should show all users regardless of jurisdiction", () => {

--- a/sites/partners/cypress/e2e/default/07-jurisdictional-admin-user-management.spec.ts
+++ b/sites/partners/cypress/e2e/default/07-jurisdictional-admin-user-management.spec.ts
@@ -1,12 +1,12 @@
 describe("Jurisdictional Admin User Mangement Tests", () => {
   beforeEach(() => {
-    cy.login("jurisdictionalAdmin")
+    cy.loginApi("jurisdictionalAdmin")
     cy.visit("/")
     cy.getByTestId("Users-1").click()
   })
 
   afterEach(() => {
-    cy.signOut()
+    cy.signOutApi()
   })
 
   it("as jurisdictional admin user, should only see partners/jurisdictional admins on the same jurisdiction", () => {

--- a/sites/partners/cypress/e2e/default/08-preference-management.spec.ts
+++ b/sites/partners/cypress/e2e/default/08-preference-management.spec.ts
@@ -1,10 +1,10 @@
 describe("Preference Management Tests", () => {
   beforeEach(() => {
-    cy.login()
+    cy.loginApi()
   })
 
   afterEach(() => {
-    cy.signOut()
+    cy.signOutApi()
   })
 
   beforeEach(() => {

--- a/sites/partners/cypress/e2e/default/09-lottery.spec.ts
+++ b/sites/partners/cypress/e2e/default/09-lottery.spec.ts
@@ -1,10 +1,10 @@
 describe("Lottery Tests", () => {
   before(() => {
-    cy.login()
+    cy.loginApi()
   })
 
   after(() => {
-    cy.signOut()
+    cy.signOutApi()
   })
 
   it("can run through every lottery action", () => {
@@ -59,8 +59,8 @@ describe("Lottery Tests", () => {
     cy.getByID("save-user").click()
 
     // Login as partner and view lottery tab
-    cy.signOut()
-    cy.login("partnerUser")
+    cy.signOutApi()
+    cy.loginApi("partnerUser")
     cy.findAndOpenListing(uniqueListingName)
     cy.get(`[role="tab"]`).eq(2).click()
     cy.get("h2").contains("Publish lottery data")
@@ -71,8 +71,8 @@ describe("Lottery Tests", () => {
     cy.get("h2").contains("Export lottery data")
 
     // Login as admin and view lottery tab
-    cy.signOut()
-    cy.login()
+    cy.signOutApi()
+    cy.loginApi()
     cy.findAndOpenListing(uniqueListingName)
     cy.get(`[role="tab"]`).eq(2).click()
     cy.get("h2").contains("Export lottery data")
@@ -83,8 +83,8 @@ describe("Lottery Tests", () => {
     cy.get("h2").contains("Export lottery data")
 
     // Login as partner and view lottery tab, ensure no data
-    cy.signOut()
-    cy.login("partnerUser")
+    cy.signOutApi()
+    cy.loginApi("partnerUser")
     cy.findAndOpenListing(uniqueListingName)
     cy.get(`[role="tab"]`).eq(2).click()
     cy.get("h2").contains("No lottery data")

--- a/sites/partners/cypress/e2e/listings-approval/listings-approval.spec.ts
+++ b/sites/partners/cypress/e2e/listings-approval/listings-approval.spec.ts
@@ -9,15 +9,15 @@ describe("Listings approval feature", () => {
       },
     })
     // Partner: Submit a listing for approval
-    cy.login("jurisdictionalAdminUser")
+    cy.loginApi("jurisdictionalAdminUser")
     cy.visit("/")
 
     cy.addMinimalListing(uniqueListingName, false, true, false)
     cy.getByID("listing-status-pending-review").should("be.visible")
-    cy.signOut()
+    cy.signOutApi()
 
     // Admin: Request changes
-    cy.login("user")
+    cy.loginApi("user")
     cy.findAndOpenListing(uniqueListingName)
     cy.getByID("listing-status-pending-review").should("be.visible")
     cy.getByID("listingEditButton").click()
@@ -25,10 +25,10 @@ describe("Listings approval feature", () => {
     cy.getByTestId("requestedChanges").type("Requested changes test summary")
     cy.getByID("requestChangesButtonConfirm").click()
     cy.getByID("listing-status-changes-requested").should("be.visible")
-    cy.signOut()
+    cy.signOutApi()
 
     // Partner: Can see the requested changes, edit the listing, and resubmit for approval
-    cy.login("jurisdictionalAdminUser")
+    cy.loginApi("jurisdictionalAdminUser")
     cy.findAndOpenListing(uniqueListingName)
     cy.getByID("listing-status-changes-requested").should("be.visible")
     cy.getByID("requestedChanges").contains("Requested changes test summary")
@@ -38,16 +38,16 @@ describe("Listings approval feature", () => {
     cy.getByID("submitButton").contains("Submit").click()
     cy.getByID("submitListingForApprovalButtonConfirm").contains("Submit").click()
     cy.getByTestId("page-header").should("have.text", uniqueListingNameEdited)
-    cy.signOut()
+    cy.signOutApi()
 
     // Admin: Approve and publish
-    cy.login("user")
+    cy.loginApi("user")
     cy.findAndOpenListing(uniqueListingNameEdited)
     cy.getByID("listingEditButton").click()
     cy.getByID("saveAndContinueButton").should("be.visible")
     cy.getByID("listing-status-pending-review").should("be.visible")
     cy.getByID("approveAndPublishButton").click()
     cy.getByID("listing-status-active").should("be.visible")
-    cy.signOut()
+    cy.signOutApi()
   })
 })

--- a/sites/partners/cypress/support/commands.js
+++ b/sites/partners/cypress/support/commands.js
@@ -47,13 +47,17 @@ Cypress.Commands.add("loginAndAcceptTerms", (fix = "user") => {
   })
 })
 
-Cypress.Commands.add("login", (fix = "user") => {
-  cy.visit("/")
+// Authenticate via api for tests not explicitly testing login functionality
+Cypress.Commands.add("loginApi", (fix = "user") => {
   cy.fixture(fix).then((user) => {
-    cy.get("input#email").type(user.email)
-    cy.get("input#password").type(user.password)
-    cy.get("button").contains("Sign In").click()
-    cy.contains("Listings")
+    cy.request("POST", "/api/adapter/auth/login", {
+      email: user.email,
+      password: user.password,
+    }).then((response) => {
+      expect(response.status).eq(201)
+      expect(response).to.have.property("headers")
+      cy.getCookie("access-token").should("exist")
+    })
   })
 })
 
@@ -73,6 +77,14 @@ Cypress.Commands.add("loginWithMfa", () => {
 Cypress.Commands.add("signOut", () => {
   cy.get("button").contains("Sign Out").click()
   cy.get("input#email")
+})
+
+Cypress.Commands.add("signOutApi", (fix = "user") => {
+  cy.fixture(fix).then((user) => {
+    cy.request("GET", "/api/adapter/auth/logout").then((response) => {
+      expect(response.status).eq(200)
+    })
+  })
 })
 
 Cypress.Commands.add("verifyAlertBox", () => {

--- a/sites/partners/cypress/support/index.d.ts
+++ b/sites/partners/cypress/support/index.d.ts
@@ -14,7 +14,7 @@ declare namespace Cypress {
     getByID(value: string): Chainable<Element>
     getByTestId(value: string): Chainable<Element>
     loginAndAcceptTerms(fixture?: string): Chainable
-    login(fixture?: string): Chainable
+    loginApi(fixture?: string): Chainable
     loginWithMfa(): Chainable
     attachFile(command: string, optionalProcessingConfig: attachFileSubjectArgs): Chainable
     verifyAlertBox(): Chainable
@@ -34,6 +34,7 @@ declare namespace Cypress {
     verifyTerms(value: Record<string, string>, fieldsToSkip?: string[]): Chainable
     fillMailingAddress(value: Record<string, string>, fieldsToSkip?: string[]): Chainable
     signOut(): Chainable
+    signOutApi(): Chainable
     fillFields(
       obj: Record<string, string>,
       fieldsToType: fieldObj[],


### PR DESCRIPTION
This PR addresses #5086 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR removes the necessity of walking through the login page UI before starting each test. Instead authentication is handled via an api whenever the test is not explicitly testing the login functionality.

The goal of this change is to speed up and reduce flakiness of tests by removing unnecessary UI steps.

Changes were only made to the partner site tests. I believe it makes sense for the tests in the public site currently using a shared signin function to continue walking through the UI.

## How Can This Be Tested/Reviewed?

No functional changes introduced. All tests should continue to pass as before.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
