### PR TITLE
feat(api): automate lottery audit workflow and refactor dependencies

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -16,6 +16,8 @@ CLOUDINARY_CLOUD_NAME=exygy
 APP_SECRET="some-long-secret-key"
 # url for the proxy
 PROXY_URL=
+# This endpoint is called after a successful lottery run. If null, the audit operation is skipped.
+LOTTERY_AUDIT_ENDPOINT=
 # the node env the app should be running as
 NODE_ENV=development
 # how long a generated multi-factor authentication code should be

--- a/api/src/dtos/listings/lottery-audit-response.dto.ts
+++ b/api/src/dtos/listings/lottery-audit-response.dto.ts
@@ -1,8 +1,0 @@
-import { Expose } from 'class-transformer';
-import { ApiProperty } from '@nestjs/swagger';
-
-export class LotteryAuditResponseDto {
-  @Expose()
-  @ApiProperty()
-  workQueueItemID: string;
-}

--- a/api/src/dtos/listings/lottery-audit-response.dto.ts
+++ b/api/src/dtos/listings/lottery-audit-response.dto.ts
@@ -1,0 +1,8 @@
+import { Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LotteryAuditResponseDto {
+  @Expose()
+  @ApiProperty()
+  workQueueItemID: string;
+}

--- a/api/src/modules/lottery.module.ts
+++ b/api/src/modules/lottery.module.ts
@@ -1,4 +1,5 @@
 import { Logger, Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { ApplicationExporterModule } from './application-exporter.module';
 import { ConfigService } from '@nestjs/config';
 import { EmailModule } from './email.module';
@@ -13,6 +14,7 @@ import { CronJobModule } from './cron-job.module';
 @Module({
   imports: [
     ApplicationExporterModule,
+    HttpModule,
     PrismaModule,
     ListingModule,
     EmailModule,

--- a/api/src/modules/lottery.module.ts
+++ b/api/src/modules/lottery.module.ts
@@ -1,4 +1,5 @@
 import { Logger, Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { ApplicationExporterModule } from './application-exporter.module';
 import { ConfigService } from '@nestjs/config';
 import { EmailModule } from './email.module';
@@ -14,6 +15,7 @@ import { SnapshotCreateModule } from './snapshot-create.module';
 @Module({
   imports: [
     ApplicationExporterModule,
+    HttpModule,
     PrismaModule,
     ListingModule,
     EmailModule,

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -7,6 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { LotteryAuditResponseDto } from '../dtos/listings/lottery-audit-response.dto';
 import {
   LanguagesEnum,
   ListingEventsTypeEnum,
@@ -167,6 +168,20 @@ export class LotteryService {
         },
         user,
       );
+
+      // Trigger automated audit if the lottery audit endpoint is configured
+      const auditEndpoint = this.configService.get<string>(
+        'LOTTERY_AUDIT_ENDPOINT',
+      );
+      if (auditEndpoint) {
+        try {
+          await this.triggerLotteryAudit(listingId, auditEndpoint);
+        } catch (auditError) {
+          this.logger.error(
+            `Automated lottery audit failed to trigger for listing ${listingId}: ${auditError.message}`,
+          );
+        }
+      }
     } catch (e) {
       console.error(e);
       await this.lotteryStatus(
@@ -864,5 +879,49 @@ export class LotteryService {
     });
 
     return results;
+  }
+
+  async triggerLotteryAudit(
+    listingId: string,
+    endpoint: string,
+  ): Promise<LotteryAuditResponseDto> {
+    this.logger.warn(`Triggering lottery audit for listing ${listingId}`);
+    try {
+      // Use native fetch available in Node.js >= 18
+      const nativeFetch = (globalThis as any).fetch;
+      const response = await nativeFetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ListingId: listingId }),
+      });
+
+      if (!response.ok) {
+        let errorData = 'Failed to start lottery audit';
+        try {
+          errorData = await response.text();
+        } catch (e) {
+          // ignore
+        }
+        throw new HttpException(errorData, response.status || 500);
+      }
+
+      const data = await response.json();
+      return mapTo(LotteryAuditResponseDto, {
+        workQueueItemID: data.WorkQueueItemID,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to trigger lottery audit for listing ${listingId}: ${error.message}`,
+      );
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        error.message || 'Failed to start lottery audit',
+        500,
+      );
+    }
   }
 }

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -7,7 +7,8 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { LotteryAuditResponseDto } from '../dtos/listings/lottery-audit-response.dto';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
 import {
   LanguagesEnum,
   ListingEventsTypeEnum,
@@ -63,6 +64,7 @@ export class LotteryService {
     private logger = new Logger(LotteryService.name),
     private permissionService: PermissionService,
     private cronJobService: CronJobService,
+    private httpService: HttpService,
   ) {}
 
   onModuleInit() {
@@ -174,13 +176,13 @@ export class LotteryService {
         'LOTTERY_AUDIT_ENDPOINT',
       );
       if (auditEndpoint) {
-        try {
-          await this.triggerLotteryAudit(listingId, auditEndpoint);
-        } catch (auditError) {
-          this.logger.error(
-            `Automated lottery audit failed to trigger for listing ${listingId}: ${auditError.message}`,
-          );
-        }
+        this.triggerLotteryAudit(listingId, auditEndpoint).catch(
+          (auditError) => {
+            this.logger.error(
+              `Automated lottery audit failed to trigger for listing ${listingId}: ${auditError.message}`,
+            );
+          },
+        );
       }
     } catch (e) {
       console.error(e);
@@ -884,39 +886,29 @@ export class LotteryService {
   async triggerLotteryAudit(
     listingId: string,
     endpoint: string,
-  ): Promise<LotteryAuditResponseDto> {
+  ): Promise<void> {
     this.logger.warn(`Triggering lottery audit for listing ${listingId}`);
     try {
-      // Use native fetch available in Node.js >= 18
-      const nativeFetch = (globalThis as any).fetch;
-      const response = await nativeFetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ ListingId: listingId }),
-      });
-
-      if (!response.ok) {
-        let errorData = 'Failed to start lottery audit';
-        try {
-          errorData = await response.text();
-        } catch (e) {
-          // ignore
-        }
-        throw new HttpException(errorData, response.status || 500);
-      }
-
-      const data = await response.json();
-      return mapTo(LotteryAuditResponseDto, {
-        workQueueItemID: data.WorkQueueItemID,
-      });
+      await firstValueFrom(
+        this.httpService.post(
+          endpoint,
+          { ListingId: listingId },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+      );
     } catch (error) {
       this.logger.error(
         `Failed to trigger lottery audit for listing ${listingId}: ${error.message}`,
       );
-      if (error instanceof HttpException) {
-        throw error;
+      if (error.response) {
+        throw new HttpException(
+          error.response.data || 'Failed to start lottery audit',
+          error.response.status || 500,
+        );
       }
       throw new HttpException(
         error.message || 'Failed to start lottery audit',

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -9,7 +9,8 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { LotteryAuditResponseDto } from '../dtos/listings/lottery-audit-response.dto';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
 import {
   LanguagesEnum,
   ListingEventsTypeEnum,
@@ -69,6 +70,7 @@ export class LotteryService {
     private permissionService: PermissionService,
     private cronJobService: CronJobService,
     private snapshotCreateService: SnapshotCreateService,
+    private httpService: HttpService,
   ) {}
 
   onModuleInit() {
@@ -191,13 +193,13 @@ export class LotteryService {
         'LOTTERY_AUDIT_ENDPOINT',
       );
       if (auditEndpoint) {
-        try {
-          await this.triggerLotteryAudit(listingId, auditEndpoint);
-        } catch (auditError) {
-          this.logger.error(
-            `Automated lottery audit failed to trigger for listing ${listingId}: ${auditError.message}`,
-          );
-        }
+        this.triggerLotteryAudit(listingId, auditEndpoint).catch(
+          (auditError) => {
+            this.logger.error(
+              `Automated lottery audit failed to trigger for listing ${listingId}: ${auditError.message}`,
+            );
+          },
+        );
       }
     } catch (e) {
       console.error(e);
@@ -922,42 +924,32 @@ export class LotteryService {
   async triggerLotteryAudit(
     listingId: string,
     endpoint: string,
-  ): Promise<LotteryAuditResponseDto> {
+  ): Promise<void> {
     this.logger.warn(`Triggering lottery audit for listing ${listingId}`);
     try {
-      // Use native fetch available in Node.js >= 18
-      const nativeFetch = (globalThis as any).fetch;
-      const response = await nativeFetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ ListingId: listingId }),
-      });
-
-      if (!response.ok) {
-        let errorData = 'Failed to start lottery audit';
-        try {
-          errorData = await response.text();
-        } catch (e) {
-          // ignore
-        }
-        throw new HttpException(errorData, response.status || 500);
-      }
-
-      const data = await response.json();
-      return mapTo(LotteryAuditResponseDto, {
-        workQueueItemID: data.WorkQueueItemID,
-      });
+      await firstValueFrom(
+        this.httpService.post(
+          endpoint,
+          { ListingId: listingId },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+      );
     } catch (error) {
       this.logger.error(
-        `Failed to trigger lottery audit for listing ${listingId}: ${error.message}`,
+        `Failed to trigger lottery audit for listing ${listingId}: ${error?.message}`,
       );
-      if (error instanceof HttpException) {
-        throw error;
+      if (error?.response) {
+        throw new HttpException(
+          error.response?.data || 'Failed to start lottery audit',
+          error.response?.status || 500,
+        );
       }
       throw new HttpException(
-        error.message || 'Failed to start lottery audit',
+        error?.message || 'Failed to start lottery audit',
         500,
       );
     }

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -9,6 +9,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { LotteryAuditResponseDto } from '../dtos/listings/lottery-audit-response.dto';
 import {
   LanguagesEnum,
   ListingEventsTypeEnum,
@@ -184,6 +185,20 @@ export class LotteryService {
         },
         user,
       );
+
+      // Trigger automated audit if the lottery audit endpoint is configured
+      const auditEndpoint = this.configService.get<string>(
+        'LOTTERY_AUDIT_ENDPOINT',
+      );
+      if (auditEndpoint) {
+        try {
+          await this.triggerLotteryAudit(listingId, auditEndpoint);
+        } catch (auditError) {
+          this.logger.error(
+            `Automated lottery audit failed to trigger for listing ${listingId}: ${auditError.message}`,
+          );
+        }
+      }
     } catch (e) {
       console.error(e);
       await this.lotteryStatus(
@@ -902,5 +917,49 @@ export class LotteryService {
     });
 
     return results;
+  }
+
+  async triggerLotteryAudit(
+    listingId: string,
+    endpoint: string,
+  ): Promise<LotteryAuditResponseDto> {
+    this.logger.warn(`Triggering lottery audit for listing ${listingId}`);
+    try {
+      // Use native fetch available in Node.js >= 18
+      const nativeFetch = (globalThis as any).fetch;
+      const response = await nativeFetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ListingId: listingId }),
+      });
+
+      if (!response.ok) {
+        let errorData = 'Failed to start lottery audit';
+        try {
+          errorData = await response.text();
+        } catch (e) {
+          // ignore
+        }
+        throw new HttpException(errorData, response.status || 500);
+      }
+
+      const data = await response.json();
+      return mapTo(LotteryAuditResponseDto, {
+        workQueueItemID: data.WorkQueueItemID,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to trigger lottery audit for listing ${listingId}: ${error.message}`,
+      );
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        error.message || 'Failed to start lottery audit',
+        500,
+      );
+    }
   }
 }

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -7,12 +7,12 @@ import {
   MultiselectQuestionsApplicationSectionEnum,
   ReviewOrderTypeEnum,
 } from '@prisma/client';
-import { HttpModule } from '@nestjs/axios';
 import { Request as ExpressRequest, Response } from 'express';
 import { PrismaService } from '../../../src/services/prisma.service';
 import { ApplicationExporterService } from '../../../src/services/application-exporter.service';
 import { MultiselectQuestionService } from '../../../src/services/multiselect-question.service';
 import { User } from '../../../src/dtos/users/user.dto';
+import { HttpService } from '@nestjs/axios';
 import { mockApplicationSet } from './application.service.spec';
 import { mockMultiselectQuestion } from './multiselect-question.service.spec';
 import { ListingService } from '../../../src/services/listing.service';
@@ -75,13 +75,24 @@ describe('Testing lottery service', () => {
             lotteryPublishedApplicant: lotteryPublishedApplicantMock,
           },
         },
-        ConfigService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: HttpService,
+          useValue: {
+            post: jest.fn(),
+            get: jest.fn(),
+          },
+        },
         Logger,
         SchedulerRegistry,
         GoogleTranslateService,
         CronJobService,
       ],
-      imports: [HttpModule],
     }).compile();
 
     service = module.get<LotteryService>(LotteryService);
