### PR TITLE
chore: update the accessibility label string

### DIFF
--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -1762,7 +1762,7 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
       },
       {
         path: 'unit.accessibilityPriorityType',
-        label: 'Accessibility Priority Type',
+        label: 'Accessibility Unit Type',
       },
     ];
   }

--- a/sites/partners/__tests__/components/listings/PaperListingForm/UnitForm.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/UnitForm.test.tsx
@@ -78,10 +78,12 @@ describe("UnitForm", () => {
     expect(screen.getByRole("textbox", { name: "Unit number" })).toBeInTheDocument()
 
     // Unit type dropdown selector
-    const unitTypeSelector = screen.getByRole("combobox", { name: /unit type/i })
+    const unitTypeSelector = screen.getByRole("combobox", { name: /^unit type/i })
     expect(unitTypeSelector).toBeInTheDocument()
     expect(within(unitTypeSelector).getAllByRole("option")).toHaveLength(8)
-    expect(within(unitTypeSelector).getByRole("option", { name: /unit type/i })).toBeInTheDocument()
+    expect(
+      within(unitTypeSelector).getByRole("option", { name: /^unit type/i })
+    ).toBeInTheDocument()
     expect(within(unitTypeSelector).getByRole("option", { name: "Studio" })).toBeInTheDocument()
     expect(within(unitTypeSelector).getByRole("option", { name: "SRO" })).toBeInTheDocument()
     expect(
@@ -197,9 +199,9 @@ describe("UnitForm", () => {
 
     expect(screen.getByRole("heading", { name: "Accessibility", level: 2 })).toBeInTheDocument()
 
-    // Accessibility priority type selector
+    // Accessibility unit type selector
     const priorityTypeSelector = screen.getByRole("combobox", {
-      name: "Accessibility priority type",
+      name: "Accessibility unit type",
     })
     expect(priorityTypeSelector).toBeInTheDocument()
     expect(within(priorityTypeSelector).getAllByRole("option")).toHaveLength(4)
@@ -398,7 +400,7 @@ describe("UnitForm", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("textbox", { name: "Unit number" })).toHaveValue("A-101")
-      expect(screen.getByRole("combobox", { name: /unit type/i })).toHaveValue(unitTypes[0].id)
+      expect(screen.getByRole("combobox", { name: /^unit type/i })).toHaveValue(unitTypes[0].id)
       expect(screen.getByLabelText(/square footage/i)).toHaveValue(321)
       expect(screen.getByLabelText(/minimum monthly income|monthly minimum income/i)).toHaveValue(
         2208
@@ -454,7 +456,7 @@ describe("UnitForm", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("textbox", { name: "Unit number" })).toHaveValue("B-202")
-      expect(screen.getByRole("combobox", { name: /unit type/i })).toHaveValue(unitTypes[1].id)
+      expect(screen.getByRole("combobox", { name: /^unit type/i })).toHaveValue(unitTypes[1].id)
       expect(screen.getByLabelText(/square footage/i)).toHaveValue(456)
       expect(screen.getByLabelText(/minimum monthly income|monthly minimum income/i)).toHaveValue(
         3200

--- a/sites/partners/__tests__/components/listings/PaperListingForm/UnitGroupForm.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/UnitGroupForm.test.tsx
@@ -87,7 +87,7 @@ describe("<UnitGroupForm>", () => {
     expect(screen.getAllByRole("heading", { level: 2, name: /details/i })).toHaveLength(2)
 
     // Unit Types Section
-    expect(screen.getByText(/unit type/i)).toBeInTheDocument()
+    expect(screen.getByText(/^unit type/i)).toBeInTheDocument()
     expect(await screen.findByLabelText(/studio/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/1 bedroom/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/2 bedroom/i)).toBeInTheDocument()
@@ -319,7 +319,7 @@ describe("<UnitGroupForm>", () => {
     expect(screen.getAllByRole("heading", { level: 2, name: /details/i })).toHaveLength(2)
 
     // Unit Types Section
-    expect(screen.getByText(/unit type/i)).toBeInTheDocument()
+    expect(screen.getByText(/^unit type/i)).toBeInTheDocument()
     expect(await screen.findByRole("checkbox", { name: /studio/i })).toBeInTheDocument()
     expect(screen.getByRole("checkbox", { name: /1 bedroom/i })).toBeInTheDocument()
     expect(screen.getByRole("checkbox", { name: /2 bedroom/i })).toBeInTheDocument()

--- a/sites/partners/__tests__/components/listings/PaperListingForm/index.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/index.test.tsx
@@ -246,7 +246,7 @@ describe("PaperListingForm", () => {
       // units
       expect(
         screen.getByRole("row", {
-          name: "Unit # Unit type AMI Rent SQ FT Accessibility priority type Actions",
+          name: "Unit # Unit type AMI Rent SQ FT Accessibility unit type Actions",
         })
       ).toBeInTheDocument()
       expect(

--- a/sites/partners/__tests__/pages/listings/[id]/index.test.tsx
+++ b/sites/partners/__tests__/pages/listings/[id]/index.test.tsx
@@ -571,7 +571,7 @@ describe("listing data", () => {
       expect(screen.getByText("AMI")).toBeInTheDocument()
       expect(screen.getByText("Rent")).toBeInTheDocument()
       expect(screen.getByText("SQ FT")).toBeInTheDocument()
-      expect(screen.getByText("Accessibility priority type")).toBeInTheDocument()
+      expect(screen.getByText("Accessibility unit type")).toBeInTheDocument()
 
       expect(screen.getAllByText(/#[1-9]/i)).toHaveLength(6)
       expect(screen.getAllByText("Studio")).toHaveLength(6)
@@ -2089,9 +2089,7 @@ describe("listing data", () => {
     })
     expect(accessibilitySectionHeader).toBeInTheDocument()
     const accessibilitySection = accessibilitySectionHeader.parentElement
-    expect(
-      within(accessibilitySection).getByText("Accessibility priority type")
-    ).toBeInTheDocument()
+    expect(within(accessibilitySection).getByText("Accessibility unit type")).toBeInTheDocument()
     expect(within(accessibilitySection).getByText("Mobility")).toBeInTheDocument()
 
     // Should close on done

--- a/sites/partners/page_content/locales/general.json
+++ b/sites/partners/page_content/locales/general.json
@@ -543,7 +543,7 @@
   "listings.streetAddressOrPOBox": "Street address or PO box",
   "listings.totalListings": "Total listings",
   "listings.unit.%incomeRent": "Percentage of income rent",
-  "listings.unit.accessibilityPriorityType": "Accessibility priority type",
+  "listings.unit.accessibilityUnitType": "Accessibility unit type",
   "listings.unit.add": "Add unit",
   "listings.unit.affordableGroupQuantity": "Unit Group Quantity",
   "listings.unit.ami": "AMI",

--- a/sites/partners/src/components/listings/PaperListingDetails/DetailsUnitDrawer.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/DetailsUnitDrawer.tsx
@@ -158,7 +158,7 @@ const DetailUnitDrawer = ({ unit, setUnitDrawer }: UnitDrawerProps) => {
                 <Grid.Cell>
                   <FieldValue
                     id="unit.accessibilityPriorityType"
-                    label={t("listings.unit.accessibilityPriorityType")}
+                    label={t("listings.unit.accessibilityUnitType")}
                     children={
                       unit?.accessibilityPriorityType
                         ? t(`listings.unit.accessibilityType.${unit.accessibilityPriorityType}`)

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailUnits.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailUnits.tsx
@@ -62,7 +62,7 @@ const DetailUnits = ({ setUnitDrawer }: DetailUnitsProps) => {
         amiPercentage: "t.ami",
         monthlyRent: "listings.unit.rent",
         sqFeet: "listings.unit.sqft",
-        accessibilityPriorityType: "listings.unit.accessibilityPriorityType",
+        accessibilityPriorityType: "listings.unit.accessibilityUnitType",
         action: "",
       }
 

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -666,7 +666,7 @@ const UnitForm = ({
                     <Select
                       id="accessibilityPriorityType"
                       name="accessibilityPriorityType"
-                      label={t("listings.unit.accessibilityPriorityType")}
+                      label={t("listings.unit.accessibilityUnitType")}
                       register={register}
                       controlClassName="control"
                       options={[{ value: "", label: t("t.selectOne") }, ...unitPrioritiesOptions]}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -159,7 +159,7 @@ const FormUnits = ({
         amiPercentage: "t.ami",
         monthlyRent: "listings.unit.rent",
         sqFeet: "listings.unit.sqft",
-        accessibilityPriorityType: "listings.unit.accessibilityPriorityType",
+        accessibilityPriorityType: "listings.unit.accessibilityUnitType",
         action: "",
       }
 

--- a/sites/public/__tests__/components/listing/listing_sections/MainDetails.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/MainDetails.test.tsx
@@ -90,7 +90,7 @@ describe("<MainDetails>", () => {
     expect(view.queryByText("Veteran")).toBeNull()
   })
 
-  it("shows accessibility priority type tags when feature flag is enabled", () => {
+  it("shows accessibility unit type tags when feature flag is enabled", () => {
     render(
       <MainDetails
         listing={{
@@ -127,7 +127,7 @@ describe("<MainDetails>", () => {
     expect(screen.getByText("Mobility, hearing and vision units")).toBeInTheDocument()
   })
 
-  it("hides accessibility priority type tags when feature flag is disabled", () => {
+  it("hides accessibility unit type tags when feature flag is disabled", () => {
     render(
       <MainDetails
         listing={{

--- a/sites/public/__tests__/components/listing/listing_sections/RentSummary.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/RentSummary.test.tsx
@@ -203,7 +203,7 @@ describe("<RentSummary>", () => {
     expect(tableHeaders).toHaveLength(3)
 
     const [unitTypeHeader, rentHeader, availabilityHeader] = tableHeaders
-    expect(unitTypeHeader).toHaveTextContent(/unit type/i)
+    expect(unitTypeHeader).toHaveTextContent(/^unit type/i)
     expect(rentHeader).toHaveTextContent(/rent/i)
     expect(availabilityHeader).toHaveTextContent(/availability/i)
 


### PR DESCRIPTION

This PR addresses #1493

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Updates the accessibility types label to: `Accessible unit type` on partners site.

## How Can This Be Tested/Reviewed?

1. Go to partners site and select any listing with units available
2. Scroll down to the Units section (the table should include a `Accessible unit type` column header)
3. Click on the unit edit button (the preview drawer and unit form should both include `Accessible unit type` labels)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
