### PR TITLE
fix: exclude tests from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,11 +28,3 @@
 backend/core/dist
 backend/core/test
 README.md
-
-**/.jest
-**/__mocks__
-**/__tests__
-**/.cypress
-**/.next
-
-**/.terraform

--- a/tasks/import-listings/.dockerignore
+++ b/tasks/import-listings/.dockerignore
@@ -1,7 +1,4 @@
 .build
-node_modules
-dist
-test
 coverage
 node_modules
 README.md


### PR DESCRIPTION
This PR addresses [failing pipeline](https://us-west-1.console.aws.amazon.com/codesuite/codepipeline/pipelines/doorway-prod-bloom-app/view?action=BuildImportListings&region=us-west-1&stage=BuildImages)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The docker images run tests in the pipeline. We added all tests files to the .dockerignore. This changes reverts that. 

Note: we will need to change how the pipeline works when we "corify" Doorway

## How Can This Be Tested/Reviewed?

Not much can be done until it is merged

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
