### PR TITLE
fix: listing export memory error

### DIFF
--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -143,7 +143,7 @@ export class ListingController {
     return await this.listingCsvExportService.exporterSecure(req, queryParams);
   }
 
-  @Get('mapMarkers')
+  @Post('mapMarkers')
   @ApiOperation({
     summary: 'Get listing map markers',
     operationId: 'mapMarkers',

--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -129,7 +129,21 @@ export class ListingController {
     return await this.listingCsvExportService.exportFile(req, res, queryParams);
   }
 
-  @Post('mapMarkers')
+  @Get(`csvSecure`)
+  @ApiOperation({
+    summary: 'Get listings and units as secured zip',
+    operationId: 'listAsCsvSecure',
+  })
+  @UseInterceptors(ExportLogInterceptor)
+  async listAsCsvSecure(
+    @Request() req: ExpressRequest,
+    @Query(new ValidationPipe(defaultValidationPipeOptions))
+    queryParams: ListingCsvQueryParams,
+  ): Promise<string> {
+    return await this.listingCsvExportService.exporterSecure(req, queryParams);
+  }
+
+  @Get('mapMarkers')
   @ApiOperation({
     summary: 'Get listing map markers',
     operationId: 'mapMarkers',

--- a/api/src/modules/listing.module.ts
+++ b/api/src/modules/listing.module.ts
@@ -13,6 +13,7 @@ import { ListingCsvExporterService } from '../services/listing-csv-export.servic
 import { GoogleTranslateService } from '../services/google-translate.service';
 import { TranslationService } from '../services/translation.service';
 import { SnapshotCreateModule } from './snapshot-create.module';
+// import { S3Module } from './s3.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { SnapshotCreateModule } from './snapshot-create.module';
     PermissionModule,
     PrismaModule,
     SnapshotCreateModule,
+    // S3Module,
   ],
   controllers: [ListingController],
   providers: [

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -77,7 +77,7 @@ includeViews.csv = {
   },
   userAccounts: true,
 };
-const NUMBER_TO_PAGINATE_BY = 500;
+const NUMBER_TO_PAGINATE_BY = 100;
 
 export const formatStatus = {
   active: 'Public',

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -76,6 +76,8 @@ includeViews.csv = {
     },
   },
   userAccounts: true,
+  units: { select: { id: true } },
+  unitGroups: { select: { id: true } },
 };
 const NUMBER_TO_PAGINATE_BY = 100;
 
@@ -544,7 +546,29 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
               new Promise(async (resolve) => {
                 // grab listings NUMBER_TO_PAGINATE_BY at a time
                 const paginatedListings = await this.prisma.listings.findMany({
-                  include: includeViews.csv,
+                  include: {
+                    jurisdictions: true,
+                    units: {
+                      include: {
+                        unitTypes: true,
+                        unitAmiChartOverrides: true,
+                      },
+                    },
+                    unitGroups: {
+                      include: {
+                        unitTypes: true,
+                        unitGroupAmiLevels: {
+                          include: {
+                            amiChart: {
+                              include: {
+                                jurisdictions: true,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
                   where: {
                     id: {
                       in: listings

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -56,6 +56,8 @@ import { UnitGroupSummary } from '../dtos/unit-groups/unit-group-summary.dto';
 import { addUnitGroupsSummarized } from '../utilities/unit-groups-transformations';
 import { ListingDocuments } from '../dtos/listings/listing-documents.dto';
 import { ListingParkingType } from '../dtos/listings/listing-parking-type.dto';
+import { generatePresignedGetURL, uploadToS3 } from '../utilities/s3-helpers';
+// import { S3Service } from './s3.service';
 
 includeViews.csv = {
   listingMultiselectQuestions: {
@@ -75,7 +77,7 @@ includeViews.csv = {
   },
   userAccounts: true,
 };
-const NUMBER_TO_PAGINATE_BY = 100;
+const NUMBER_TO_PAGINATE_BY = 500;
 
 export const formatStatus = {
   active: 'Public',
@@ -188,7 +190,7 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
   constructor(
     private prisma: PrismaService,
     @Inject(Logger)
-    private logger = new Logger(ListingCsvExporterService.name),
+    private logger = new Logger(ListingCsvExporterService.name), // private s3Service: S3Service,
   ) {}
 
   /**
@@ -226,6 +228,141 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
       `src/temp/unit-groups-${user.id}-${new Date().getTime()}.csv`,
     );
 
+    const enableUnitGroups = doAnyJurisdictionHaveFeatureFlagSet(
+      user.jurisdictions,
+      FeatureFlagEnum.enableUnitGroups,
+    );
+
+    const hasUnits =
+      !enableUnitGroups ||
+      doAnyJurisdictionHaveFalsyFeatureFlagValue(
+        user.jurisdictions,
+        FeatureFlagEnum.enableUnitGroups,
+      );
+
+    await this.generateExportedFiles(
+      user,
+      queryParams,
+      hasUnits,
+      enableUnitGroups,
+      listingFilePath,
+      unitFilePath,
+      unitGroupsFilePath,
+    );
+
+    return new Promise((resolve) => {
+      const output = fs.createWriteStream(zipFilePath);
+      const archive = archiver('zip', { zlib: { level: 9 } });
+
+      output.on('close', () => {
+        const zipFile = createReadStream(zipFilePath);
+        resolve(new StreamableFile(zipFile));
+      });
+
+      archive.pipe(output);
+      const listingCsv = createReadStream(listingFilePath);
+      archive.append(listingCsv, { name: 'listings.csv' });
+      if (hasUnits) {
+        const unitCsv = createReadStream(unitFilePath);
+        archive.append(unitCsv, { name: 'units.csv' });
+      }
+      if (enableUnitGroups) {
+        const unitGroupsCsv = createReadStream(unitGroupsFilePath);
+        archive.append(unitGroupsCsv, { name: 'unitGroups.csv' });
+      }
+      archive.finalize();
+    });
+  }
+
+  async exporterSecure<QueryParams extends ListingCsvQueryParams>(
+    req: ExpressRequest,
+    queryParams: QueryParams,
+  ): Promise<string> {
+    this.logger.warn('Generating Listing-Unit Zip Secure');
+    const user = mapTo(User, req['user']);
+    await this.authorizeCSVExport(user);
+    const now = new Date();
+
+    const zipFileName = `listings-units-${user.id}-${new Date().getTime()}.zip`;
+    const zipFilePath = join(process.cwd(), `src/temp/${zipFileName}`);
+
+    const listingFilePath = join(
+      process.cwd(),
+      `src/temp/listings-${user.id}-${new Date().getTime()}.csv`,
+    );
+    const unitFilePath = join(
+      process.cwd(),
+      `src/temp/units-${user.id}-${new Date().getTime()}.csv`,
+    );
+    const unitGroupsFilePath = join(
+      process.cwd(),
+      `src/temp/unit-groups-${user.id}-${new Date().getTime()}.csv`,
+    );
+
+    const enableUnitGroups = doAnyJurisdictionHaveFeatureFlagSet(
+      user.jurisdictions,
+      FeatureFlagEnum.enableUnitGroups,
+    );
+
+    const hasUnits =
+      !enableUnitGroups ||
+      doAnyJurisdictionHaveFalsyFeatureFlagValue(
+        user.jurisdictions,
+        FeatureFlagEnum.enableUnitGroups,
+      );
+
+    await this.generateExportedFiles(
+      user,
+      queryParams,
+      hasUnits,
+      enableUnitGroups,
+      listingFilePath,
+      unitFilePath,
+      unitGroupsFilePath,
+    );
+
+    const output = fs.createWriteStream(zipFilePath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    archive.pipe(output);
+    const listingCsv = createReadStream(listingFilePath);
+    archive.append(listingCsv, { name: 'listings.csv' });
+    if (hasUnits) {
+      const unitCsv = createReadStream(unitFilePath);
+      archive.append(unitCsv, { name: 'units.csv' });
+    }
+    if (enableUnitGroups) {
+      const unitGroupsCsv = createReadStream(unitGroupsFilePath);
+      archive.append(unitGroupsCsv, { name: 'unitGroups.csv' });
+    }
+    await archive.finalize();
+
+    const s3Key = `listing_export_${now.getTime()}.zip`;
+    await uploadToS3(
+      process.env.ASSET_FS_PRIVATE_CONFIG_s3_BUCKET,
+      s3Key,
+      zipFilePath,
+      process.env.ASSET_FS_CONFIG_s3_REGION,
+    );
+
+    return await generatePresignedGetURL(
+      process.env.ASSET_FS_PRIVATE_CONFIG_s3_BUCKET,
+      s3Key,
+      process.env.ASSET_FS_CONFIG_s3_REGION,
+      Number(process.env.TTL_SECURE_FILES || '0'),
+    );
+    // await this.s3Service.uploadToPrivate(s3Key, zipFilePath);
+    // return await this.s3Service.urlForPrivate(s3Key);
+  }
+
+  async generateExportedFiles<QueryParams extends ListingCsvQueryParams>(
+    user: User,
+    queryParams: QueryParams,
+    hasUnits: boolean,
+    enableUnitGroups: boolean,
+    listingFilePath: string,
+    unitFilePath: string,
+    unitGroupsFilePath: string,
+  ): Promise<void> {
     if (queryParams.timeZone) {
       this.timeZone = queryParams.timeZone;
     }
@@ -241,34 +378,17 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
         id: jurisdiction.id,
       });
     });
-
-    const enableUnitGroups = doAnyJurisdictionHaveFeatureFlagSet(
-      user.jurisdictions,
-      FeatureFlagEnum.enableUnitGroups,
-    );
-
-    const hasUnits =
-      !enableUnitGroups ||
-      doAnyJurisdictionHaveFalsyFeatureFlagValue(
-        user.jurisdictions,
-        FeatureFlagEnum.enableUnitGroups,
-      );
-
     const listings = await this.prisma.listings.findMany({
-      include: includeViews.csv,
+      select: {
+        id: true,
+      },
       where: whereClause,
     });
 
-    // Add unit groups summarized to listings
-    // should be removed when unit summarized stored in db
-    addUnitGroupsSummarized(listings as unknown as Listing[]);
-
-    await this.createCsv(listingFilePath, queryParams, {
+    await this.createCsv(listingFilePath, whereClause, {
       listings: listings as unknown as Listing[],
       user,
     });
-
-    const listingCsv = createReadStream(listingFilePath);
 
     if (enableUnitGroups) {
       await this.createUnitCsv(
@@ -285,28 +405,6 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
         false,
       );
     }
-
-    return new Promise((resolve) => {
-      const output = fs.createWriteStream(zipFilePath);
-      const archive = archiver('zip', { zlib: { level: 9 } });
-
-      output.on('close', () => {
-        const zipFile = createReadStream(zipFilePath);
-        resolve(new StreamableFile(zipFile));
-      });
-
-      archive.pipe(output);
-      archive.append(listingCsv, { name: 'listings.csv' });
-      if (hasUnits) {
-        const unitCsv = createReadStream(unitFilePath);
-        archive.append(unitCsv, { name: 'units.csv' });
-      }
-      if (enableUnitGroups) {
-        const unitGroupsCsv = createReadStream(unitGroupsFilePath);
-        archive.append(unitGroupsCsv, { name: 'unitGroups.csv' });
-      }
-      archive.finalize();
-    });
   }
 
   /**
@@ -315,9 +413,9 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
    * @param optionParams
    * @returns a promise with SuccessDTO
    */
-  async createCsv<QueryParams extends ListingCsvQueryParams>(
+  async createCsv(
     filename: string,
-    queryParams: QueryParams,
+    whereClause: Record<string, any>,
     optionParams: { listings: Listing[]; user: User },
   ): Promise<void> {
     const csvHeaders = await this.getCsvHeaders(optionParams.user);
@@ -334,43 +432,77 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
         .on('close', () => {
           resolve();
         })
-        .on('open', () => {
+        .on('open', async () => {
           writableStream.write(
             csvHeaders.map((header) => header.label).join(',') + '\n',
           );
 
-          // now loop over listings and write them to file
-          optionParams.listings.forEach((listing) => {
-            let row = '';
-            csvHeaders.forEach((header, index) => {
-              let value = header.path.split('.').reduce((acc, curr) => {
-                // handles working with arrays, e.g. householdMember.0.firstName
-                if (!isNaN(Number(curr))) {
-                  const index = Number(curr);
-                  return acc[index];
-                }
+          const promiseArray: Promise<string>[] = [];
+          for (
+            let i = 0;
+            i < optionParams.listings.length;
+            i += NUMBER_TO_PAGINATE_BY
+          ) {
+            promiseArray.push(
+              new Promise(async (resolve) => {
+                // grab listings NUMBER_TO_PAGINATE_BY at a time
+                const paginatedListings = await this.prisma.listings.findMany({
+                  include: includeViews.csv,
+                  where: {
+                    id: {
+                      in: optionParams.listings
+                        .slice(i, i + NUMBER_TO_PAGINATE_BY)
+                        .map((app) => app.id),
+                    },
+                  },
+                });
+                let data = '';
+                // now loop over listings and write them to file
+                paginatedListings.forEach((listing) => {
+                  let row = '';
+                  csvHeaders.forEach((header, index) => {
+                    let value = header.path.split('.').reduce((acc, curr) => {
+                      // handles working with arrays, e.g. householdMember.0.firstName
+                      if (!isNaN(Number(curr))) {
+                        const index = Number(curr);
+                        return acc[index];
+                      }
 
-                if (acc === null || acc === undefined) {
-                  return '';
-                }
-                return acc[curr];
-              }, listing);
-              value = value === undefined ? '' : value === null ? '' : value;
-              if (header.format) {
-                value = header.format(value, listing);
-              }
+                      if (acc === null || acc === undefined) {
+                        return '';
+                      }
+                      return acc[curr];
+                    }, listing);
+                    value =
+                      value === undefined ? '' : value === null ? '' : value;
+                    if (header.format) {
+                      value = header.format(value, listing);
+                    }
 
-              row += value ? `"${value.toString().replace(/"/g, `""`)}"` : '';
-              if (index < csvHeaders.length - 1) {
-                row += ',';
-              }
-            });
+                    row += value
+                      ? `"${value.toString().replace(/"/g, `""`)}"`
+                      : '';
+                    if (index < csvHeaders.length - 1) {
+                      row += ',';
+                    }
+                  });
 
+                  data += row + '\n';
+                });
+                resolve(data);
+              }),
+            );
+          }
+
+          const resolvedArray = await Promise.all(promiseArray);
+          // now loop over batched row data and write them to file
+          resolvedArray.forEach((row) => {
             try {
-              writableStream.write(row + '\n');
+              writableStream.write(row);
             } catch (e) {
               console.log('writeStream write error = ', e);
               writableStream.once('drain', () => {
+                console.log('drain buffer');
                 writableStream.write(row + '\n');
               });
             }
@@ -390,23 +522,6 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
       ? this.getUnitGroupCsvHeaders()
       : this.getUnitCsvHeaders();
 
-    const data = enableUnitGroups
-      ? listings.flatMap(
-          (listing) =>
-            listing.unitGroups?.map((unitGroup, index) => ({
-              listing: { id: listing.id, name: listing.name },
-              unitGroup,
-              unitGroupSummary:
-                listing.unitGroupsSummarized?.unitGroupSummary?.[index],
-            })) || [],
-        )
-      : listings.flatMap((listing) =>
-          (listing.units || []).map((unit) => ({
-            listing: { id: listing.id, name: listing.name },
-            unit,
-          })),
-        );
-
     return new Promise((resolve, reject) => {
       const writableStream = fs.createWriteStream(`${filename}`);
       writableStream
@@ -418,46 +533,105 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
         .on('close', () => {
           resolve();
         })
-        .on('open', () => {
+        .on('open', async () => {
           writableStream.write(
             csvHeaders.map((header) => header.label).join(',') + '\n',
           );
-          data.forEach((item) => {
-            let row = '';
-            csvHeaders.forEach((header, index) => {
-              let value = header.path.split('.').reduce((acc, curr) => {
-                // handles working with arrays, e.g. householdMember.0.firstName
-                if (!isNaN(Number(curr))) {
-                  const index = Number(curr);
-                  return acc[index];
+
+          const promiseArray: Promise<string>[] = [];
+          for (let i = 0; i < listings.length; i += NUMBER_TO_PAGINATE_BY) {
+            promiseArray.push(
+              new Promise(async (resolve) => {
+                // grab listings NUMBER_TO_PAGINATE_BY at a time
+                const paginatedListings = await this.prisma.listings.findMany({
+                  include: includeViews.csv,
+                  where: {
+                    id: {
+                      in: listings
+                        .slice(i, i + NUMBER_TO_PAGINATE_BY)
+                        .map((app) => app.id),
+                    },
+                  },
+                });
+
+                let data = '';
+
+                if (enableUnitGroups) {
+                  // Add unit groups summarized to listings
+                  // should be removed when unit summarized stored in db
+                  addUnitGroupsSummarized(
+                    paginatedListings as unknown as Listing[],
+                  );
                 }
+                const flattenedListings = enableUnitGroups
+                  ? (paginatedListings as unknown as Listing[]).flatMap(
+                      (listing) =>
+                        listing.unitGroups?.map((unitGroup, index) => ({
+                          listing: { id: listing.id, name: listing.name },
+                          unitGroup,
+                          unitGroupSummary:
+                            listing.unitGroupsSummarized?.unitGroupSummary?.[
+                              index
+                            ],
+                        })) || [],
+                    )
+                  : (paginatedListings as unknown as Listing[]).flatMap(
+                      (listing) =>
+                        (listing.units || []).map((unit) => ({
+                          listing: { id: listing.id, name: listing.name },
+                          unit,
+                        })),
+                    );
 
-                if (acc === null || acc === undefined) {
-                  return '';
-                }
-                return acc[curr];
-              }, item);
-              value = value === undefined ? '' : value === null ? '' : value;
-              if (header.format) {
-                value = header.format(value);
-              }
+                flattenedListings.forEach((item) => {
+                  let row = '';
+                  csvHeaders.forEach((header, index) => {
+                    let value = header.path.split('.').reduce((acc, curr) => {
+                      // handles working with arrays, e.g. householdMember.0.firstName
+                      if (!isNaN(Number(curr))) {
+                        const index = Number(curr);
+                        return acc[index];
+                      }
 
-              row += value ? `"${value.toString().replace(/"/g, `""`)}"` : '';
-              if (index < csvHeaders.length - 1) {
-                row += ',';
-              }
-            });
+                      if (acc === null || acc === undefined) {
+                        return '';
+                      }
+                      return acc[curr];
+                    }, item);
+                    value =
+                      value === undefined ? '' : value === null ? '' : value;
+                    if (header.format) {
+                      value = header.format(value);
+                    }
 
+                    row += value
+                      ? `"${value.toString().replace(/"/g, `""`)}"`
+                      : '';
+                    if (index < csvHeaders.length - 1) {
+                      row += ',';
+                    }
+                  });
+
+                  data += row + '\n';
+                });
+                resolve(data);
+              }),
+            );
+          }
+
+          const resolvedArray = await Promise.all(promiseArray);
+          // now loop over batched row data and write them to file
+          resolvedArray.forEach((row) => {
             try {
-              writableStream.write(row + '\n');
+              writableStream.write(row);
             } catch (e) {
               console.log('writeStream write error = ', e);
               writableStream.once('drain', () => {
+                console.log('drain buffer');
                 writableStream.write(row + '\n');
               });
             }
           });
-
           writableStream.end();
         });
     });

--- a/api/test/unit/services/listing-csv-export.service.spec.ts
+++ b/api/test/unit/services/listing-csv-export.service.spec.ts
@@ -21,18 +21,21 @@ import { Unit } from '../../../src/dtos/units/unit.dto';
 import { FeatureFlagEnum } from '../../../src/enums/feature-flags/feature-flags-enum';
 import { Jurisdiction } from '../../../src/dtos/jurisdictions/jurisdiction.dto';
 import { FeatureFlag } from '../../../src/dtos/feature-flags/feature-flag.dto';
+// import { S3Service } from '../../../src/services/s3.service';
 
 describe('Testing listing csv export service', () => {
   let service: ListingCsvExporterService;
+  let prisma: PrismaService;
   let writeStream;
 
   beforeAll(async () => {
     process.env.CLOUDINARY_CLOUD_NAME = 'exygy';
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PrismaService, ListingCsvExporterService, Logger],
+      providers: [PrismaService, ListingCsvExporterService, Logger], //S3Service
     }).compile();
 
     service = module.get<ListingCsvExporterService>(ListingCsvExporterService);
+    prisma = module.get<PrismaService>(PrismaService);
   });
 
   beforeEach(() => {
@@ -243,6 +246,9 @@ describe('Testing listing csv export service', () => {
 
   describe('createCsv', () => {
     it('should create the listing csv with no feature flags', async () => {
+      prisma.listings.findMany = jest
+        .fn()
+        .mockResolvedValueOnce([mockBaseListing]);
       await service.createCsv('sampleFile.csv', undefined, {
         listings: [mockBaseListing],
         user: { jurisdictions: [mockBaseJurisdiction] } as unknown as User,
@@ -260,6 +266,17 @@ describe('Testing listing csv export service', () => {
       );
     });
     it('should create the listing csv with marketing type seasons', async () => {
+      prisma.listings.findMany = jest.fn().mockResolvedValueOnce([
+        {
+          ...mockBaseListing,
+          marketingMonth: null,
+          showWaitlist: false,
+          referralApplication: null,
+          listingsBuildingSelectionCriteriaFile: null,
+          buildingSelectionCriteria:
+            'https://www.example.com/building-criteria.pdf',
+        },
+      ]);
       await service.createCsv('sampleFile.csv', undefined, {
         listings: [
           {
@@ -299,6 +316,14 @@ describe('Testing listing csv export service', () => {
       );
     });
     it('should create the listing csv with marketing type months', async () => {
+      prisma.listings.findMany = jest.fn().mockResolvedValue([
+        {
+          ...mockBaseListing,
+          marketingSeason: null,
+          showWaitlist: false,
+          referralApplication: null,
+        },
+      ]);
       await service.createCsv('sampleFile.csv', undefined, {
         listings: [
           {
@@ -402,6 +427,12 @@ describe('Testing listing csv export service', () => {
           },
         ],
       };
+      prisma.listings.findMany = jest
+        .fn()
+        .mockResolvedValueOnce([
+          mockListing as unknown as Listing,
+          mockListing2 as unknown as Listing,
+        ]);
       await service.createUnitCsv('sampleFile.csv', [
         mockListing as unknown as Listing,
         mockListing2 as unknown as Listing,
@@ -439,13 +470,17 @@ describe('Testing listing csv export service', () => {
         unitGroupAmiLevels: [
           {
             id: randomUUID(),
-            monthlyRentDeterminationType: 'percentOfIncome',
+            monthlyRentDeterminationType: 'flatRent',
             amiChart: { id: randomUUID(), name: 'Ami Chart Name' },
+            amiPercentage: 30,
+            flatRentValue: 3000,
           },
           {
             id: randomUUID(),
             monthlyRentDeterminationType: 'flatRent',
             amiChart: { id: randomUUID(), name: 'Ami Chart Name' },
+            amiPercentage: 50,
+            flatRentValue: 4000,
           },
         ],
       };
@@ -470,6 +505,10 @@ describe('Testing listing csv export service', () => {
         },
       };
 
+      prisma.listings.findMany = jest
+        .fn()
+        .mockResolvedValueOnce([mockListing as unknown as Listing]);
+
       await service.createUnitCsv(
         'sampleFile.csv',
         [mockListing as unknown as Listing],
@@ -485,7 +524,7 @@ describe('Testing listing csv export service', () => {
       );
 
       expect(content).toContain(
-        `"listing1-ID","listing1-Name","${unitGroup.id}","Studio, One Bedroom","Ami Chart Name","30% - 50%","Percent Of Income, Flat Rent","3000 - 4000","5","2","No","1","3","800","1000","1","3","1","2"`,
+        `"listing1-ID","listing1-Name","${unitGroup.id}","Studio, One Bedroom","Ami Chart Name","30% - 50%","Flat Rent","$3000 - $4000","5","2","No","1","3","800","1000","1","3","1","2"`,
       );
     });
   });

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -229,6 +229,25 @@ export class ListingsService {
     })
   }
   /**
+   * Get listings and units as secured zip
+   */
+  listAsCsvSecure(
+    params: {
+      /**  */
+      timeZone?: string
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/csvSecure"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+      configs.params = { timeZone: params["timeZone"] }
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
    * Get listing map markers
    */
   mapMarkers(
@@ -241,7 +260,11 @@ export class ListingsService {
     return new Promise((resolve, reject) => {
       let url = basePath + "/listings/mapMarkers"
 
-      const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
 
       let data = params.body
 
@@ -10739,6 +10762,7 @@ export enum HouseholdMemberRelationship {
   "grandparentGreatGrandparent" = "grandparentGreatGrandparent",
   "liveInAide" = "liveInAide",
   "other" = "other",
+  "aideOrAttendant" = "aideOrAttendant",
 }
 export type AllExtraDataTypes = BooleanInput | TextInput | AddressInput
 export enum MultiselectQuestionOrderByKeys {

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -260,11 +260,7 @@ export class ListingsService {
     return new Promise((resolve, reject) => {
       let url = basePath + "/listings/mapMarkers"
 
-      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
-
-      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+      const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
 
       let data = params.body
 

--- a/sites/partners/.env.template
+++ b/sites/partners/.env.template
@@ -30,5 +30,5 @@ APPLICATION_EXPORT_AS_SPREADSHEET=FALSE
 # controls use of edit, republish, and reopen functionality when listing is closed
 LIMIT_CLOSED_LISTING_ACTIONS=FALSE
 
-# controls whether we download via a short lived secure URL or via direct download from the API
+# when true we will download exported listings and applications through the secure pathway of s3 private bucket
 USE_SECURE_DOWNLOAD_PATHWAY=TRUE

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -140,7 +140,7 @@ export function useListingsData({
   }
 }
 
-export const useListingExport = () => {
+export const useListingExport = (useSecurePathway = false) => {
   const { listingsService } = useContext(AuthContext)
   const { addToast } = useContext(MessageContext)
 
@@ -150,12 +150,21 @@ export const useListingExport = () => {
     setCsvExportLoading(true)
 
     try {
-      const content = await listingsService.listAsCsv(
-        { timeZone: dayjs.tz.guess() },
-        { responseType: "arraybuffer" }
-      )
-      const blob = new Blob([new Uint8Array(content)], { type: "application/zip" })
-      const url = window.URL.createObjectURL(blob)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let content: any
+      let url: string
+
+      if (useSecurePathway) {
+        content = await listingsService.listAsCsvSecure({ timeZone: dayjs.tz.guess() })
+        url = content
+      } else {
+        content = await listingsService.listAsCsv(
+          { timeZone: dayjs.tz.guess() },
+          { responseType: "arraybuffer" }
+        )
+        const blob = new Blob([new Uint8Array(content)], { type: "application/zip" })
+        url = window.URL.createObjectURL(blob)
+      }
       const link = document.createElement("a")
       link.href = url
       const now = new Date()

--- a/sites/partners/src/pages/index.tsx
+++ b/sites/partners/src/pages/index.tsx
@@ -107,7 +107,7 @@ export default function ListingsList() {
     profile?.userRoles?.isJurisdictionalAdmin ||
     profile?.userRoles?.isLimitedJurisdictionalAdmin ||
     false
-  const { onExport, csvExportLoading } = useListingExport()
+  const { onExport, csvExportLoading } = useListingExport(!!process.env.useSecureDownloadPathway)
   const router = useRouter()
   const tableOptions = useAgTable()
 


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Doorway listings export is failing and crashing the site due to memory issues. Pulling over new pagination logic should alleviate it

## How Can This Be Tested/Reviewed?

With `USE_SECURE_DOWNLOAD_PATHWAY=TRUE` in the partners env, run the app and export listings

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
