### PR TITLE
fix: remove ami chart data from listing update body (#5942)

### DIFF
--- a/sites/partners/src/lib/listings/UnitsFormatter.ts
+++ b/sites/partners/src/lib/listings/UnitsFormatter.ts
@@ -60,6 +60,14 @@ export default class UnitsFormatter extends Formatter {
 
       delete unit.tempId
 
+      // remove unnecessary ami chart fields for listing editing
+      if (unit.amiChart) {
+        delete unit.amiChart.items
+        delete unit.amiChart.jurisdictions
+        delete unit.createdAt
+        delete unit.updatedAt
+      }
+
       return unit
     })
   }


### PR DESCRIPTION
This PR addresses [#5941](https://github.com/bloom-housing/bloom/issues/5941)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

NOTE: this is directly taken from core https://github.com/bloom-housing/bloom/pull/5942

When trying to save either a new listing or updating an existing listing that has many units (150+) attached the request is failing with a 413 response. The 413 error code means the "Request Entity Too Large". This is because we are sending over 1mb of data in the request body.

This change removes the AMI chart data from each unit as we only need the id and name when saving it to the listing.

## How Can This Be Tested/Reviewed?

You will need a lot of units to reproduce the 413 error. I recommend changing the seeded data so that a listing has 200+ units.

* Go to the partner site, click edit on the listing that now has a lot of units.
* Add a new unit and save the listing
## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
