### PR TITLE
fix: properly display preferences in the correct order

### DIFF
--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -233,14 +233,16 @@ export const ListingView = (props: ListingProps) => {
     } else {
       multiselectQuestionSet = listingPreferences
     }
-    return multiselectQuestionSet.map((listingMultiselectQuestion, index) => {
-      return {
-        ordinal: index + 1,
-        links: listingMultiselectQuestion?.multiselectQuestions?.links,
-        title: listingMultiselectQuestion?.multiselectQuestions?.text,
-        description: listingMultiselectQuestion?.multiselectQuestions?.description,
-      }
-    })
+    return multiselectQuestionSet
+      .sort((a, b) => a.ordinal - b.ordinal)
+      .map((listingMultiselectQuestion, index) => {
+        return {
+          ordinal: listingMultiselectQuestion.ordinal || index + 1,
+          links: listingMultiselectQuestion?.multiselectQuestions?.links,
+          title: listingMultiselectQuestion?.multiselectQuestions?.text,
+          description: listingMultiselectQuestion?.multiselectQuestions?.description,
+        }
+      })
   }
 
   if (listingPrograms && listingPrograms?.length > 0) {


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

In production you can sometimes get into a scenario where the preferences aren't returned in the correct order. This is because we are not sorting by the ordinal anywhere so whatever order the preferences are returned by the database is what order they are displayed on the public site
https://github.com/user-attachments/assets/f6b0bc97-66c4-42e9-ad9a-72c71737bfbd

TODO: This same issue can happen on the partner site when loading a listing. 

Example: https://housingbayarea.mtc.ca.gov/preview/listings/ab34ffb7-4f8d-4211-94c6-ff5938ab9720

## How Can This Be Tested/Reviewed?

add multiple preferences to a listing and validate that the preferences are in the correct order.
## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
