### PR TITLE
Fix: Fix issue causing rent value duplication when changing rent determination type

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
@@ -8,6 +8,7 @@ import { fieldHasError } from "../../../lib/helpers"
 import {
   AmiChartItem,
   EnumUnitGroupAmiLevelMonthlyRentDeterminationType,
+  UnitGroupAmiLevel,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { TempAmiLevel } from "../../../lib/listings/formTypes"
 
@@ -31,7 +32,8 @@ const UnitGroupAmiForm = ({
   const [amiChartPercentageOptions, setAmiChartPercentageOptions] = useState([])
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, control, trigger, clearErrors, setValue, getValues, errors, reset } = useForm()
+  const { register, control, trigger, clearErrors, setValue, getValues, errors, reset } =
+    useForm<UnitGroupAmiLevel>()
 
   const amiChartID: string = useWatch({
     control,
@@ -88,6 +90,16 @@ const UnitGroupAmiForm = ({
       createdAt: undefined,
       updatedAt: undefined,
       ...data,
+      ...(data.monthlyRentDeterminationType ===
+      EnumUnitGroupAmiLevelMonthlyRentDeterminationType.flatRent
+        ? {
+            flatRentValue: data.flatRentValue,
+            percentageOfIncomeValue: null,
+          }
+        : {
+            percentageOfIncomeValue: data.percentageOfIncomeValue,
+            flatRentValue: null,
+          }),
     }
 
     const current = amiLevels.find((summary) => summary.tempId === currentTempId)
@@ -140,7 +152,7 @@ const UnitGroupAmiForm = ({
                     labelClassName="sr-only"
                     controlClassName="control"
                     register={register}
-                    error={fieldHasError(errors?.amiChart)}
+                    error={fieldHasError(errors?.amiChart?.id)}
                     errorMessage={t("errors.requiredFieldError")}
                     validation={{ required: true }}
                     inputProps={{
@@ -189,7 +201,7 @@ const UnitGroupAmiForm = ({
                         readerOnly
                         register={register}
                         type="number"
-                        error={errors?.flatRentValue}
+                        error={fieldHasError(errors?.flatRentValue)}
                         errorMessage={t("errors.requiredFieldError")}
                         validation={{ required: true }}
                       />
@@ -203,7 +215,7 @@ const UnitGroupAmiForm = ({
                         readerOnly
                         register={register}
                         type="number"
-                        error={errors?.percentageOfIncomeValue}
+                        error={fieldHasError(errors?.percentageOfIncomeValue)}
                         errorMessage={t("errors.requiredFieldError")}
                         validation={{ required: true }}
                       />


### PR DESCRIPTION
This PR addresses #5204 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Adds rent value clearing for the currently unselected monthly rent determination type (this fixes the issue where listings are falsely filtered)

## How Can This Be Tested/Reviewed?

* On the partner's site, create a new listing with a unit group where the Eligibility has % of income set
* Publish the listing. Then click Edit.
* Edit the unit group eligibility from % of income to a flat rate (Ex. 1500)
* Access Prisma Studio and make sure that the `percentageOfIncomeValue` field for this unit group has been cleared
* On the  public sites `/listing` page, filter for a rent range where that listing will fall outside of the range (ex min rent $0, max rent $1)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
