### PR TITLE
fix: additional help link correction

### DIFF
--- a/sites/public/src/components/page/Content404Deprecated.tsx
+++ b/sites/public/src/components/page/Content404Deprecated.tsx
@@ -16,7 +16,7 @@ export const Content404Deprecated = () => {
       <div className="homepage-extra">
         <MaxWidthLayout className={"seeds-p-b-container"}>
           <p className={"seeds-m-be-header text-center"}>{t("welcome.seeMoreOpportunities")}</p>
-          <Button variant="primary-outlined" href="/additional-resources">
+          <Button variant="primary-outlined" href="/help/housing-help">
             {t("welcome.viewAdditionalHousing")}
           </Button>
         </MaxWidthLayout>


### PR DESCRIPTION
- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Previous PR accidentally changed the path of the additional help button on the [404 page](https://housingbayarea.mtc.ca.gov/404).

## How Can This Be Tested/Reviewed?

Cause a 404 error on the public site.
Click on the additional help button

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
