### PR TITLE
fix: update ui-c for draggle table (#5959)

### DIFF
--- a/doorway-ui-components/package.json
+++ b/doorway-ui-components/package.json
@@ -52,7 +52,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@bloom-housing/ui-components": "13.0.2",
+    "@bloom-housing/ui-components": "13.0.7",
     "@bloom-housing/ui-seeds": "3.1.1",
     "ag-grid-community": "^26.0.0",
     "markdown-to-jsx": "7.1.8",

--- a/shared-helpers/.jest/setup-tests.js
+++ b/shared-helpers/.jest/setup-tests.js
@@ -1,3 +1,9 @@
+// ui-components uses ResizeObserver for drag-and-drop, so we need to mock it here before importing anything from ui-components
+global.ResizeObserver = jest.fn(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}))
 import { addTranslation } from "@bloom-housing/ui-components"
 import generalTranslations from "@bloom-housing/shared-helpers/src/locales/general.json"
 import "@testing-library/jest-dom"

--- a/shared-helpers/package.json
+++ b/shared-helpers/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@bloom-housing/doorway-ui-components": "^1.0.0",
-    "@bloom-housing/ui-components": "13.0.2",
+    "@bloom-housing/ui-components": "13.0.7",
     "@bloom-housing/ui-seeds": "3.1.1",
     "@heroicons/react": "^2.1.1",
     "axios-cookiejar-support": "^5.0.5",

--- a/sites/partners/.jest/setup-tests.js
+++ b/sites/partners/.jest/setup-tests.js
@@ -1,10 +1,16 @@
 // Future home of additional Jest config
 import "@testing-library/jest-dom"
-import { addTranslation } from "@bloom-housing/ui-components"
 import generalTranslations from "@bloom-housing/shared-helpers/src/locales/general.json"
 import { serviceOptions } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import axios from "axios"
 import general from "../page_content/locale_overrides/general.json"
+// ui-components uses ResizeObserver for drag-and-drop, so we need to mock it here before importing anything from ui-components
+global.ResizeObserver = jest.fn(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}))
+import { addTranslation } from "@bloom-housing/ui-components"
 addTranslation({ ...generalTranslations, ...general })
 
 process.env.cloudinaryCloudName = "exygy"

--- a/sites/partners/__tests__/components/listings/PaperListingForm/sections/ListingPhotos.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/sections/ListingPhotos.test.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import "@testing-library/jest-dom"
 import { FormProvider, useForm } from "react-hook-form"
