### PR TITLE
fix: update warn user of deletion email (bloom-housing#6394)

### DIFF
--- a/api/prisma/migrations/61_update_warn_email_translation/migration.sql
+++ b/api/prisma/migrations/61_update_warn_email_translation/migration.sql
@@ -1,0 +1,90 @@
+-- Adds new waitlist lottery confirmation translations for emails.
+UPDATE
+    translations
+SET
+    translations = jsonb_set(
+        translations,
+        '{accountRemoval}',
+        '{
+        "subject": "Bloom Housing Scheduled Account Removal Due to Inactivity",
+        "courtesyText1": "This is a courtesy email to let you know that because your Bloom Housing Portal account has been inactive for 3 years, your account will be deleted in 30 days per our",
+        "courtesyText2": "If you’d like to keep your account, please log in anytime in the next month and we’ll consider your account active again.",
+        "signIn": "Sign in to Bloom Housing",
+        "privacyPolicy": "Privacy Policy",
+        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        }'
+    )
+WHERE
+    language = 'en';
+
+UPDATE
+    translations
+SET
+    translations = jsonb_set(
+        translations,
+        '{accountRemoval}',
+        '{
+        "subject": "Eliminación programada de cuenta de Bloom Housing debido a inactividad",
+        "courtesyText1": "Este es un mensaje de cortesía para informarle que, debido a que su cuenta del portal Bloom Housing ha estado inactiva durante 3 años, se eliminará en un plazo de 30 días conforme a nuestra",
+        "courtesyText2": "Si desea conservar su cuenta, por favor inicie sesión en cualquier momento durante el próximo mes y la consideraremos nuevamente activa.",        "signIn": "Iniciar sesión en Bloom Housing",
+        "privacyPolicy": "Política de privacidad",
+        "privacyPolicyUrl": "localhost:3000/privacy-policy",
+        "signIn": "Iniciar sesión en Bloom Housing"
+        }'
+    )
+WHERE
+    language = 'es';
+
+UPDATE
+    translations
+SET
+    translations = jsonb_set(
+        translations,
+        '{accountRemoval}',
+        '{
+        "subject": "Bloom Housing Scheduled Account Removal Dahil sa Kawalan ng Aktibidad",
+        "courtesyText1": "Ito ay isang courtesy email upang ipaalam sa iyo na dahil ang iyong Bloom Housing Portal account ay hindi aktibo sa loob ng 3 taon, ang iyong account ay buburahin sa loob ng 30 araw ayon sa aming",
+        "courtesyText2": "Kung nais mong panatilihin ang iyong account, mangyaring mag-log in anumang oras sa susunod na buwan at ituturing naming aktibo muli ang iyong account.",
+        "signIn": "Mag-sign in sa Bloom Housing",
+        "privacyPolicy": "Patakaran sa Pagkapribado",
+        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        }'
+    )
+WHERE
+    language = 'tl';
+
+UPDATE
+    translations
+SET
+    translations = jsonb_set(
+        translations,
+        '{accountRemoval}',
+        '{
+        "subject": "Bloom Housing đã lên lịch xóa tài khoản do không hoạt động",
+        "courtesyText1": "Đây là một email thông báo rằng vì tài khoản Bloom Housing Portal của bạn đã không hoạt động trong 3 năm, tài khoản của bạn sẽ bị xóa trong vòng 30 ngày theo chính sách của chúng tôi.",
+        "courtesyText2": "Nếu bạn muốn giữ tài khoản của mình, vui lòng đăng nhập bất cứ lúc nào trong tháng tới và chúng tôi sẽ coi tài khoản của bạn là hoạt động trở lại.",
+        "signIn": "Đăng nhập vào Bloom Housing",
+        "privacyPolicy": "Chính sách bảo mật",
+        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        }'
+    )
+WHERE
+    language = 'vi';
+
+UPDATE
+    translations
+SET
+    translations = jsonb_set(
+        translations,
+        '{accountRemoval}',
+        '{
+        "subject": "Bloom Housing 因帳戶長期不活躍，計劃刪除您的帳戶",
+        "courtesyText1": "這是一封禮貌性郵件，通知您由於您的 Bloom Housing Portal 帳戶已閒置 3 年，根據我們的政策，您的帳戶將在 30 天後被刪除。",
+        "courtesyText2": "如果您想保留您的帳戶，請在下個月內隨時登錄，我們將視您的帳戶為已重新啟用。",
+        "signIn": "登入 Bloom Housing",
+        "privacyPolicy": "隱私權政策",
+        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        }'
+    )
+WHERE
+    language = 'zh';

--- a/api/prisma/migrations/61_update_warn_email_translation/migration.sql
+++ b/api/prisma/migrations/61_update_warn_email_translation/migration.sql
@@ -6,12 +6,12 @@ SET
         translations,
         '{accountRemoval}',
         '{
