### PR TITLE
feat: Waitlist Lottery - Adjust Doorway Listing Type Filter doorway

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -349,7 +349,7 @@ export class ListingService implements OnModuleInit {
           FilterAvailabilityEnum.waitlistOpen
         ) {
           whereClauseArray.push(
-            `combined.review_order_type in {'waitlist', 'waitlistLottery'}`,
+            `combined.review_order_type IN ('waitlist', 'waitlistLottery')`,
           );
         } else if (
           filter[ListingFilterKeys.availability] ===


### PR DESCRIPTION
This PR addresses #5506

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The purpose of this change is to return also waitlist lotteries listing type when filtered by `FilterAvailabilityEnum.waitlistOpen`

## How Can This Be Tested/Reviewed?

1. Go to the partners site and create two listing. 

-  open waitlist lottery
-  available units

2. Go to the public site, select the filter and filter by open waitlist

-  should see the open waitlist lottery listing you created

3. select the filter and filter by available units

- should see the available units listing you created

Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