@@ -1360,6 +1371,68 @@ describe('Testing lottery service', () => {
       await expect(
         async () => await service.lotteryTotals(listingId, null),
       ).rejects.toThrowError();
+    });
+  });
+
+  describe('Testing triggerLotteryAudit()', () => {
+    it('should trigger a lottery audit and return the response', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+      const mockWorkQueueItemId = randomUUID();
+
+      (globalThis as any).fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue({ WorkQueueItemID: mockWorkQueueItemId }),
+      });
+
+      const result = await service.triggerLotteryAudit(
+        mockListingId,
+        mockEndpoint,
+      );
+      expect((globalThis as any).fetch).toHaveBeenCalledWith(mockEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ListingId: mockListingId }),
+      });
+      expect(result.workQueueItemID).toEqual(mockWorkQueueItemId);
+    });
+
+    it('should throw HttpException with 500 when fetch response is not ok', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+
+      (globalThis as any).fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: jest
+          .fn()
+          .mockResolvedValue('Internal error from lottery audit endpoint'),
+      });
+
+      await expect(
+        async () =>
+          await service.triggerLotteryAudit(mockListingId, mockEndpoint),
+      ).rejects.toThrowError('Internal error from lottery audit endpoint');
+    });
+
+    it('should throw HttpException with 409 when fetch response returns 409', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+
+      (globalThis as any).fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        text: jest
+          .fn()
+          .mockResolvedValue('Conflict error from lottery audit endpoint'),
+      });
+
+      await expect(
+        async () =>
+          await service.triggerLotteryAudit(mockListingId, mockEndpoint),
+      ).rejects.toThrowError('Conflict error from lottery audit endpoint');
     });
   });
 });

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { of, throwError } from 'rxjs';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   ListingEventsTypeEnum,
@@ -1380,36 +1381,34 @@ describe('Testing lottery service', () => {
       const mockEndpoint = 'https://example.com/audit';
       const mockWorkQueueItemId = randomUUID();
 
-      (globalThis as any).fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: jest
-          .fn()
-          .mockResolvedValue({ WorkQueueItemID: mockWorkQueueItemId }),
-      });
-
-      const result = await service.triggerLotteryAudit(
-        mockListingId,
-        mockEndpoint,
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        of({
+          data: { WorkQueueItemID: mockWorkQueueItemId },
+        }),
       );
