### PR TITLE
fix: change jsonb to array for is newest script run

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -2857,8 +2857,9 @@ export class ScriptRunnerService {
         user_id: string;
         application_id: string;
       }[] = await this.prisma
-        .$queryRaw`select a.user_id, (a.application_ids::jsonb)[0]::text as application_id from (
-                    select a.user_id, json_agg(a.id ORDER BY a.created_at DESC) as application_ids from applications a
+        .$queryRaw`select a.user_id, (a.application_ids)[1] as application_id from (
+                    select a.user_id, array_agg(a.id ORDER BY a.created_at DESC) as application_ids from applications a
+                    WHERE a.user_id is not null
                     GROUP BY a.user_id) a
                     OFFSET ${currentCount}
                     LIMIT 1000;`;


### PR DESCRIPTION
This PR addresses [#5216](https://github.com/bloom-housing/bloom/issues/5216)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When testing the `setIsNewestApplicationValues` in Doorway staging a postgres error occurred doing the raw query
```
cannot subscript type jsonb because it is not an array
```
Specifically this is happening in the `a.application_ids::jsonb` step. The previous solution worked both locally and in core but failed when running in Doorway staging. I could not isolate exactly why this happened however it could be because of different versions of postgres.

The fix is to switch from `json_agg` to `array_agg` and no longer have to convert to jsonb

## How Can This Be Tested/Reviewed?

The e2e tests still pass.

This is how I tested it:
### verify solution works in Doorway postgres
1. Log into staging jumpbox's postgres
2. Run the postgres query in this environment

### local testing
1. Add several public users to the seeding
```
const publicUser1 = await prismaClient.userAccounts.create({
    data: await userFactory({
      confirmedAt: new Date(),
      jurisdictionIds: [jurisdiction.id],
      acceptedTerms: true,
    }),
  });
  const publicUser2 = await prismaClient.userAccounts.create({
    data: await userFactory({
      confirmedAt: new Date(),
      jurisdictionIds: [jurisdiction.id],
      acceptedTerms: true,
    }),
  });
  const publicUser3 = await prismaClient.userAccounts.create({
    data: await userFactory({
      confirmedAt: new Date(),
      jurisdictionIds: [jurisdiction.id],
      acceptedTerms: true,
    }),
  });
```
2. Connect the created applications to these users with different created at times
```
 await applicationFactory({
          userId: publicUser1.id,
          createdAt: dayjs(new Date()).subtract(5, 'seconds').toDate(),
        })
```
3. Run the script and verify the correct application got updated with the `is_newest` value

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
