### PR TITLE
fix: review order type selection fixes (#5807)

### DIFF
--- a/shared-helpers/src/utilities/events.ts
+++ b/shared-helpers/src/utilities/events.ts
@@ -1,7 +1,7 @@
 import { Listing, ListingEvent, ListingEventsTypeEnum } from "../types/backend-swagger"
 
 export const getLotteryEvent = (listing: Listing): ListingEvent | undefined => {
-  return listing?.listingEvents.find(
+  return listing?.listingEvents?.find(
     (event) => event.type === ListingEventsTypeEnum.publicLottery && event.startDate
   )
 }

--- a/sites/partners/__tests__/components/listings/PaperListingForm/sections/RankingsAndResults.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/sections/RankingsAndResults.test.tsx
@@ -1,6 +1,11 @@
 import React from "react"
+import {
+  Listing,
+  ReviewOrderTypeEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { setupServer } from "msw/node"
-import { screen } from "@testing-library/react"
 import RankingsAndResults from "../../../../../src/components/listings/PaperListingForm/sections/RankingsAndResults"
 import { formDefaults } from "../../../../../src/lib/listings/formTypes"
 import {
@@ -9,7 +14,6 @@ import {
   mockTipTapEditor,
   render,
 } from "../../../../testUtils"
-import userEvent from "@testing-library/user-event"
 
 const server = setupServer()
 beforeAll(() => {
@@ -19,11 +23,11 @@ beforeAll(() => {
 })
 
 describe("RankingsAndResults", () => {
-  describe("RankingsAndResults enableWaitlistLottery", () => {
+  describe("Review Order", () => {
     afterEach(() => server.resetHandlers())
     afterAll(() => server.close())
 
-    it("should not show lottery fields when enableWaitlistLottery is false and waitlist is open", async () => {
+    it("should only show waitlist fields when enableWaitlistLottery is false and waitlist is open", async () => {
       render(
         <FormProviderWrapper
           values={{
@@ -44,25 +48,42 @@ describe("RankingsAndResults", () => {
         </FormProviderWrapper>
       )
 
-      await screen.findByText("Rankings & results")
-
-      const waitlistYesRadio = await screen.findByRole("radio", { name: "Yes" })
-      await userEvent.click(waitlistYesRadio)
+      expect(screen.getByRole("heading", { name: "Rankings & results" })).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "Provide details about what happens to applications once they are submitted."
+        )
+      ).toBeInTheDocument()
 
       expect(
         screen.queryByText("How is the application review order determined?")
       ).not.toBeInTheDocument()
+      const waitlistSizeGroup = screen.getByRole("group", {
+        name: "Do you want to show a waitlist size?",
+      })
+      const waitlistYesRadio = within(waitlistSizeGroup).getByRole("radio", { name: "Yes" })
+      expect(within(waitlistSizeGroup).getByRole("radio", { name: "No" })).toBeInTheDocument()
+      expect(
+        screen.queryByRole("spinbutton", { name: "How many spots are open on the list?" })
+      ).not.toBeInTheDocument()
+
+      // after clicking yes the waitlist size field should appear
+      await userEvent.click(waitlistYesRadio)
+      expect(
+        screen.getByRole("spinbutton", { name: "How many spots are open on the list?" })
+      ).toBeInTheDocument()
 
       expect(screen.queryByTestId("lottery-start-date")).not.toBeInTheDocument()
       expect(screen.queryByTestId("lottery-start-time")).not.toBeInTheDocument()
       expect(screen.queryByTestId("lottery-end-time")).not.toBeInTheDocument()
     })
 
-    it("should show review order options when waitlist is open and feature flag is enabled", async () => {
+    it("should show review order options when waitlist is open and enableWaitlistLottery is true", async () => {
       render(
         <FormProviderWrapper
           values={{
             ...formDefaults,
+            isWaitlistOpen: true,
             jurisdictions: { id: "jurisdiction1" },
             listingAvailabilityQuestion: "openWaitlist",
           }}
@@ -75,19 +96,41 @@ describe("RankingsAndResults", () => {
             enableWaitlistAdditionalFields={false}
             enableWaitlistLottery={true}
             enableWhatToExpectAdditionalField={false}
+            listing={{ isWaitlistOpen: true } as Listing}
           />
         </FormProviderWrapper>
       )
 
-      screen.getByRole("heading", { name: "Rankings & results" })
+      expect(screen.getByRole("heading", { name: "Rankings & results" })).toBeInTheDocument()
 
-      const waitlistYesRadio = await screen.findByRole("radio", { name: "Yes" })
-      await userEvent.click(waitlistYesRadio)
+      const reviewOrderTypeGroup = screen.getByRole("group", {
+        name: "How is the application review order determined?",
+      })
 
-      await screen.findByText("How is the application review order determined?")
+      expect(
+        within(reviewOrderTypeGroup).getByRole("radio", { name: /First come first serve/i })
+      ).toBeChecked()
+      expect(
+        within(reviewOrderTypeGroup).getByRole("radio", { name: "Lottery" })
+      ).toBeInTheDocument()
 
-      expect(screen.getByRole("radio", { name: /First come first serve/i })).toBeInTheDocument()
-      expect(screen.getByRole("radio", { name: "Lottery" })).toBeInTheDocument()
+      const waitlistSizeGroup = screen.getByRole("group", {
+        name: "Do you want to show a waitlist size?",
+      })
+      expect(within(waitlistSizeGroup).getByRole("radio", { name: "Yes" })).toBeInTheDocument()
+      expect(within(waitlistSizeGroup).getByRole("radio", { name: "No" })).toBeInTheDocument()
+
+      await userEvent.click(within(reviewOrderTypeGroup).getByRole("radio", { name: "Lottery" }))
+      expect(
+        screen.getByRole("group", { name: "When will the lottery be run?" })
+      ).toBeInTheDocument()
+      expect(screen.getByRole("group", { name: "Lottery start time" })).toBeInTheDocument()
+      expect(screen.getByRole("group", { name: "Lottery end time" })).toBeInTheDocument()
+      expect(
+        within(
+          screen.getByRole("group", { name: "Do you want to show a waitlist size?" })
+        ).getByRole("radio", { name: "Yes" })
+      ).not.toBeDisabled()
     })
 
     it("should show review order options when availabilityQuestion is availableUnits and enableWaitlistLottery is false", () => {
@@ -111,14 +154,86 @@ describe("RankingsAndResults", () => {
         </FormProviderWrapper>
       )
 
-      screen.getByRole("heading", { name: "Rankings & results" })
-      expect(
-        screen.getByText("How is the application review order determined?")
-      ).toBeInTheDocument()
+      expect(screen.getByRole("heading", { name: "Rankings & results" })).toBeInTheDocument()
+      const reviewOrderTypeGroup = screen.getByRole("group", {
+        name: "How is the application review order determined?",
+      })
 
-      expect(screen.getByRole("radio", { name: /First come first serve/i })).toBeInTheDocument()
-      expect(screen.getByRole("radio", { name: "Lottery" })).toBeInTheDocument()
+      expect(
+        within(reviewOrderTypeGroup).getByRole("radio", { name: /First come first serve/i })
+      ).toBeChecked()
+      expect(
+        within(reviewOrderTypeGroup).getByRole("radio", { name: "Lottery" })
+      ).toBeInTheDocument()
     })
+
+    it("should show lottery questions when review order is lottery", () => {
+      render(
+        <FormProviderWrapper
+          values={{
+            ...formDefaults,
+            jurisdictions: { id: "jurisdiction1" },
+            listingAvailabilityQuestion: "availableUnits",
+          }}
+        >
+          <RankingsAndResults
+            requiredFields={[]}
+            whatToExpectEditor={null}
+            whatToExpectAdditionalTextEditor={null}
+            enableUnitGroups={false}
+            enableWaitlistAdditionalFields={false}
+            enableWaitlistLottery={false}
+            enableWhatToExpectAdditionalField={false}
+            listing={{ reviewOrderType: ReviewOrderTypeEnum.lottery } as Listing}
+          />
+        </FormProviderWrapper>
+      )
+
+      expect(screen.getByRole("heading", { name: "Rankings & results" })).toBeInTheDocument()
+      const reviewOrderTypeGroup = screen.getByRole("group", {
+        name: "How is the application review order determined?",
+      })
+
+      expect(
+        within(reviewOrderTypeGroup).getByRole("radio", { name: /First come first serve/i })
+      ).not.toBeChecked()
+      expect(within(reviewOrderTypeGroup).getByRole("radio", { name: "Lottery" })).toBeChecked()
+
+      const lotteryRunGroup = screen.getByRole("group", { name: "When will the lottery be run?" })
+      expect(within(lotteryRunGroup).getByRole("textbox", { name: "Month" })).toBeInTheDocument()
+      expect(within(lotteryRunGroup).getByRole("textbox", { name: "Day" })).toBeInTheDocument()
+      expect(within(lotteryRunGroup).getByRole("textbox", { name: "Year" })).toBeInTheDocument()
+      const lotteryStartTimeGroup = screen.getByRole("group", { name: "Lottery start time" })
+      expect(
+        within(lotteryStartTimeGroup).getByRole("textbox", { name: "Hour" })
+      ).toBeInTheDocument()
+      expect(
+        within(lotteryStartTimeGroup).getByRole("textbox", { name: "minutes" })
+      ).toBeInTheDocument()
+      expect(
+        within(within(lotteryStartTimeGroup).getByRole("combobox", { name: "time" })).getByRole(
+          "option",
+          { name: "AM" }
+        )
+      ).toBeInTheDocument()
+      const lotteryEndTimeGroup = screen.getByRole("group", { name: "Lottery end time" })
+      expect(within(lotteryEndTimeGroup).getByRole("textbox", { name: "Hour" })).toBeInTheDocument()
+      expect(
+        within(lotteryEndTimeGroup).getByRole("textbox", { name: "minutes" })
+      ).toBeInTheDocument()
+      expect(
+        within(within(lotteryEndTimeGroup).getByRole("combobox", { name: "time" })).getByRole(
+          "option",
+          { name: "AM" }
+        )
+      ).toBeInTheDocument()
+      expect(screen.getByRole("textbox", { name: "Lottery date notes" })).toBeInTheDocument()
+    })
+  })
+  describe("What to expect", () => {
+    it.todo(
+      "should show additional what to expect editor if enableWhatToExpectAdditionalField is true"
+    )
   })
   describe("Verifying text when selecting lottery radio button", () => {
     it("should show proper message when selecting lottery as a non admin user", async () => {

--- a/sites/partners/cypress/e2e/default/03-listing.spec.ts
+++ b/sites/partners/cypress/e2e/default/03-listing.spec.ts
@@ -292,7 +292,7 @@ describe("Listing Management Tests", () => {
     cy.get("button").contains("Application process").click()
     cy.getByID("reviewOrderFCFS").check()
     cy.getByID("waitlistOpenNo").check()
-    cy.getByID("whatToExpect").clear()
+    cy.getByID("whatToExpect").children().first().clear()
     cy.getByID("whatToExpect").type("Custom unformatted text")
     cy.getByID("whatToExpect").type("{enter}Item A")
     cy.getByID("whatToExpect")

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -75,8 +75,7 @@ const RankingsAndResults = ({
   })
 
   const showFSFCLotterySection =
-    (enableWaitlistLottery && waitlistOpen) ||
-    (availabilityQuestion !== "openWaitlist" && !enableWaitlistLottery)
+    (enableWaitlistLottery && waitlistOpen) || availabilityQuestion !== "openWaitlist"
 
   // Ensure the lottery fields only show when it's "available units" listing
   const showLotteryFields =
@@ -116,7 +115,9 @@ const RankingsAndResults = ({
                     disabled:
                       disableDueDates && listing?.reviewOrderType === ReviewOrderTypeEnum.lottery,
                     defaultChecked:
-                      listing?.reviewOrderType === ReviewOrderTypeEnum.firstComeFirstServe,
+                      listing?.reviewOrderType === ReviewOrderTypeEnum.firstComeFirstServe ||
+                      listing?.reviewOrderType === ReviewOrderTypeEnum.waitlist ||
+                      !listing?.reviewOrderType,
                   },
                   {
                     label: t("listings.lotteryTitle"),


### PR DESCRIPTION
This PR addresses Doorway bug bash find

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

During the bashing of Doorway for the "waitlist lottery" feature a few issues were discovered around the selection of the review order type question.
1. When editing a listing that was FCFS and "open waitlist" the FCFS radio button was not being selected
2. Multiple scenarios caused the FCFS/Lottery radio buttons to not appear

## How Can This Be Tested/Reviewed?

All of the following scenarios need to be tested for both create listing as well as edit of listing
1. enableWaitlistLottery turned *OFF* and "available units" selected should show the review order options
2. enableWaitlistLottery turned *OFF* and "open waitlist" selected should *NOT* show the review order options
3. enableWaitlistLottery turned *ON* and "available units" selected should show the review order options
4. enableWaitlistLottery turned *ON* and "open waitlist" selected should show the review order options


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