-      expect((globalThis as any).fetch).toHaveBeenCalledWith(mockEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ListingId: mockListingId }),
-      });
-      expect(result.workQueueItemID).toEqual(mockWorkQueueItemId);
+
+      await service.triggerLotteryAudit(mockListingId, mockEndpoint);
+      expect(httpService.post).toHaveBeenCalledWith(
+        mockEndpoint,
+        { ListingId: mockListingId },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
     });
 
-    it('should throw HttpException with 500 when fetch response is not ok', async () => {
+    it('should throw HttpException with 500 when HttpService returns error response', async () => {
       const mockListingId = randomUUID();
       const mockEndpoint = 'https://example.com/audit';
 
-      (globalThis as any).fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: jest
-          .fn()
-          .mockResolvedValue('Internal error from lottery audit endpoint'),
-      });
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        throwError(() => ({
+          response: {
+            status: 500,
+            data: 'Internal error from lottery audit endpoint',
+          },
+        })),
+      );
 
       await expect(
         async () =>
@@ -1417,17 +1416,19 @@ describe('Testing lottery service', () => {
       ).rejects.toThrowError('Internal error from lottery audit endpoint');
     });
 
-    it('should throw HttpException with 409 when fetch response returns 409', async () => {
+    it('should throw HttpException with 409 when HttpService returns 409', async () => {
       const mockListingId = randomUUID();
       const mockEndpoint = 'https://example.com/audit';
 
-      (globalThis as any).fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 409,
-        text: jest
-          .fn()
-          .mockResolvedValue('Conflict error from lottery audit endpoint'),
-      });
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        throwError(() => ({
+          response: {
+            status: 409,
+            data: 'Conflict error from lottery audit endpoint',
+          },
+        })),
+      );
 
       await expect(
         async () =>

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'crypto';
 import { Request as ExpressRequest, Response } from 'express';
-import { HttpModule } from '@nestjs/axios';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { of, throwError } from 'rxjs';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   ListingEventsTypeEnum,
@@ -1643,36 +1643,34 @@ describe('Testing lottery service', () => {
       const mockEndpoint = 'https://example.com/audit';
       const mockWorkQueueItemId = randomUUID();
 
-      (globalThis as any).fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: jest
-          .fn()
-          .mockResolvedValue({ WorkQueueItemID: mockWorkQueueItemId }),
-      });
-
-      const result = await service.triggerLotteryAudit(
-        mockListingId,
-        mockEndpoint,
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        of({
+          data: { WorkQueueItemID: mockWorkQueueItemId },
+        }),
       );
-      expect((globalThis as any).fetch).toHaveBeenCalledWith(mockEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ListingId: mockListingId }),
-      });
-      expect(result.workQueueItemID).toEqual(mockWorkQueueItemId);
+
+      await service.triggerLotteryAudit(mockListingId, mockEndpoint);
+      expect(httpService.post).toHaveBeenCalledWith(
+        mockEndpoint,
+        { ListingId: mockListingId },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
     });
 
