### PR TITLE
fix: make contact preferences nullable

### DIFF
--- a/api/prisma/migrations/40_contact_preferences_nullable/migration.sql
+++ b/api/prisma/migrations/40_contact_preferences_nullable/migration.sql
@@ -1,0 +1,5 @@
+-- Remove NULL requirement
+ALTER TABLE
+    "applications"
+ALTER COLUMN
+    "contact_preferences" DROP NOT NULL;


### PR DESCRIPTION
This PR addresses issue found during bash

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Application submissions on the public site are failing in the deployed environments because of a requirement for `contact_preferences` in the applications table. This was not caught in core or the PR because this requirement is from before the prisma change-over and the contact preferences are returned from the application submission everywhere except for Doorway

## How Can This Be Tested/Reviewed?

Locally you won't see any differences as it already works correctly. The migration should run as expected and the `contact_preferences` should remain as a nullable field

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
