### PR TITLE
fix: public 404 error around what to expect

### DIFF
--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -979,14 +979,16 @@ export const ListingView = (props: ListingProps) => {
               </div>
             )}
             {lotterySection}
-            <ExpandableSection
-              content={<Markdown className={"bloom-markdown"}>{listing.whatToExpect}</Markdown>}
-              strings={{
-                title: t("whatToExpect.label"),
-                readMore: t("t.readMore"),
-                readLess: t("t.readLess"),
-              }}
-            />
+            {listing.whatToExpect && (
+              <ExpandableSection
+                content={<Markdown className={"bloom-markdown"}>{listing.whatToExpect}</Markdown>}
+                strings={{
+                  title: t("whatToExpect.label"),
+                  readMore: t("t.readMore"),
+                  readLess: t("t.readLess"),
+                }}
+              />
+            )}
             {!appOpenInFuture && (
               <Contact
                 sectionTitle={t("leasingAgent.contact")}


### PR DESCRIPTION
This PR addresses [#(5354)](https://github.com/bloom-housing/bloom/issues/5354)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description
When the "What To Expect" field is not set (aka null) on the partners site, attempting to open the Listing Details page on the public site throws a 404 not found error as the Markdown does not expect null.

These are fixed by checking if there is a value in the "What To Expect" field on the Public site.

## How Can This Be Tested/Reviewed?

Create/Edit a listing on the Partner site. Delete the default text from the "What To Expect" field. Save changes/publish listing.
Go to the above listing on the Public site. Make sure you can see the listing and that no "What To Expect" section is present.
Go back to the Partners site and edit the listing. Add some text into the field.
Back to Public site again. Make sure you can see the text that was added to the "What To Expect" section.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