-    it('should throw HttpException with 500 when fetch response is not ok', async () => {
+    it('should throw HttpException with 500 when HttpService returns error response', async () => {
       const mockListingId = randomUUID();
       const mockEndpoint = 'https://example.com/audit';
 
-      (globalThis as any).fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: jest
-          .fn()
-          .mockResolvedValue('Internal error from lottery audit endpoint'),
-      });
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        throwError(() => ({
+          response: {
+            status: 500,
+            data: 'Internal error from lottery audit endpoint',
+          },
+        })),
+      );
 
       await expect(
         async () =>
@@ -1680,17 +1678,19 @@ describe('Testing lottery service', () => {
       ).rejects.toThrowError('Internal error from lottery audit endpoint');
     });
 
-    it('should throw HttpException with 409 when fetch response returns 409', async () => {
+    it('should throw HttpException with 409 when HttpService returns 409', async () => {
       const mockListingId = randomUUID();
       const mockEndpoint = 'https://example.com/audit';
 
-      (globalThis as any).fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 409,
-        text: jest
-          .fn()
-          .mockResolvedValue('Conflict error from lottery audit endpoint'),
-      });
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        throwError(() => ({
+          response: {
+            status: 409,
+            data: 'Conflict error from lottery audit endpoint',
+          },
+        })),
+      );
 
       await expect(
         async () =>

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -824,6 +824,98 @@ describe('Testing lottery service', () => {
 
       expect(prisma.listingSnapshot.create).toHaveBeenCalled();
     });
+
+    it('should trigger lottery audit if env variable is set', async () => {
+      const mockEndpoint = 'https://example.com/audit';
+      config.get = jest.fn().mockImplementation((key: string) => {
+        if (key === 'LOTTERY_AUDIT_ENDPOINT') return mockEndpoint;
+        return undefined; // or the real value for other keys
+      });
+      const mockWorkQueueItemId = randomUUID();
+
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        of({
+          data: { WorkQueueItemID: mockWorkQueueItemId },
+        }),
+      );
+      const listingId = randomUUID();
+      const requestingUser = {
+        firstName: 'requesting fName',
+        lastName: 'requesting lName',
+        email: 'requestingUser@email.com',
+        jurisdictions: [{ id: 'juris id' }],
+        userRoles: { isAdmin: true },
+      } as unknown as User;
+
+      canOrThrowMock.mockResolvedValue(true);
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: listingId,
+        jurisdictions: {
+          featureFlags: [],
+        },
+        lotteryLastRunAt: null,
+        lotteryStatus: null,
+        status: ListingsStatusEnum.closed,
+      });
+      const applications = mockApplicationSet(5, new Date());
+      prisma.applications.findMany = jest.fn().mockReturnValue(applications);
+
+      prisma.multiselectQuestions.findMany = jest.fn().mockReturnValue([
+        {
+          ...mockMultiselectQuestion(
+            0,
+            new Date(),
+            MultiselectQuestionsApplicationSectionEnum.preferences,
+          ),
+          options: [
+            { id: 1, text: 'text' },
+            { id: 2, text: 'text', collectAddress: true },
+          ],
+        },
+        {
+          ...mockMultiselectQuestion(
+            1,
+            new Date(),
+            MultiselectQuestionsApplicationSectionEnum.programs,
+          ),
+          options: [{ id: 1, text: 'text' }],
+        },
+      ]);
+
+      prisma.applicationLotteryTotal.create = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.applicationLotteryTotal.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.listings.update = jest.fn().mockResolvedValue({
+        id: listingId,
+        lotteryLastRunAt: null,
+        lotteryStatus: null,
+      });
+      prisma.userAccounts.findMany = jest.fn().mockResolvedValue([]);
+      prisma.listingSnapshot.create = jest
+        .fn()
+        .mockResolvedValue({ id: 'example snapshot id' });
+
+      await service.lotteryGenerate(
+        { user: requestingUser } as unknown as ExpressRequest,
+        {} as unknown as Response,
+        { id: listingId },
+      );
+      expect(httpService.post).toHaveBeenCalledWith(
+        mockEndpoint,
+        { ListingId: listingId },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    });
   });
 
   describe('Testing lotteryStatus()', () => {

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -12,6 +12,7 @@ import {
   MultiselectQuestionsApplicationSectionEnum,
   ReviewOrderTypeEnum,
 } from '@prisma/client';
+import { HttpService } from '@nestjs/axios';
 import { mockApplicationSet } from './application.service.spec';
 import { mockMultiselectQuestion } from './multiselect-question.service.spec';
 import { randomNoun } from '../../../prisma/seed-helpers/word-generator';
@@ -78,14 +79,25 @@ describe('Testing lottery service', () => {
             lotteryPublishedApplicant: lotteryPublishedApplicantMock,
           },
         },
-        ConfigService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: HttpService,
+          useValue: {
+            post: jest.fn(),
+            get: jest.fn(),
+          },
+        },
         Logger,
         SchedulerRegistry,
         GoogleTranslateService,
         CronJobService,
         SnapshotCreateService,
       ],