-import { render, screen, within } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { jurisdiction, listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { Jurisdiction } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { setupServer } from "msw/lib/node"
 import { formDefaults, FormListing } from "../../../../../src/lib/listings/formTypes"
 import ListingPhotos from "../../../../../src/components/listings/PaperListingForm/sections/ListingPhotos"
 import { mockNextRouter } from "../../../../testUtils"
-import userEvent from "@testing-library/user-event"
 import * as helpers from "../../../../../src/lib/helpers"
 import * as assets from "../../../../../src/lib/assets"
 import { rest } from "msw"
@@ -369,7 +369,9 @@ describe("<ListingPhotos>", () => {
       const editButtons = within(drawer).getAllByRole("button", { name: "Edit" })
       expect(editButtons).toHaveLength(2)
 
-      await userEvent.click(editButtons[0])
+      // The userEvent.click triggers additional aspects of the dom that we don't have mocked
+      // and the drag and drop functionality within this drawer depends on those aspects. Using fireEvent.click to avoid that.
+      fireEvent.click(editButtons[0])
 
       const altTextDrawer = await screen.findByRole("dialog", { name: "Add image description" })
       expect(
@@ -417,7 +419,7 @@ describe("<ListingPhotos>", () => {
       await userEvent.click(editPhotosButton)
 
       const drawer = await screen.findByRole("dialog", { name: "Edit photos" })
-      await userEvent.click(within(drawer).getByRole("button", { name: "Edit" }))
+      fireEvent.click(within(drawer).getByRole("button", { name: "Edit" }))
 
       const altTextDrawer = await screen.findByRole("dialog", { name: "Add image description" })
       const altTextInput = within(altTextDrawer).getByLabelText(/Image description \(alt text\)/i, {

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bloom-housing/doorway-ui-components": "^1.0.0",
     "@bloom-housing/shared-helpers": "^7.7.1",
-    "@bloom-housing/ui-components": "13.0.2",
+    "@bloom-housing/ui-components": "13.0.7",
     "@bloom-housing/ui-seeds": "3.1.1",
     "@heroicons/react": "^2.2.0",
     "@mapbox/mapbox-sdk": "^0.13.0",
@@ -91,6 +91,7 @@
     "nyc": "^15.1.0",
     "postcss": "^8.5.3",
     "postcss-custom-media": "^10.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "sass": "^1.93.3",
     "sass-loader": "^16.0.6",
     "ts-loader": "^9.5.2",

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhotos.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhotos.tsx
@@ -279,6 +279,7 @@ const ListingPhotos = (props: ListingPhotosProps) => {
       )
 
       return {
+        id: { content: image.fileId },
         ordinal: {
           content: ordinalContent,
         },

--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -96,6 +96,7 @@ const SelectAndOrder = ({
   const draggableTableData: StandardTableData = useMemo(
     () =>
       draftListingData.map((item) => ({
+        id: { content: item.id },
         name: { content: item.text },
         additionalFields: {
           content: (

--- a/sites/partners/src/components/settings/PreferenceDrawer.tsx
+++ b/sites/partners/src/components/settings/PreferenceDrawer.tsx
@@ -142,6 +142,7 @@ const PreferenceDrawer = ({
       questionData?.options
         ?.sort((a, b) => (a.ordinal < b.ordinal ? -1 : 1))
         .map((item) => ({
+          id: { content: item.text },
           name: { content: item.text },
           description: { content: item.description },
           action: {

--- a/sites/public/.jest/setup-tests.js
+++ b/sites/public/.jest/setup-tests.js
@@ -1,4 +1,9 @@
-// Future home of additional Jest config
+// ui-components uses ResizeObserver for drag-and-drop, so we need to mock it here before importing anything from ui-components
+global.ResizeObserver = jest.fn(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}))
 import { addTranslation } from "@bloom-housing/ui-components"
 import generalTranslations from "../../../shared-helpers/src/locales/general.json"
 import general from "../page_content/locale_overrides/general.json"

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bloom-housing/doorway-ui-components": "^1.0.0",
     "@bloom-housing/shared-helpers": "^7.7.1",
-    "@bloom-housing/ui-components": "13.0.2",
+    "@bloom-housing/ui-components": "13.0.7",
     "@bloom-housing/ui-seeds": "3.1.1",
     "@googlemaps/markerclusterer": "^2.5.3",
     "@heroicons/react": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,7 +1162,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.15.4", "@babel/runtime@^7.2.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.2.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
   integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
@@ -1289,11 +1289,12 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@13.0.2":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-13.0.2.tgz#f352242c6303cf89523f96143317f178036ba671"
-  integrity sha512-YniyO9czP73flbWdV0FmIq7r2DRzBReDwrnp27M4G/DpodnFSyjYwJU5eA7V/ViXQqxGCHO4X7Du66xSJcWAbQ==
+"@bloom-housing/ui-components@13.0.7":
+  version "13.0.7"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-13.0.7.tgz#13ce1706d2a5df67980533c689b4131dddac5b4a"
+  integrity sha512-heWy9bjYrOndjPC1e1vM99hUIiHhdQZ0LjHvACwV/HR91XCGnQ7AXcBJxFji+F/084VSBrf5wo6MJJCug8xJYQ==
   dependencies:
+    "@dnd-kit/react" "^0.3.2"
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"
     "@fortawesome/free-solid-svg-icons" "^6.1.1"
@@ -1306,10 +1307,9 @@
     markdown-to-jsx "7.1.8"
     nanoid "^3.1.12"
     node-polyglot "^2.4.0"
-    react "^19.1.1"
+    react "19.2.3"
     react-accessible-accordion "5.0.0"
-    react-beautiful-dnd "^13.1.1"
-    react-dom "^19.1.1"
+    react-dom "19.2.3"
     react-dropzone "^11.3.2"
     react-focus-lock "^2.9.4"
     react-hook-form "^6.15.5"
@@ -1589,6 +1589,61 @@
     colorspace "1.1.x"
     enabled "2.0.x"
     kuler "^2.0.0"
+
+"@dnd-kit/abstract@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/abstract/-/abstract-0.3.2.tgz#b3f559b398a57f121d8f9bf966c18d4aa6c9e7b9"
+  integrity sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==
+  dependencies:
+    "@dnd-kit/geometry" "^0.3.2"
+    "@dnd-kit/state" "^0.3.2"
+    tslib "^2.6.2"
+
+"@dnd-kit/collision@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/collision/-/collision-0.3.2.tgz#4e24643cb0cf92c24d2c6aea6a0019cd309bb37f"
+  integrity sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==
+  dependencies:
+    "@dnd-kit/abstract" "^0.3.2"
+    "@dnd-kit/geometry" "^0.3.2"
+    tslib "^2.6.2"
+
+"@dnd-kit/dom@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/dom/-/dom-0.3.2.tgz#45e1f68985b45ea008ee5be89ae5d7387b15d52a"
+  integrity sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==
+  dependencies:
+    "@dnd-kit/abstract" "^0.3.2"
+    "@dnd-kit/collision" "^0.3.2"
+    "@dnd-kit/geometry" "^0.3.2"
+    "@dnd-kit/state" "^0.3.2"
+    tslib "^2.6.2"
+
+"@dnd-kit/geometry@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/geometry/-/geometry-0.3.2.tgz#632601167fcbcec930add68254842aa726f571d3"
+  integrity sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==
+  dependencies:
+    "@dnd-kit/state" "^0.3.2"
+    tslib "^2.6.2"
+
+"@dnd-kit/react@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/react/-/react-0.3.2.tgz#d3fd37da4cd36e6c7dc92a5d70a4f1b3d6b36d82"
+  integrity sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==
+  dependencies:
+    "@dnd-kit/abstract" "^0.3.2"
+    "@dnd-kit/dom" "^0.3.2"
+    "@dnd-kit/state" "^0.3.2"
+    tslib "^2.6.2"
+
+"@dnd-kit/state@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/state/-/state-0.3.2.tgz#fd7c2089c680cab48e9067adfa09596fe36491ac"
+  integrity sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==
+  dependencies:
+    "@preact/signals-core" "^1.10.0"
+    tslib "^2.6.2"
 
 "@emnapi/runtime@^1.5.0":
   version "1.6.0"
@@ -2525,6 +2580,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
+"@preact/signals-core@^1.10.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@preact/signals-core/-/signals-core-1.13.0.tgz#ed770df2855701e7b42828fae5a348edeee9a3df"
+  integrity sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -3223,14 +3283,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@^3.3.0":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/http-cache-semantics@*":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
@@ -3454,16 +3506,6 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react-redux@^7.1.20":
-  version "7.1.25"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.25.tgz#de841631205b24f9dfb4967dd4a7901e048f9a88"
-  integrity sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==
-  dependencies:
-    "@types/hoist-non-react-statics" "^3.3.0"
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-    redux "^4.0.0"
-
 "@types/react-tabs@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-tabs/-/react-tabs-5.0.5.tgz#f50a9527adbaf8d146da7f787d1fbdfeff31dd56"
@@ -3491,9 +3533,9 @@
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
 "@types/react@*", "@types/react@^19.1.1":
-  version "19.2.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.8.tgz#307011c9f5973a6abab8e17d0293f48843627994"
-  integrity sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==
+  version "19.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
+  integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
   dependencies:
     csstype "^3.2.2"
 
@@ -5561,13 +5603,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-css-box-model@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
-  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
-  dependencies:
-    tiny-invariant "^1.0.6"
 
 css-unit-converter@^1.1.1:
   version "1.1.2"
@@ -8062,7 +8097,7 @@ headers-polyfill@3.2.5:
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.2.5.tgz#6e67d392c9d113d37448fe45014e0afdd168faed"
   integrity sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10107,11 +10142,6 @@ mdurl@^2.0.0:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
   integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
-memoize-one@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz"
@@ -11337,7 +11367,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11635,11 +11665,6 @@ quickselect@^3.0.0:
   resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-3.0.0.tgz#a37fc953867d56f095a20ac71c6d27063d2de603"
   integrity sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==
 
-raf-schd@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
-  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
-
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
@@ -11651,19 +11676,6 @@ react-accessible-accordion@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-accessible-accordion/-/react-accessible-accordion-5.0.0.tgz#5b61d06aec38906a99f977c10324d9bddec0f64c"
   integrity sha512-MT2obYpTgLIIfPr9d7hEyvPB5rg8uJcHpgA83JSRlEUHvzH48+8HJPvzSs+nM+XprTugDgLfhozO5qyJpBvYRQ==
-
-react-beautiful-dnd@^13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
-  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    css-box-model "^1.2.0"
-    memoize-one "^5.1.1"
-    raf-schd "^4.0.2"
-    react-redux "^7.2.0"
-    redux "^4.0.4"
-    use-memo-one "^1.1.1"
 
 react-clientside-effect@^1.2.6:
   version "1.2.6"
@@ -11717,7 +11729,7 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1, react-is@^17.0.2:
+react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -11744,18 +11756,6 @@ react-media@^1.10.0:
     invariant "^2.2.2"
     json2mq "^0.2.0"
     prop-types "^15.5.10"
-
-react-redux@^7.2.0:
-  version "7.2.9"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
-  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/react-redux" "^7.1.20"
-    hoist-non-react-statics "^3.3.2"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
 
 react-remove-scroll-bar@^2.3.3:
   version "2.3.4"
@@ -11936,13 +11936,6 @@ reduce-css-calc@^2.1.8:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
 
-redux@^4.0.0, redux@^4.0.4:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
-  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-
 reflect.getprototypeof@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.5.tgz#e0bd28b597518f16edaf9c0e292c631eb13e0674"
@@ -12103,6 +12096,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
@@ -13428,11 +13426,6 @@ through2@^4.0.0:
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tiny-invariant@^1.0.6:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
-  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
-
 tinyqueue@^1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
@@ -13638,7 +13631,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -13979,11 +13972,6 @@ use-callback-ref@^1.3.0:
   integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
   dependencies:
     tslib "^2.0.0"
-
-use-memo-one@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
-  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 use-sidecar@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR addresses #5889

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

NOTE: this is a direct pull over from core https://github.com/bloom-housing/bloom/pull/5959

The drag and drop library used in UI-components broke with the recent upgrade of react. We have switched the library to allow it to work again. With this we also need to give ids to each row so that re-ordering doesn't cause unnecessary re-renders

## How Can This Be Tested/Reviewed?

Here are all of the places that use a draggable table.
1. Add/edit preferences attached to listings
2. Add/edit programs attached to listings
3. Add/edit photos attached to listings
4. Add/edit options in preferences within `/settings/preferences` - Note: there are now two pages of this functionality with the environment variable `enableV2MSQ`

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
