### PR TITLE
fix: correct import for test

### DIFF
--- a/sites/public/__tests__/components/account/PasswordExpiredModal.test.tsx
+++ b/sites/public/__tests__/components/account/PasswordExpiredModal.test.tsx
@@ -3,8 +3,7 @@ import { useRouter } from "next/router"
 // eslint-disable-next-line import/no-named-as-default
 import PasswordExpiredModal from "../../../src/components/account/PasswordExpiredModal"
 import userEvent from "@testing-library/user-event"
-import { waitFor } from "../../../../partners/__tests__/testUtils"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 
 jest.mock("next/router", () => ({
   useRouter: jest.fn(),


### PR DESCRIPTION
This PR addresses release fix

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

There is an import in the test file for public pointing to the partners util file. This shouldn't be the case and the test won't run in the AWS environment with the incorrect path

## How Can This Be Tested/Reviewed?

All tests should pass


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
