### PR TITLE
fix: use correct doorway colors

### DIFF
--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -1122,6 +1122,8 @@ export class UserService {
       where: { lastLoginAt: { lt: deleteBeforeDate }, userRoles: null },
     });
 
+    this.logger.warn(`deleting ${usersToBeDeleted.length} users`);
+
     for (const user of usersToBeDeleted) {
       if (!user.wasWarnedOfDeletion) {
         this.logger.warn(

--- a/sites/public/styles/colors.scss
+++ b/sites/public/styles/colors.scss
@@ -16,7 +16,7 @@
   --seeds-color-primary-dark: var(--dwy-color-blue-900);
   --seeds-color-primary: var(--dwy-color-blue-700);
   --seeds-color-primary-light: var(--dwy-color-blue-500);
-  --seeds-color-primary-lighter: var(--dwy-color-blue-300);
+  --seeds-color-primary-lighter: var(--bloom-color-blue-100);
 
   --seeds-color-secondary-darker: var(--dwy-color-cyan-900);
   --seeds-color-secondary-dark: var(--dwy-color-cyan-700);


### PR DESCRIPTION
When pulling in the newer icons from core the icons in Doorway have a darker background than what it should. This is because the override colors in Doorway are not what we are expecting

Here is the desired colors for each environment
<img width="2412" height="598" alt="image" src="https://github.com/user-attachments/assets/bf5b1447-ce7e-4cad-bd4c-7db3cf1d4dbf" />

Note: this could change the color in other places of the system. 