-      imports: [HttpModule],
     }).compile();
 
     service = module.get<LotteryService>(LotteryService);
@@ -1622,6 +1634,68 @@ describe('Testing lottery service', () => {
       await expect(
         async () => await service.lotteryTotals(listingId, null),
       ).rejects.toThrowError();
+    });
+  });
+
+  describe('Testing triggerLotteryAudit()', () => {
+    it('should trigger a lottery audit and return the response', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+      const mockWorkQueueItemId = randomUUID();
+
+      (globalThis as any).fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue({ WorkQueueItemID: mockWorkQueueItemId }),
+      });
+
+      const result = await service.triggerLotteryAudit(
+        mockListingId,
+        mockEndpoint,
+      );
+      expect((globalThis as any).fetch).toHaveBeenCalledWith(mockEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ListingId: mockListingId }),
+      });
+      expect(result.workQueueItemID).toEqual(mockWorkQueueItemId);
+    });
+
+    it('should throw HttpException with 500 when fetch response is not ok', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+
+      (globalThis as any).fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: jest
+          .fn()
+          .mockResolvedValue('Internal error from lottery audit endpoint'),
+      });
+
+      await expect(
+        async () =>
+          await service.triggerLotteryAudit(mockListingId, mockEndpoint),
+      ).rejects.toThrowError('Internal error from lottery audit endpoint');
+    });
+
+    it('should throw HttpException with 409 when fetch response returns 409', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+
+      (globalThis as any).fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        text: jest
+          .fn()
+          .mockResolvedValue('Conflict error from lottery audit endpoint'),
+      });
+
+      await expect(
+        async () =>
+          await service.triggerLotteryAudit(mockListingId, mockEndpoint),
+      ).rejects.toThrowError('Conflict error from lottery audit endpoint');
     });
   });
 });


