### PR TITLE
fix: lottery upload

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
@@ -137,11 +137,7 @@ const LotteryResults = (props: LotteryResultsProps) => {
     Pass the file for the dropzone callback along to the uploader
   */
   const pdfUploader = async (file: File) => {
-    if (process.env.cloudinaryCloudName) {
-      // void (await cloudinaryFileUploader({ file, setCloudinaryData, setProgressValue }))
-    } else {
-      await uploadAssetAndSetData(file, "lottery", setProgressValue, setCloudinaryData)
-    }
+    await uploadAssetAndSetData(file, "lottery", setProgressValue, setCloudinaryData)
   }
 
   return (

--- a/sites/partners/src/components/listings/PaperListingForm/sections/MarketingFlyer.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/MarketingFlyer.tsx
@@ -260,28 +260,16 @@ const MarketingFlyer = ({ currentData, onSubmit }: MarketingFlyerProps) => {
   ].filter(Boolean)
 
   const pdfUploader = async (file: File) => {
-    if (process.env.cloudinaryCloudName) {
-      // await cloudinaryFileUploader({ file, setCloudinaryData, setProgressValue })
-    } else {
-      await uploadAssetAndSetData(file, "marketing-flyer", setProgressValue, setCloudinaryData)
-    }
+    await uploadAssetAndSetData(file, "marketing-flyer", setProgressValue, setCloudinaryData)
   }
 
   const accessiblePdfUploader = async (file: File) => {
-    if (process.env.cloudinaryCloudName) {
-      // await cloudinaryFileUploader({
-      //   file,
-      //   setCloudinaryData: setAccessibleCloudinaryData,
-      //   setProgressValue: setAccessibleProgressValue,
-      // })
-    } else {
-      await uploadAssetAndSetData(
-        file,
-        "marketing-flyer",
-        setAccessibleProgressValue,
-        setAccessibleCloudinaryData
-      )
-    }
+    await uploadAssetAndSetData(
+      file,
+      "marketing-flyer",
+      setAccessibleProgressValue,
+      setAccessibleCloudinaryData
+    )
   }
 
   const buildPreviewTableRow = (data: CloudinaryData, onDelete: () => void): StandardTableData => {


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Doorway is not able to upload lottery result files due to code being merged in from core that made changes to allow for AWS uploads and was not implemented correctly. Reverting the code to pre-aws logic. Further investigation will be needed during core-ification.

## How Can This Be Tested/Reviewed?

Login to the partners portal
One a closed, lottery listing, click edit
Upload a lottery result
Click on the preview

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
