### PR TITLE
fix: update node version in dockerfile

### DIFF
--- a/build/docker/Dockerfile.backend
+++ b/build/docker/Dockerfile.backend
@@ -1,10 +1,10 @@
 ARG ECR_ACCOUNT_ID
 ARG ECR_REGION
 
-FROM --platform=linux/amd64 ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:16.3.0
+FROM --platform=linux/amd64 ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:22.15.0
 
 # The source stage will contain only the necessary source code
-FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:18.20-alpine AS source
+FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:22.15-alpine AS source
 
 RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 
@@ -51,7 +51,7 @@ CMD yarn test
 #####################
 
 # The build stage builds the code using the dependencies from the deps stage
-FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:18.20-alpine AS build
+FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:22.15-alpine AS build
 
 RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 
@@ -73,7 +73,7 @@ RUN yarn build
 #####################
 
 # The optimize stage contains only dependencies needed to run the service
-FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:18.20-alpine AS optimize
+FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:22.15-alpine AS optimize
 
 RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 
@@ -102,7 +102,7 @@ RUN yarn prisma generate
 #####################
 
 # The run stage contains an optimized image for running the application
-FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:18.20-alpine AS run
+FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:22.15-alpine AS run
 
 RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 

--- a/build/docker/Dockerfile.sites-generic
+++ b/build/docker/Dockerfile.sites-generic
@@ -29,7 +29,7 @@ ARG ECR_ACCOUNT_ID
 ARG ECR_REGION
 
 # The base image will contain all the source code needed for our site
-FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:18.20-alpine AS base
+FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:22.15.0-alpine AS base
 
 # https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine
 RUN apk add --no-cache libc6-compat
@@ -199,7 +199,7 @@ RUN yarn install --frozen-lockfile --only=production
 ARG ECR_ACCOUNT_ID
 ARG ECR_REGION
 # The run stage is used to run our optimized app
-FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:18.20-alpine AS run
+FROM ${ECR_ACCOUNT_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/docker-hub/library/node:22.15.0-alpine AS run
 
 ARG SITE
 


### PR DESCRIPTION
This PR addresses release fixes

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

With the recent upgrade of node we need to have the node version defined in the Dockerfiles

## How Can This Be Tested/Reviewed?

This is hard to test locally because the docker image is pulled through the AWS ECR during the deploy pipeline.

I tested this by changing the import lines to no longer use the ECR passthrough, however this just tests that the new node version works and not if it will build in AWS. That requires merging.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
