### PR TITLE
fix: open waitlist stays set

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -115,8 +115,7 @@ export const stagingSeed = async (
   });
   const napaCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Napa', {
-      listingApprovalPermissions,
-      duplicateListingPermissions,
+      ...doorwaySpecificSettings,
     }),
   });
   const sanFranciscoCounty = await prismaClient.jurisdictions.create({
@@ -136,8 +135,7 @@ export const stagingSeed = async (
   });
   const solanaCounty = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Solano', {
-      listingApprovalPermissions,
-      duplicateListingPermissions,
+      ...doorwaySpecificSettings,
     }),
   });
   const sonomaCounty = await prismaClient.jurisdictions.create({

--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -398,7 +398,7 @@ const FormUnits = ({
                     id: "openWaitlist",
                     dataTestId: "listingAvailability.openWaitlist",
                     defaultChecked:
-                      listing?.reviewOrderType === ReviewOrderTypeEnum.waitlist &&
+                      listing?.reviewOrderType === ReviewOrderTypeEnum.waitlist ||
                       listing?.reviewOrderType === ReviewOrderTypeEnum.waitlistLottery,
                     disabled:
                       disableListingAvailability &&


### PR DESCRIPTION
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Issue was found during bug bash where a listing that was set to Open Waitlist did not have the default set correctly when editing. This is due to an error from a merge from core. Button now correctly reflects the existing value.

Additionally move Napa and Solano to the doorway standard seeding.

## How Can This Be Tested/Reviewed?

Run app
Little Village Apartments is seed with Open Waitlist set. Open listing, click edit, verify Open Waitlist is selected.
Create a new listing and set Open Waitlist and Lottery to true. Save/Publish
Edit new listing, verify Open Waitlist is selected.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
