### PR TITLE
fix: use position to click on correct cluster

### DIFF
--- a/sites/public/cypress/e2e/pages/listings-map.spec.ts
+++ b/sites/public/cypress/e2e/pages/listings-map.spec.ts
@@ -68,7 +68,7 @@ describe("Listings map", function () {
     cy.get("@listingsSearch.all").should("have.length", 2)
 
     // Click into another cluster
-    cy.get('[position="38.00311508029071,-121.8022781610489"]').contains("3").click({ force: true })
+    cy.get('[position="38.00311508029071,-121.8022781610489"]').contains("3").click()
     waitForLoading()
     // Flaky area of test, logging results to help troubleshoot when it fails
     logTotalMapResults()


### PR DESCRIPTION
This PR addresses #1290

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Logs indicate that the map test is failing in the same spot each time, selecting a map cluster of 3 and expecting total results to be 6. This PR updates the selector for the map cluster to be the specific cluster intended by selecting on the map position instead of the aria-label. This will help narrow down the potential cause of flakiness by eliminating the possibility it may be clicking on the incorrect map cluster. I have also removed [{force: true} ](https://docs.cypress.io/app/core-concepts/interacting-with-elements#Forcing) because I believe we want the built in cypress checks in place for this interaction.

## How Can This Be Tested/Reviewed?

All automated tests continue to pass.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
