### PR TITLE
chore: set seeds for circleci (#5231)

### DIFF
--- a/sites/public/cypress.config.ts
+++ b/sites/public/cypress.config.ts
@@ -35,7 +35,8 @@ export default defineConfig({
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
     experimentalRunAllSpecs: true,
     env: {
-      showSeedsDesign: process.env.SHOW_NEW_SEEDS_DESIGNS,
+      showSeedsDesign: process.env.SHOW_NEW_SEEDS_DESIGNS === "TRUE",
+      runAccessibilityTests: process.env.RUN_ACCESSIBILITY_E2E_TESTS === "TRUE",
     },
   },
 


### PR DESCRIPTION
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Our cypress config was simply checking if `SHOW_NEW_SEEDS_DESIGNS` was set, not the value. This was causing failures when we set it to FALSE. Fix is needed to improve HBA & Doorway seed data and testing.

## How Can This Be Tested/Reviewed?

In your local public/.env file, set `SHOW_NEW_SEEDS_DESIGNS` to FALSE
Run application
Run public Cypress tests
application-submit test should pass

In your local public/.env file, set `SHOW_NEW_SEEDS_DESIGNS` to TRUE
Run application
Run public Cypress tests
application-submit test should pass

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
