### PR TITLE
fix: add seo env variable to buildspec

### DIFF
--- a/ci/buildspec/build_partners.yml
+++ b/ci/buildspec/build_partners.yml
@@ -64,6 +64,7 @@ phases:
         --build-arg "LOTTERY_DAYS_TILL_EXPIRY=${LOTTERY_DAYS_TILL_EXPIRY}"
         --build-arg "LIMIT_CLOSED_LISTING_ACTIONS=${LIMIT_CLOSED_LISTING_ACTIONS}"
         --build-arg "USE_SECURE_DOWNLOAD_PATHWAY=${USE_SECURE_DOWNLOAD_PATHWAY}"
+        --build-arg "ALLOW_SEO_INDEXING=${ALLOW_SEO_INDEXING}"
         -t sites/partners:run-candidate
 
       # Tag the run image

--- a/ci/buildspec/build_public.yml
+++ b/ci/buildspec/build_public.yml
@@ -86,6 +86,7 @@ phases:
         --build-arg "GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}"
         --build-arg "GOOGLE_MAPS_MAP_ID=${GOOGLE_MAPS_MAP_ID}"
         --build-arg "SHOW_ALL_MAP_PINS=${SHOW_ALL_MAP_PINS}"
+        --build-arg "ALLOW_SEO_INDEXING=${ALLOW_SEO_INDEXING}"
         --target run
         -t sites/public:run-candidate
         .


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

After adding  ALLOW_SEO_INDEXING to the dockerfile it was still not being read because the build script doesn't have it as an argument

## How Can This Be Tested/Reviewed?

This can only be tested in AWS pipeline

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
