### PR TITLE
fix: waitlist lottery public search

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -354,7 +354,9 @@ export class ListingService implements OnModuleInit {
           filter[ListingFilterKeys.availability] ===
           FilterAvailabilityEnum.unitsAvailable
         ) {
-          whereClauseArray.push(`combined.units_available >= 1`);
+          whereClauseArray.push(
+            `combined.review_order_type IN ('lottery', 'firstComeFirstServe')`,
+          );
         }
         if (filter[ListingFilterKeys.monthlyRent]) {
           includeUnitFiltering = true;


### PR DESCRIPTION
This PR addresses #1481

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Filtering on Doorway public site is different than core as it uses the combinedListing endpoint. So a change specific in the Doorway repo is needed

## How Can This Be Tested/Reviewed?

1. Add a listing in partners that is of type waitlistLottery ("open waitlist" and "lottery")
2. Go to the public site and from either the home page or the listing search page filter by "Opportunity type"
<img width="592" height="103" alt="image" src="https://github.com/user-attachments/assets/362590b2-3c90-4ff5-8c67-57b85b884ace" />
3. The new listing should only appear in the "open waitlist" filtered results and not "available units"

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
