### PR TITLE
fix: set draft applications to submitted

### DIFF
--- a/api/prisma/migrations/42_application_status_waitlist_fields/migration.sql
+++ b/api/prisma/migrations/42_application_status_waitlist_fields/migration.sql
@@ -1,10 +1,6 @@
-/*
-  Warnings:
-
-  - The values [draft,removed] on the enum `application_status_enum` will be removed. If these variants are still used in the database, this will fail.
-*/
 -- AlterEnum
 BEGIN;
+UPDATE applications SET status = 'submitted' where status = 'draft';
 CREATE TYPE "application_status_enum_new" AS ENUM ('submitted', 'declined', 'receivedUnit', 'waitlist', 'waitlistDeclined');
 ALTER TABLE "applications" ALTER COLUMN "status" TYPE "application_status_enum_new" USING ("status"::text::"application_status_enum_new");
 ALTER TYPE "application_status_enum" RENAME TO "application_status_enum_old";


### PR DESCRIPTION
This PR addresses - release fix

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

One of the new migrations added in the latest Doorway release PR included a change to application statuses. We were only ever using the "submitted" status so it seemed ok to fully remove the "draft" status without any issues. However the [power BI script](https://github.com/metrotranscom/doorway-lambdas/blob/main/lib/applications/applications.ts#L444) to upload paper applications in Doorway is setting all submitted applications to have the status "draft".

This PR updates the migration to first set the status of all of those applications to "submitted" before updating the enum of application statuses.

An additional change will be needed to update the doorway-lambda script

## How Can This Be Tested/Reviewed?

You will need to setup the application without the `42_application_status_waitlist_fields` migration in order to get the real experience which can be done via these steps

1. Delete the `api/prisma/migrations/42_application_status_waitlist_fields/` directory from the code base. Or move it temporarily outside of the `migrations` directory.
2. Run all migrations and reseed
3. Update at least one application manually to have status of "draft"
4. Re-add the `api/prisma/migrations/42_application_status_waitlist_fields/` directory and `migration.sql` file
5. Run `yarn db:migration:run` in the api directory


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
