### PR TITLE
fix: put what to expect additional text behind feature flag (#5425)

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -175,6 +175,7 @@ export const stagingSeed = async (
         FeatureFlagEnum.enableSection8Question,
         FeatureFlagEnum.enableSingleUseCode,
         FeatureFlagEnum.enableUtilitiesIncluded,
+        FeatureFlagEnum.enableWhatToExpectAdditionalField,
       ],
       languages: Object.values(LanguagesEnum),
       requiredListingFields: [
@@ -228,6 +229,7 @@ export const stagingSeed = async (
         FeatureFlagEnum.hideCloseListingButton,
         FeatureFlagEnum.swapCommunityTypeWithPrograms,
         FeatureFlagEnum.enableFullTimeStudentQuestion,
+        FeatureFlagEnum.enableWhatToExpectAdditionalField,
       ],
       requiredListingFields: ['name', 'listingsBuildingAddress'],
       languages: [

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -32,6 +32,7 @@ export enum FeatureFlagEnum {
   enableUnitGroups = 'enableUnitGroups',
   enableUtilitiesIncluded = 'enableUtilitiesIncluded',
   enableWaitlistAdditionalFields = 'enableWaitlistAdditionalFields',
+  enableWhatToExpectAdditionalField = 'enableWhatToExpectAdditionalField',
   enableV2MSQ = 'enableV2MSQ',
   example = 'example', // sample feature flag for testing purposes
   hideCloseListingButton = 'hideCloseListingButton',
@@ -200,6 +201,11 @@ export const featureFlagMap: { name: string; description: string }[] = [
     name: FeatureFlagEnum.enableWaitlistAdditionalFields,
     description:
       'When true, the waitlist additional fields are displayed in the waitlist section of the listing form',
+  },
+  {
+    name: FeatureFlagEnum.enableWhatToExpectAdditionalField,
+    description:
+      'When true, the what to expect additional field is displayed in listing creation/edit form on the partner site',
   },
   {
     name: FeatureFlagEnum.enableV2MSQ,

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -7754,6 +7754,7 @@ export enum FeatureFlagEnum {
   "enableUnitGroups" = "enableUnitGroups",
   "enableUtilitiesIncluded" = "enableUtilitiesIncluded",
   "enableWaitlistAdditionalFields" = "enableWaitlistAdditionalFields",
+  "enableWhatToExpectAdditionalField" = "enableWhatToExpectAdditionalField",
   "enableV2MSQ" = "enableV2MSQ",
   "example" = "example",
   "hideCloseListingButton" = "hideCloseListingButton",

--- a/sites/partners/__tests__/components/listings/PaperListingForm/index.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/index.test.tsx
@@ -195,6 +195,8 @@ describe("add listing", () => {
             switch (featureFlag) {
               case FeatureFlagEnum.swapCommunityTypeWithPrograms:
                 return false
+              case FeatureFlagEnum.enableWhatToExpectAdditionalField:
+                return true
               default:
                 return false
             }
@@ -415,7 +417,6 @@ describe("add listing", () => {
     })
 
     unrequiredFields.forEach((fieldName) => {
-      console.log(fieldName)
       const query = screen.getAllByText(fieldName)
       expect(query[0].textContent).not.toContain("*")
     })

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -27,6 +27,11 @@ const DetailRankingsAndResults = () => {
     listing.jurisdictions.id
   )
 
+  const enableWhatToExpectAdditionalField = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableWhatToExpectAdditionalField,
+    listing.jurisdictions.id
+  )
+
   const lotteryEvent = getLotteryEvent(listing)
   const getReviewOrderType = () => {
     if (!listing.reviewOrderType) {
@@ -134,14 +139,19 @@ const DetailRankingsAndResults = () => {
           </FieldValue>
         </Grid.Cell>
       </Grid.Row>
-      <Grid.Row>
-        <FieldValue
-          id="whatToExpectAdditionalText"
-          label={t("listings.whatToExpectAdditionalText")}
-        >
-          {getDetailFieldRichText(listing.whatToExpectAdditionalText, "whatToExpectAdditionalText")}
-        </FieldValue>
-      </Grid.Row>
+      {enableWhatToExpectAdditionalField && (
+        <Grid.Row>
+          <FieldValue
+            id="whatToExpectAdditionalText"
+            label={t("listings.whatToExpectAdditionalText")}
+          >
+            {getDetailFieldRichText(
+              listing.whatToExpectAdditionalText,
+              "whatToExpectAdditionalText"
+            )}
+          </FieldValue>
+        </Grid.Row>
+      )}
     </SectionWithGrid>
   )
 }

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -83,6 +83,11 @@ const RankingsAndResults = ({
     selectedJurisdictionId
   )
 
+  const enableWhatToExpectAdditionalField = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableWhatToExpectAdditionalField,
+    selectedJurisdictionId
+  )
+
   // Ensure the lottery fields only show when it's "available units" listing
   const showLotteryFields =
     (availabilityQuestion !== "openWaitlist" || enableUnitGroups) &&
@@ -380,21 +385,23 @@ const RankingsAndResults = ({
             />
           </Grid.Cell>
         </Grid.Row>
-        <Grid.Row columns={3}>
-          <Grid.Cell className="seeds-grid-span-2">
-            <TextEditor
-              editor={whatToExpectAdditionalTextEditor}
-              editorId={"whatToExpectAdditionalText"}
-              error={fieldHasError(errors?.whatToExpectAdditionalText)}
-              label={getLabel(
-                "whatToExpectAdditionalText",
-                requiredFields,
-                t("listings.whatToExpectAdditionalTextLabel")
-              )}
-              errorMessage={fieldMessage(errors.whatToExpectAdditionalText)}
-            />
-          </Grid.Cell>
-        </Grid.Row>
+        {enableWhatToExpectAdditionalField && (
+          <Grid.Row columns={3}>
+            <Grid.Cell className="seeds-grid-span-2">
+              <TextEditor
+                editor={whatToExpectAdditionalTextEditor}
+                editorId={"whatToExpectAdditionalText"}
+                error={fieldHasError(errors?.whatToExpectAdditionalText)}
+                label={getLabel(
+                  "whatToExpectAdditionalText",
+                  requiredFields,
+                  t("listings.whatToExpectAdditionalTextLabel")
+                )}
+                errorMessage={fieldMessage(errors.whatToExpectAdditionalText)}
+              />
+            </Grid.Cell>
+          </Grid.Row>
+        )}
       </SectionWithGrid>
     </>
   )

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -106,7 +106,7 @@ const getUnhiddenMultiselectQuestions = (
 export const ListingView = (props: ListingProps) => {
   const { initialStateLoaded, profile, doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
   let buildingSelectionCriteria, preferencesSection, programsSection
-  const { listing } = props
+  const { listing, jurisdiction } = props
 
   const statusContent = getListingApplicationStatus(listing)
 
@@ -982,6 +982,17 @@ export const ListingView = (props: ListingProps) => {
             {listing.whatToExpect && (
               <ExpandableSection
                 content={<Markdown className={"bloom-markdown"}>{listing.whatToExpect}</Markdown>}
+                expandableContent={
+                  listing.whatToExpectAdditionalText &&
+                  isFeatureFlagOn(
+                    jurisdiction,
+                    FeatureFlagEnum.enableWhatToExpectAdditionalField
+                  ) ? (
+                    <Markdown className={"bloom-markdown"}>
+                      {listing.whatToExpectAdditionalText}
+                    </Markdown>
+                  ) : undefined
+                }
                 strings={{
                   title: t("whatToExpect.label"),
                   readMore: t("t.readMore"),

--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -9,7 +9,7 @@ import {
   ListingsStatusEnum,
   User,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { ExpandableSection, t } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
 import {
   AuthContext,
   MessageContext,
@@ -140,15 +140,16 @@ export const ListingViewSeeds = ({ listing, jurisdiction, profile, preview }: Li
           <div className={"bloom-markdown"}>
             <Markdown>{listing.whatToExpect}</Markdown>
           </div>
-          {listing.whatToExpectAdditionalText && (
-            <div>
-              <ReadMore
-                className={"bloom-markdown"}
-                maxLength={0}
-                content={listing.whatToExpectAdditionalText}
-              />
-            </div>
-          )}
+          {listing.whatToExpectAdditionalText &&
+            isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableWhatToExpectAdditionalField) && (
+              <div>
+                <ReadMore
+                  className={"bloom-markdown"}
+                  maxLength={0}
+                  content={listing.whatToExpectAdditionalText}
+                />
+              </div>
+            )}
         </InfoCard>
       )}
     </>


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Pulls over this commit from core:
fix: put what to expect additional text behind feature flag (#5425) 

## How Can This Be Tested/Reviewed?

The "What to expect addition text" form field should not appear on any of the Doorway jurisdictions

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
