### PR TITLE
fix: edit account server side props

### DIFF
--- a/sites/public/src/pages/account/edit.tsx
+++ b/sites/public/src/pages/account/edit.tsx
@@ -2,30 +2,20 @@ import React, { useContext } from "react"
 import { AuthContext } from "@bloom-housing/shared-helpers"
 import { EditPublicAccount } from "../../components/account/EditPublicAccount"
 import { EditAdvocateAccount } from "../../components/account/EditAdvocateAccount"
-import { fetchAgencies, fetchJurisdictionByName } from "../../lib/hooks"
-import { Agency } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
-interface EditProps {
-  agencies: Agency[]
-}
-
-const Edit = (props: EditProps) => {
+const Edit = () => {
   const { profile } = useContext(AuthContext)
-  return profile?.isAdvocate ? (
-    <EditAdvocateAccount agencies={props.agencies} />
-  ) : (
-    <EditPublicAccount />
-  )
+  return profile?.isAdvocate ? <EditAdvocateAccount agencies={[]} /> : <EditPublicAccount />
 }
 
 export default Edit
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function getServerSideProps(context: { req: any; query: any }) {
-  const jurisdiction = await fetchJurisdictionByName(context.req)
-  const agencies = await fetchAgencies(context.req, jurisdiction?.id)
+// export async function getServerSideProps(context: { req: any; query: any }) {
+//   const jurisdiction = await fetchJurisdictionByName(context.req)
+//   const agencies = await fetchAgencies(context.req, jurisdiction?.id)
 
-  return {
-    props: { jurisdiction, agencies: agencies?.items || [] },
-  }
-}
+//   return {
+//     props: { jurisdiction, agencies: agencies?.items || [] },
+//   }
+// }


### PR DESCRIPTION
This PR addresses issue found during bash

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When attempting to load the user edit page in the deployed staging environment a 504 bad gateway response is happening. This is because the the getServerSideProps calls are failing. Specifically it is due to the base url not being configured at build time. All configuration should go through the runtimeConfiguration.

Because we don't need the data from that call as we are not using the advocate account this PR comments out the entire serverSideProps.

## How Can This Be Tested/Reviewed?

Log into a public account and edit the account via the /account/edit page. The page should load and you should be able to edit any field

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