-        "subject": "Bloom Housing Scheduled Account Removal Due to Inactivity",
-        "courtesyText1": "This is a courtesy email to let you know that because your Bloom Housing Portal account has been inactive for 3 years, your account will be deleted in 30 days per our",
+        "subject": "Doorway Scheduled Account Removal Due to Inactivity",
+        "courtesyText1": "This is a courtesy email to let you know that because your Doorway Housing Portal account has been inactive for 3 years, your account will be deleted in 30 days per our",
         "courtesyText2": "If you’d like to keep your account, please log in anytime in the next month and we’ll consider your account active again.",
-        "signIn": "Sign in to Bloom Housing",
+        "signIn": "Sign in to Doorway",
         "privacyPolicy": "Privacy Policy",
-        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        "privacyPolicyUrl": "https://mtc.ca.gov/doorway-housing-portal-privacy-policy"
         }'
     )
 WHERE
@@ -24,12 +24,12 @@ SET
         translations,
         '{accountRemoval}',
         '{
-        "subject": "Eliminación programada de cuenta de Bloom Housing debido a inactividad",
-        "courtesyText1": "Este es un mensaje de cortesía para informarle que, debido a que su cuenta del portal Bloom Housing ha estado inactiva durante 3 años, se eliminará en un plazo de 30 días conforme a nuestra",
-        "courtesyText2": "Si desea conservar su cuenta, por favor inicie sesión en cualquier momento durante el próximo mes y la consideraremos nuevamente activa.",        "signIn": "Iniciar sesión en Bloom Housing",
+        "subject": "Eliminación programada de cuenta de Doorway debido a inactividad",
+        "courtesyText1": "Este es un mensaje de cortesía para informarle que, debido a que su cuenta del portal Doorway ha estado inactiva durante 3 años, se eliminará en un plazo de 30 días conforme a nuestra",
+        "courtesyText2": "Si desea conservar su cuenta, por favor inicie sesión en cualquier momento durante el próximo mes y la consideraremos nuevamente activa.",
+        "signIn": "Iniciar sesión en Doorway Housing Portal",
         "privacyPolicy": "Política de privacidad",
-        "privacyPolicyUrl": "localhost:3000/privacy-policy",
-        "signIn": "Iniciar sesión en Bloom Housing"
+        "privacyPolicyUrl": "https://mtc.ca.gov/doorway-housing-portal-privacy-policy"
         }'
     )
 WHERE
@@ -42,12 +42,12 @@ SET
         translations,
         '{accountRemoval}',
         '{
-        "subject": "Bloom Housing Scheduled Account Removal Dahil sa Kawalan ng Aktibidad",
-        "courtesyText1": "Ito ay isang courtesy email upang ipaalam sa iyo na dahil ang iyong Bloom Housing Portal account ay hindi aktibo sa loob ng 3 taon, ang iyong account ay buburahin sa loob ng 30 araw ayon sa aming",
+        "subject": "Doorway Scheduled Account Removal Dahil sa Kawalan ng Aktibidad",
+        "courtesyText1": "Ito ay isang courtesy email upang ipaalam sa iyo na dahil ang iyong Doorway Housing Portal account ay hindi aktibo sa loob ng 3 taon, ang iyong account ay buburahin sa loob ng 30 araw ayon sa aming",
         "courtesyText2": "Kung nais mong panatilihin ang iyong account, mangyaring mag-log in anumang oras sa susunod na buwan at ituturing naming aktibo muli ang iyong account.",
-        "signIn": "Mag-sign in sa Bloom Housing",
+        "signIn": "Mag-sign in sa Doorway Housing Portal",
         "privacyPolicy": "Patakaran sa Pagkapribado",
-        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        "privacyPolicyUrl": "https://mtc.ca.gov/doorway-housing-portal-privacy-policy"
         }'
     )
 WHERE
@@ -60,12 +60,12 @@ SET
         translations,
         '{accountRemoval}',
         '{
-        "subject": "Bloom Housing đã lên lịch xóa tài khoản do không hoạt động",
-        "courtesyText1": "Đây là một email thông báo rằng vì tài khoản Bloom Housing Portal của bạn đã không hoạt động trong 3 năm, tài khoản của bạn sẽ bị xóa trong vòng 30 ngày theo chính sách của chúng tôi.",
+        "subject": "Doorway đã lên lịch xóa tài khoản do không hoạt động",
+        "courtesyText1": "Đây là một email thông báo rằng vì tài khoản Doorway Housing Portal của bạn đã không hoạt động trong 3 năm, tài khoản của bạn sẽ bị xóa trong vòng 30 ngày theo chính sách của chúng tôi.",
         "courtesyText2": "Nếu bạn muốn giữ tài khoản của mình, vui lòng đăng nhập bất cứ lúc nào trong tháng tới và chúng tôi sẽ coi tài khoản của bạn là hoạt động trở lại.",
-        "signIn": "Đăng nhập vào Bloom Housing",
+        "signIn": "Đăng nhập vào Doorway Housing Portal",
         "privacyPolicy": "Chính sách bảo mật",
-        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        "privacyPolicyUrl": "https://mtc.ca.gov/doorway-housing-portal-privacy-policy"
         }'
     )
 WHERE