### PR DESCRIPTION
# feat(api): automate lottery audit workflow and refactor dependencies

- Implement automated lottery audit trigger in LotteryService.lotteryGenerate
- Refactor triggerLotteryAudit to use native global fetch instead of HttpService
- Remove manual POST /lottery/:id/audit endpoint from LotteryController
- Remove HttpModule and HttpService dependencies from LotteryModule and LotteryService
- Enhance LotteryService unit tests with comprehensive audit trigger coverage

This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR automates the lottery audit workflow by integrating it directly into the `lotteryGenerate` process. When a LOTTERY_AUDIT_ENDPOINT value is supplied, then a lottery run triggers an audit to that endpoint. 

## How Can This Be Tested/Reviewed?

1. **Environment Config**: Ensure your `api/.env` has a valid URL for `LOTTERY_AUDIT_ENDPOINT`. (A sample is provided in `.env.template`).
2. **Execution**: Trigger a lottery generation for a listing.
3. **Validation**: 
   - Check the `api` logs for `Triggering lottery audit for listing [listingId]`.
   - Verify the audit endpoint receives a `POST` request with the correct `ListingId`.
4. **Unit Tests**: Run `npm run test api/test/unit/services/lottery.service.spec.ts` and verify the `triggerLotteryAudit()` test suite passes.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