@@ -78,12 +78,12 @@ SET
         translations,
         '{accountRemoval}',
         '{
-        "subject": "Bloom Housing 因帳戶長期不活躍，計劃刪除您的帳戶",
-        "courtesyText1": "這是一封禮貌性郵件，通知您由於您的 Bloom Housing Portal 帳戶已閒置 3 年，根據我們的政策，您的帳戶將在 30 天後被刪除。",
+        "subject": "Doorway 因帳戶長期不活躍，計劃刪除您的帳戶",
+        "courtesyText1": "這是一封禮貌性郵件，通知您由於您的 Doorway Housing Portal 帳戶已閒置 3 年，根據我們的政策，您的帳戶將在 30 天後被刪除。",
         "courtesyText2": "如果您想保留您的帳戶，請在下個月內隨時登錄，我們將視您的帳戶為已重新啟用。",
-        "signIn": "登入 Bloom Housing",
+        "signIn": "登入 Doorway Housing Portal",
         "privacyPolicy": "隱私權政策",
-        "privacyPolicyUrl": "localhost:3000/privacy-policy"
+        "privacyPolicyUrl": "https://mtc.ca.gov/doorway-housing-portal-privacy-policy"
         }'
     )
 WHERE

--- a/api/prisma/seed-helpers/translation-factory.ts
+++ b/api/prisma/seed-helpers/translation-factory.ts
@@ -64,9 +64,13 @@ const translations = (
         accountRemoval: {
           subject:
             'Eliminación programada de cuenta de Doorway debido a inactividad',
-          courtesyText:
-            'Este es un correo electrónico de cortesía para informarle que, debido a que su cuenta del Portal de Bloom Housing ha estado inactiva durante 3 años, se eliminará en 30 días según nuestros Términos de Uso y Política de Privacidad. Si desea conservar su cuenta, inicie sesión durante el próximo mes y la consideraremos activa de nuevo.',
-          signIn: 'Iniciar sesión en Bloom Housing',
+          courtesyText1:
+            'Este es un mensaje de cortesía para informarle que, debido a que su cuenta del portal Doorway ha estado inactiva durante 3 años, se eliminará en un plazo de 30 días conforme a nuestra',
+          courtesyText2:
+            'Si desea conservar su cuenta, por favor inicie sesión en cualquier momento durante el próximo mes y la consideraremos nuevamente activa.',
+          signIn: 'Iniciar sesión en Doorway Housing Portal',
+          privacyPolicy: 'Política de privacidad',
+          privacyPolicyUrl: 'localhost:3000/privacy-policy',
         },
         register: {
           welcome: 'Bienvenido',
@@ -591,9 +595,13 @@ const translations = (
         },
         accountRemoval: {
           subject: 'Doorway Scheduled Account Removal Due to Inactivity',
-          courtesyText:
-            'This is a courtesy email to let you know that because your Doorway Housing Portal account has been inactive for 3 years, your account will be deleted in 30 days per our Terms of Use and Privacy Policy. If you’d like to keep your account, please log in sometime in the next month and we’ll consider your account active again.',
-          signIn: 'Sign in to Bloom Housing',
+          courtesyText1:
+            'This is a courtesy email to let you know that because your Doorway Housing Portal account has been inactive for 3 years, your account will be deleted in 30 days per our',
+          courtesyText2:
+            'If you’d like to keep your account, please log in anytime in the next month and we’ll consider your account active again.',
+          signIn: 'Sign in to Doorway Housing Portal',
+          privacyPolicy: 'Privacy Policy',
+          privacyPolicyUrl: 'localhost:3000/privacy-policy',
         },
         advocateApproved: {
           subject: 'Your account has been approved',

--- a/api/src/views/warn-removal.hbs
+++ b/api/src/views/warn-removal.hbs
@@ -6,7 +6,7 @@
         <tr>
             <td align="left">
             <p>
-                {{t "accountRemoval.courtesyText"}}
+                {{t "accountRemoval.courtesyText1"}} <a href="{{t "accountRemoval.privacyPolicyUrl"}}">{{t "accountRemoval.privacyPolicy"}}</a>. {{t "accountRemoval.courtesyText2"}}
             </p>
             </td>
         </tr>


### PR DESCRIPTION
This PR addresses #1536 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Pulls the commit from core related to user deletion email content update

## How Can This Be Tested/Reviewed?

## Verify the email translations are updated
In order to test that the migration file properly works manual validation is required.
1. Before pulling down these changes seed the database
2. Pull down the changes and run `yarn db:migration:run`
3. Verify that the database has the new fields and updated language for the `accountRemoval` field in the translations table

## Verify the email looks correct
1. Seed the database
2. Create a public user with your email
3. In the database update the last_login_at and password_updated_at to be way in the past
4. Set the `USER_DELETION_WARN_CRON_STRING` value in the .env file to run soon (ideally the next few minutes)
5. Set the `USERS_DAYS_TILL_EXPIRY` value in .env file to be a small number (e.g 1)
6. Wait for the cron job to run and verify the received email looks correct

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
